### PR TITLE
Allow overscan region to be along either axis

### DIFF
--- a/ccdproc/ccdproc.py
+++ b/ccdproc/ccdproc.py
@@ -84,7 +84,7 @@ def create_variance(ccd_data, gain=None, readnoise=None):
 
 
 @log_to_metadata
-def subtract_overscan(ccd, overscan=None, fits_section=None,
+def subtract_overscan(ccd, overscan=None, overscan_axis=1, fits_section=None,
                       median=False, model=None):
     """
     Subtract the overscan region from an image.  This will first
@@ -100,6 +100,11 @@ def subtract_overscan(ccd, overscan=None, fits_section=None,
     overscan : CCDData
         Slice from `ccd` that contains the overscan. Must provide either
         this argument or `fits_section`, but not both.
+
+    overscan_axis : 0 or 1, optional
+        Axis along which overscan should combined with mean or median. Axis
+        numbering follows the *python* convention for ordering, so 0 is the
+        first axis and 1 is the second axis.
 
     fits_section :  str
         Region of `ccd` from which the overscan is extracted, using the FITS
@@ -179,19 +184,18 @@ def subtract_overscan(ccd, overscan=None, fits_section=None,
         overscan = ccd[slice_from_string(fits_section, fits_convention=True)]
 
     # Assume axis with the smaller dimension is the one to aggregate over
-    oscan_axis = 1 if overscan.shape[0] > overscan.shape[1] else 0
 
     if median:
-        oscan = np.median(overscan.data, axis=oscan_axis)
+        oscan = np.median(overscan.data, axis=overscan_axis)
     else:
-        oscan = np.mean(overscan.data, axis=oscan_axis)
+        oscan = np.mean(overscan.data, axis=overscan_axis)
 
     if model is not None:
         of = fitting.LinearLSQFitter()
         yarr = np.arange(len(oscan))
         oscan = of(model, yarr, oscan)
         oscan = oscan(yarr)
-        if oscan_axis == 1:
+        if overscan_axis == 1:
             oscan = np.reshape(oscan, (oscan.size, 1))
         else:
             oscan = np.reshape(oscan, (1, oscan.size))

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -79,11 +79,15 @@ def test_subtract_overscan(ccd_data, median, transpose):
     oscan_region = (slice(None), slice(0, 10))  # indices 0 through 9
     fits_section = '[1:10, :]'
     science_region = (slice(None), slice(10, None))
+
+    overscan_axis = 1
     if transpose:
         # Put overscan in first axis, not second, a test for #70
         oscan_region = oscan_region[::-1]
         fits_section = '[:, 1:10]'
         science_region = science_region[::-1]
+        overscan_axis = 0
+
     ccd_data.data[oscan_region] = oscan
     # Add a fake sky background so the "science" part of the image has a
     # different average than the "overscan" part.
@@ -93,6 +97,7 @@ def test_subtract_overscan(ccd_data, median, transpose):
     # Test once using the overscan argument to specify the overscan region
     ccd_data_overscan = subtract_overscan(ccd_data,
                                           overscan=ccd_data[oscan_region],
+                                          overscan_axis=overscan_axis,
                                           median=median, model=None)
     # Is the mean of the "science" region the sum of sky and the mean the
     # "science" section had before backgrounds were added?
@@ -105,6 +110,7 @@ def test_subtract_overscan(ccd_data, median, transpose):
     # Now do what should be the same subtraction, with the overscan specified
     # with the fits_section
     ccd_data_fits_section = subtract_overscan(ccd_data,
+                                              overscan_axis=overscan_axis,
                                               fits_section=fits_section,
                                               median=median, model=None)
     # Is the mean of the "science" region the sum of sky and the mean the
@@ -137,7 +143,9 @@ def test_subtract_overscan_model(ccd_data, transpose):
         oscan_region = oscan_region[::-1]
         science_region = science_region[::-1]
         scan = xscan
+        overscan_axis = 0
     else:
+        overscan_axis = 1
         scan = yscan
 
     original_mean = ccd_data.data[science_region].mean()
@@ -146,6 +154,7 @@ def test_subtract_overscan_model(ccd_data, transpose):
     ccd_data.data = ccd_data.data + scan
 
     ccd_data = subtract_overscan(ccd_data, overscan=ccd_data[oscan_region],
+                                 overscan_axis=overscan_axis,
                                  median=False, model=models.Polynomial1D(2))
     np.testing.assert_almost_equal(ccd_data.data[science_region].mean(),
                                    original_mean)


### PR DESCRIPTION
As reported in #70, `subtract_overscan` assumed that the axis along which the overscan should be aggregated (with either median or mean) was the second of the two axes. This allows the overscan to be in either axis (though it will fail in the unlikely case that the overscan is square).
