### PR TITLE
Adding the changelog for tracking changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,51 @@
+
+0.3.0 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+
+0.2.2 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+Bug Fixes
+^^^^^^^^^
+
+
+0.2.1 (2014-09-09)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+- Add a unit directly from BUNIT if it is available in the FITS header [#169]
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Relaxed the requirements on what the metadata must be. It can be anything dict-like, e.g. an astropy.io.fits.Header, a python dict, an OrderedDict or some custom object created by the user. [#167]
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixed a new-style formating issue in the logging [#170]
+
+
+0.2 (2014-07-28)
+----------------
+
+- Initial release.


### PR DESCRIPTION
Added the changelog.   The initial version has the same format as the astropy version.  In addition, I have entered into the changes from the pull requests since the release of version 0.2
