### PR TITLE
Added catch if adu is uppercase in fits header

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -334,6 +334,9 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, **kwd):
 
     try:
         fits_unit_string = hdr['bunit']
+        #patch to handle FITS files using ADU for the unit instead of the 
+        #standard version of 'adu'
+        if fits_unit_string.strip().lower()=='adu': fits_unit_string=fits_unit_string.lower()
     except KeyError:
         fits_unit_string = None
 

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -66,6 +66,17 @@ def test_initialize_from_fits_with_unit_in_header(tmpdir):
     ccd2 = CCDData.read(filename, unit="photon")
     assert ccd2.unit is u.photon
 
+def test_initialize_from_fits_with_ADU_in_header(tmpdir):
+    fake_img = np.random.random(size=(100, 100))
+    hdu = fits.PrimaryHDU(fake_img)
+    hdu.header['bunit'] = 'ADU'
+    filename = tmpdir.join('afile.fits').strpath
+    hdu.writeto(filename)
+    ccd = CCDData.read(filename)
+    # ccd should pick up the unit adu from the fits header...did it?
+    assert ccd.unit is u.adu
+
+
 
 def test_write_unit_to_hdu(ccd_data, tmpdir):
     ccd_unit = ccd_data.unit


### PR DESCRIPTION
If 'ADU' is used in BUNIT, this adds a function to convert this to the lower case 'adu' which is the FITS and astropy standard.   

edit: closes #177 
(autoclosing only works in the first comment)
