### PR TITLE
Allow uncertainty to be set with an array

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -39,7 +39,7 @@ class CCDData(NDData):
         make copy the `data` before passing it in if that's the  desired
         behavior.
 
-    uncertainty : `~astropy.nddata.StdDevUncertainty`, optional
+    uncertainty : `~astropy.nddata.StdDevUncertainty` or `~numpy.ndarray`, optional
         Uncertainties on the data.
 
     mask : `~numpy.ndarray`, optional
@@ -143,10 +143,17 @@ class CCDData(NDData):
         if value is not None:
             if isinstance(value, NDUncertainty):
                 self._uncertainty = value
-                self._uncertainty._parent_nddata = self
+            elif isinstance(value, np.ndarray):
+                if value.shape != self.shape:
+                    raise ValueError("Uncertainty must have same shape as "
+                                     "data")
+                self._uncertainty = StdDevUncertainty(value)
+                log.info("Array provided for uncertainty; assuming it is a "
+                         "StdDevUncertainty.")
             else:
                 raise TypeError("Uncertainty must be an instance of a "
-                                "NDUncertainty object")
+                                "NDUncertainty object or a numpy array.")
+            self._uncertainty._parent_nddata = self
         else:
             self._uncertainty = value
 

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -150,6 +150,18 @@ def test_setting_bad_uncertainty_raises_error(ccd_data):
         ccd_data.uncertainty = 10
 
 
+def test_setting_uncertainty_with_array(ccd_data):
+    ccd_data.uncertainty = None
+    fake_uncertainty = np.sqrt(np.abs(ccd_data.data))
+    ccd_data.uncertainty = fake_uncertainty.copy()
+    np.testing.assert_array_equal(ccd_data.uncertainty.array, fake_uncertainty)
+
+
+def test_setting_uncertainty_wrong_shape_raises_error(ccd_data):
+    with pytest.raises(ValueError):
+        ccd_data.uncertainty = np.random.random(size=2 * ccd_data.shape)
+
+
 def test_to_hdu(ccd_data):
     ccd_data.meta = {'observer': 'Edwin Hubble'}
     fits_hdulist = ccd_data.to_hdu()

--- a/docs/ccdproc/ccddata.rst
+++ b/docs/ccdproc/ccddata.rst
@@ -132,7 +132,7 @@ Pixel-by-pixel uncertainty can be calculated for you:
 
 See :ref:`create_variance` for more details.
 
-You can also set the uncertainty directly but need to create a
+You can also set the uncertainty directly, either by creating a
 `~astropy.nddata.StdDevUncertainty` object first:
 
     >>> from astropy.nddata.nduncertainty import StdDevUncertainty
@@ -140,8 +140,14 @@ You can also set the uncertainty directly but need to create a
     >>> my_uncertainty = StdDevUncertainty(uncertainty)
     >>> ccd.uncertainty = my_uncertainty
 
-Using `~astropy.nddata.StdDevUncertainty` is required to enable error
-propagation in `~ccdproc.ccddata.CCDData`
+or by providing a `~numpy.ndarray` with the same shape as the data:
+
+    >>> ccd.uncertainty = 0.1 * ccd.data
+    INFO: Array provided for uncertainty; assuming it is a StdDevUncertainty. [ccdproc.ccddata]
+
+In this case the uncertainty is assumed to be
+`~astropy.nddata.StdDevUncertainty`. Using `~astropy.nddata.StdDevUncertainty`
+is required to enable error propagation in `~ccdproc.ccddata.CCDData`
 
 If you want access to the underlying uncertainty use its ``.array`` attribute:
 


### PR DESCRIPTION
An INFO-level message is issued indicating that the uncertainty is assumed to be a `StdDevUncertainty`
