### PR TITLE
Remove generic warning for using ccdproc

### DIFF
--- a/docs/ccdproc/index.rst
+++ b/docs/ccdproc/index.rst
@@ -21,14 +21,6 @@ The `ccdproc` package provides:
 Getting Started
 ---------------
 
-.. warning::
-    `ccdproc` is still under active development. The API will almost
-    certainly change.
-
-    In addition, testing of `ccdproc` on real data is currently very limited.
-    Use with caution, and please report any errors you find at the 
-    `GitHub repo`_ for this project.
-
 A ``CCDData`` object can be created from a numpy array (masked or not) or from
 a FITS file:
 


### PR DESCRIPTION
This just removes the warning from the docs in ccdproc.  Right now the warning is pretty scary, and I think it probably prevents anyone from using it for real work.  I'm speculating that it's from a while back and the situation is not quite so dire,  @crawfordsm and @mwcraig?

If you think at least the "API might change" should still be in there, I could put that back in.  I think "you might have to make some future changes to keep it working" is much less scary than "this might be totally wrong" (which is the current tone).