### PR TITLE
Astropy v1.05

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then 
-       # TODO can use latest version of coverage (4.0) once
-       # https://github.com/astropy/astropy/issues/4175 is addressed in
-       # astropy release version.
-       pip install coverage==3.7.1;
-       pip install coveralls;
-       fi		 
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage==3.7.1 coveralls; fi
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,12 @@ install:
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+       # TODO can use latest version of coverage (4.0) once
+       # https://github.com/astropy/astropy/issues/4175 is addressed in
+       # astropy release version.
+       pip install coverage==3.7.1;
+       pip install coveralls;
+       fi		 
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then 
        # TODO can use latest version of coverage (4.0) once
        # https://github.com/astropy/astropy/issues/4175 is addressed in
        # astropy release version.

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -204,7 +204,7 @@ class CCDData(NDDataArray):
             # header we are constructing. This probably indicates that
             # _insert_in_metadata_fits_safe should be rewritten in a more
             # sensible way...
-            dummy_ccd = CCDData(data=[1], meta=fits.Header(), unit="adu")
+            dummy_ccd = CCDData([1], meta=fits.Header(), unit="adu")
             for k, v in self.header.items():
                 dummy_ccd._insert_in_metadata_fits_safe(k, v)
             header = dummy_ccd.header
@@ -264,7 +264,7 @@ class CCDData(NDDataArray):
         else:
             result_uncertainty = None
 
-        result = CCDData(data=result_data, unit=result_unit,
+        result = CCDData(result_data, unit=result_unit,
                          uncertainty=result_uncertainty,
                          meta=self.meta)
         return result

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -270,7 +270,7 @@ def test_subtract_dark(ccd_data, explicit_times, scale, exposure_keyword):
     exposure_unit = u.second
     dark_level = 1.7
     master_dark_data = np.zeros_like(ccd_data.data) + dark_level
-    master_dark = CCDData(data=master_dark_data, unit=u.adu)
+    master_dark = CCDData(master_dark_data, unit=u.adu)
     master_dark.header[exptime_key] = 2 * exptime
     dark_exptime = master_dark.header[exptime_key]
     ccd_data.header[exptime_key] = exptime


### PR DESCRIPTION
Update to ccdproc to take account of issues created with the merging into astorpy 1.05 of astropy/astropy#4130  and #241.   CCDData should still be backward compatible with earlier versions of astropy, but any code that uses CCDData(data=...) format will be broken.