### PR TITLE
Remove matplotlib from pip requirements

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,3 @@
 numpy>=1.7
 numpydoc
-matplotlib
 astropy>=0.3


### PR DESCRIPTION
The RTD build failed on this install and we are not currently using it.
