### PR TITLE
Add proper handling of WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,11 +9,14 @@ New Features
   it is not and there is no data in the primary extension, the first extension
   with data will be used.
 
+- Set wcs attribute when reading from a FITS file that contains WCS keywords
+  and write WCS keywords to header when converting to an HDU. [#195]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 
+
 - Updated CCDData to use the new version of NDDATA in astropy v1.0.   This
-  breaks backward compatibility with earlier versions of astropy.  
+  breaks backward compatibility with earlier versions of astropy.
 
 Bug Fixes
 ^^^^^^^^^
@@ -27,7 +30,7 @@ New Features
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
--Added Changes to the docs [#183]
+- Added Changes to the docs [#183]
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -487,13 +487,12 @@ def test_wcs_attribute(ccd_data, tmpdir):
     tmpfile = tmpdir.join('temp.fits')
     # This wcs example is taken from the astropy.wcs docs.
     wcs = WCS(naxis=2)
-    wcs.crpix = np.array(ccd_data.shape)/2
-    wcs.cdelt = np.array([-0.066667, 0.066667])
-    wcs.crval = [0, -90]
-    wcs.ctype = ["RA---AIR", "DEC--AIR"]
-    #wcs.set_pv([(2, 1, 45.0)])
+    wcs.wcs.crpix = np.array(ccd_data.shape)/2
+    wcs.wcs.cdelt = np.array([-0.066667, 0.066667])
+    wcs.wcs.crval = [0, -90]
+    wcs.wcs.ctype = ["RA---AIR", "DEC--AIR"]
+    wcs.wcs.set_pv([(2, 1, 45.0)])
     ccd_data.header = ccd_data.to_hdu()[0].header
-    print(type(ccd_data.header))
 
     ccd_data.header.extend(wcs.to_header())
     ccd_data.write(tmpfile.strpath)
@@ -501,4 +500,4 @@ def test_wcs_attribute(ccd_data, tmpdir):
     # WCS attribute should be set for ccd_new
     assert ccd_new.wcs is not None
     # WCS attribute should be equal to wcs above.
-    assert ccd_new.wcs == wcs
+    assert ccd_new.wcs.wcs == wcs.wcs

--- a/docs/ccdproc/ccddata.rst
+++ b/docs/ccdproc/ccddata.rst
@@ -53,7 +53,7 @@ In addition, the user can specify the extension in a FITS file to use:
 
     >>> ccd = ccdproc.CCDData.read('my_file.fits', hdu=1, unit="adu")  # doctest: +SKIP
 
-If ``hdu`` is not specified, it will assume the data is in the primary 
+If ``hdu`` is not specified, it will assume the data is in the primary
 extension.  If there is no data in the primary extension, the first extension
 with data will be used.
 
@@ -122,6 +122,21 @@ Flags are one or more additional arrays (of any type) whose shape matches the
 shape of the data. For more details on setting flags see
 `astropy.nddata.NDData`.
 
+WCS
++++
+
+The  ``wcs`` attribute of `~ccdproc.ccddata.CCDData` object can be set two ways.
+
++ If the `~ccdproc.ccddata.CCDData` object is created from a FITS file that has
+  WCS keywords in the header, the ``wcs`` attribute is set to a
+  `astropy.wcs.WCS` object using the information in the FITS header.
+
++ The WCS can also be provided when the `~ccdproc.ccddata.CCDData` object is
+  constructed with the ``wcs`` argument.
+
+Either way, the ``wcs`` attribute is kept up to date if the
+`~ccdproc.ccddata.CCDData` image is trimmed.
+
 Uncertainty
 -----------
 
@@ -176,7 +191,7 @@ appropriately. Note that the metadata of the result is *not* set:
     >>> result.header
     CaseInsensitiveOrderedDict()
 
-.. note::      
+.. note::
     In most cases you should use the functions described in
     :ref:`reduction_toolbox` to perform common operations like scaling by gain or
     doing dark or sky subtraction. Those functions try to construct a sensible


### PR DESCRIPTION
This really ended up being a couple of changes:

+ Create a WCS object if the necessary information is present when creating a `CCDData` object from a FITS file.
+ If there is a WCS attribute then write that attribute's information into the HDU created with `to_hdu`.

I also added a test that slicing properly affects the WCS attribute.

There is still one potential issue here -- the header could have WCS information different than the WCS attribute if the `CCDData` object is created with a FITS header as the metadata and that header would get partially overwritten (but maybe not completely if the WCS in the header is a different projection/has distortions and the WCS attribute doesn''t).