### PR TITLE
Fix package name in setup for tests

### DIFF
--- a/ccdproc/tests/setup_package.py
+++ b/ccdproc/tests/setup_package.py
@@ -1,3 +1,3 @@
 def get_package_data():
     return {
-        'packagename.tests': ['coveragerc']}
+        'ccdproc.tests': ['coveragerc']}


### PR DESCRIPTION
This fixes a problem with `test --coverage`
