### PR TITLE
Fixes to cosmic ray tasks and closes #76, closes #57, and closes #17

### DIFF
--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -43,6 +43,21 @@ def test_cosmicray_clean_scalar_background(ccd_data, background_type):
     assert abs(cc.data.std() - scale) < 0.1
     assert ((testdata - cc.data) > 0).sum() == NCRAYS
 
+@pytest.mark.data_scale(DATA_SCALE)
+def test_cosmicray_clean_gbox(ccd_data):
+    scale = DATA_SCALE  # yuck. Maybe use pytest.parametrize?
+    threshold = 5
+    add_cosmicrays(ccd_data, scale, threshold, ncrays=NCRAYS)
+    testdata = 1.0 * ccd_data.data
+    cc = ccd_data  # currently here because no copy command for NDData
+    cc = cosmicray_clean(cc, 5.0, cosmicray_median, crargs=(11,),
+                             background=background_variance_box, bargs=(25,),
+                             rbox=0, gbox=5)
+    data = np.ma.masked_array(cc.data, cc.mask)
+    assert abs(data.std() - scale) < 0.1
+    assert cc.mask.sum() > NCRAYS
+
+
 
 @pytest.mark.data_scale(DATA_SCALE)
 def test_cosmicray_clean(ccd_data):
@@ -75,10 +90,32 @@ def test_cosmicray_clean_rbox_zero_replaces_no_pixels(ccd_data):
 def test_cosmicray_median(ccd_data):
     threshold = 5
     add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
-    crarr = cosmicray_median(ccd_data, 5, mbox=11, background=DATA_SCALE)
+    crarr = cosmicray_median(ccd_data.data, 5, mbox=11, background=DATA_SCALE)
 
     # check the number of cosmic rays detected
     assert crarr.sum() == NCRAYS
+
+@pytest.mark.data_scale(DATA_SCALE)
+def test_cosmicray_median_masked(ccd_data):
+    threshold = 5
+    add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
+    data = np.ma.masked_array(ccd_data.data, (ccd_data.data>-1e6))
+    crarr = cosmicray_median(data, 5, mbox=11, background=DATA_SCALE)
+
+    # check the number of cosmic rays detected
+    assert crarr.sum() == NCRAYS
+
+
+@pytest.mark.data_scale(DATA_SCALE)
+def test_cosmicray_median_background_None(ccd_data):
+    threshold = 5
+    add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
+    crarr = cosmicray_median(ccd_data.data, 5, mbox=11, background=None)
+
+    # check the number of cosmic rays detected
+    assert crarr.sum() == NCRAYS
+
+
 
 
 def test_background_variance_box():


### PR DESCRIPTION
This is a number of minor fixes to the cosmic ray task to address issues #76, #57, and #17. 

In `cosmicray_median`, the background value has been made to match the documentation so that if None is given, the std is calculated.   

A test was added for gbox.

cosmicray_clean now returns a copy of the passed `ccddata` object with the data and mask values updated accordingly. 
