### PR TITLE
Use divide method (and fix a couple errors that uncovered)

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -463,15 +463,17 @@ def flat_correct(ccd, flat, min_value=None):
         CCDData object with flat corrected
     """
     #Use the min_value to replace any values in the flat
+    use_flat = flat
     if min_value is not None:
-        flat.data[flat.data < min_value] = min_value
-
-    # normalize the flat
-    flat_normed = flat.divide(flat.data.mean())
+        flat_min = flat.copy()
+        flat_min.data[flat_min.data < min_value] = min_value
+        use_flat = flat_min
 
     # divide through the flat
-    flat_corrected = ccd.divide(flat_normed)
-
+    flat_corrected = ccd.divide(use_flat)
+    # multiply by the mean of the flat
+    flat_corrected = flat_corrected.multiply(use_flat.data.mean() *
+                                             use_flat.unit)
     return flat_corrected
 
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -334,24 +334,26 @@ def test_flat_correct(ccd_data):
     np.testing.assert_allclose(ccd_data.data / flat_data.data,
                                flat.data / flat.data.mean())
 
+
 # test for flat correction with min_value
 @pytest.mark.data_scale(10)
 def test_flat_correct_min_value(ccd_data):
     size = ccd_data.shape[0]
-    orig_mean = ccd_data.data.mean()
     # create the flat
     data = 2 * np.random.normal(loc=1.0, scale=0.05, size=(size, size))
     flat = CCDData(data, meta=fits.header.Header(), unit=ccd_data.unit)
+    flat_orig_data = flat.data.copy()
     min_value = 2.1  # should replace some, but not all, values
     flat_data = flat_correct(ccd_data, flat, min_value=min_value)
-
     flat_with_min = flat.copy()
     flat_with_min.data[flat_with_min.data < min_value] = min_value
     #check that the flat was normalized
-    np.testing.assert_almost_equal((flat_data.data * flat.data).mean(),
-                                   ccd_data.data.mean() * flat.data.mean())
+    np.testing.assert_almost_equal((flat_data.data * flat_with_min.data).mean(),
+                                   ccd_data.data.mean() * flat_with_min.data.mean())
     np.testing.assert_allclose(ccd_data.data / flat_data.data,
-                               flat.data / flat.data.mean())
+                               flat_with_min.data / flat_with_min.data.mean())
+    # Test that flat is not modified.
+    assert (flat_orig_data == flat.data).all()
 
 
 # test for variance and for flat correction


### PR DESCRIPTION
The main change was intended to fix #92, but it turns out that running the tests of `flat_correct`` with perfectly uniform flats was masking a couple of errors.

One was that the arithmetic methods return a new array, but flat correct was returning the original array. The other was that it isn't always the case that `flat_data.data.mean() == ccd_data.data.mean()` after flat correction, because the mean of a ratio isn't the ratio of the means (though this had me going in circles for about 15 minutes).

The tests were also change to `almost_equal`-type tests. 
