### PR TITLE
Copy WCS header in a way that properly handles list-like keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
+        - python: 3.4
           env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -216,8 +216,8 @@ class CCDData(NDDataArray):
             # duplicates of the WCS keywords; iterating over the WCS
             # header should be safer.
             wcs_header = self.wcs.to_header()
-            for k in wcs_header.keys():
-                header[k] = wcs_header[k]
+            for k, v in wcs_header.iteritems():
+                header[k] = v
         hdu = fits.PrimaryHDU(self.data, header)
         hdulist = fits.HDUList([hdu])
         return hdulist

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -215,9 +215,17 @@ class CCDData(NDDataArray):
             # Simply extending the FITS header with the WCS can lead to
             # duplicates of the WCS keywords; iterating over the WCS
             # header should be safer.
+            #
+            # Turns out if I had read the io.fits.Header.extend docs more
+            # carefully, I would have realized that the keywords exist to
+            # avoid duplicates and preserve, as much as possible, the
+            # structure of the commentary cards.
+            #
+            # Note that until astropy/astropy#3967 is closed, the extend
+            # will fail if there are comment cards in the WCS header but
+            # not header.
             wcs_header = self.wcs.to_header()
-            for k, v in wcs_header.iteritems():
-                header[k] = v
+            header.extend(wcs_header, useblanks=False, unique=True)
         hdu = fits.PrimaryHDU(self.data, header)
         hdulist = fits.HDUList([hdu])
         return hdulist

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -493,8 +493,7 @@ def test_wcs_attribute(ccd_data, tmpdir):
     wcs.wcs.ctype = ["RA---AIR", "DEC--AIR"]
     wcs.wcs.set_pv([(2, 1, 45.0)])
     ccd_data.header = ccd_data.to_hdu()[0].header
-
-    ccd_data.header.extend(wcs.to_header())
+    ccd_data.header.extend(wcs.to_header(), useblanks=False)
     ccd_data.write(tmpfile.strpath)
     ccd_new = CCDData.read(tmpfile.strpath)
     original_header_length = len(ccd_new.header)
@@ -514,6 +513,10 @@ def test_wcs_attribute(ccd_data, tmpdir):
     hdu = ccd_wcs_not_in_header.to_hdu()[0]
     wcs_header = wcs.to_header()
     for k in wcs_header.keys():
+        # Skip these keywords if they are in the WCS header because they are
+        # not WCS-specific.
+        if k in ['', 'COMMENT', 'HISTORY']:
+            continue
         # No keyword from the WCS should be in the header.
         assert k not in ccd_wcs_not_in_header.header
         # Every keyword in the WCS should be in the header of the HDU


### PR DESCRIPTION
Some keywords (blank, comment, history) can have multiple values. Using `iteritems` properly iterates over those cases.

Closes #228 