### PR TITLE
Updating .travis to reflect recent miniconda changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,15 @@ before_install:
     # Use utf8 encoding. Should be default, but this is insurance against
     # future changes
     - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+
+    # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
 install:
 

--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -6,7 +6,7 @@ from astropy.tests.pytest_plugins import *
 
 from .tests.pytest_fixtures import *
 
-# This is to figure out photutils version, rather than using Astropy's
+# This is to figure out ccdproc version, rather than using Astropy's
 from . import version
 
 try:


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing.