### PR TITLE
Back to usual configuration now that astropy 1.0 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
-        - ASTROPY_VERSION=development # CHANGE BACK TO STABLE post-astropy-1.0
+        - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
     matrix:

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,4 @@
 numpy>=1.9
 scipy
 numpydoc
-astropy>=1.0rc2
+astropy>=1.0


### PR DESCRIPTION
Change travis back to using astropy stable and RTD to using 1.0 or higher rather than a release candidate.