### PR TITLE
Added default uncertainty function in average_combine of combiner.py

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -124,14 +124,6 @@ class CCDData(NDDataArray):
     @data.setter
     def data(self, value):
         self._data = value
-        
-    @property
-    def wcs(self):
-        return self._wcs
-    
-    @wcs.setter
-    def wcs(self, value):
-        self._wcs = value
 
     @property
     def wcs(self):

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -124,6 +124,14 @@ class CCDData(NDDataArray):
     @data.setter
     def data(self, value):
         self._data = value
+        
+    @property
+    def wcs(self):
+        return self._wcs
+    
+    @wcs.setter
+    def wcs(self, value):
+        self._wcs = value
 
     @property
     def wcs(self):

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -269,7 +269,7 @@ class Combiner(object):
                it overrides ``CCDData.scaling``. Defaults to None.
 
            uncertainty_func : function, optional
-               Function to calculate uncertainty. Defaults to ccdproc.sigma_func
+               Function to calculate uncertainty. Defaults to `ccdproc.sigma_func`
 
            Returns
            -------
@@ -332,7 +332,7 @@ class Combiner(object):
                it overrides ``CCDData.scaling``. Defaults to None.
 
            uncertainty_func: function, optional
-                Function to calculate uncertainty. Defaults to numpy.ma.std
+                Function to calculate uncertainty. Defaults to `numpy.ma.std`
 
            Returns
            -------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -308,7 +308,7 @@ class Combiner(object):
         # return the combined image
         return combined_image
 
-    def average_combine(self, scale_func=ma.average, scale_to=None):
+    def average_combine(self, scale_func=ma.average, scale_to=None, uncertainty_func=ma.std):
         """ Average combine together a set of arrays.
 
            A `~ccdproc.CCDData` object is returned with the data property
@@ -352,7 +352,7 @@ class Combiner(object):
         mask = (mask == len(self.data_arr))
 
         # set up the deviation
-        uncertainty = ma.std(self.data_arr, axis=0)
+        uncertainty = uncertainty_func(self.data_arr, axis=0)
 
         # create the combined image with a dtype that matches the combiner
         combined_image = CCDData(np.asarray(data.data, dtype=self.dtype),

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -267,9 +267,9 @@ class Combiner(object):
            scale_to : float, optional
                Scaling factor used in the average combined image. If given,
                it overrides ``CCDData.scaling``. Defaults to None.
-               
+
            uncertainty_func : function, optional
-               Function to calculate uncertainty. Defaults to sigma_func
+               Function to calculate uncertainty. Defaults to ccdproc.sigma_func
 
            Returns
            -------
@@ -330,10 +330,10 @@ class Combiner(object):
            scale_to : float, optional
                Scaling factor used in the average combined image. If given,
                it overrides ``CCDData.scaling``. Defaults to None.
-               
+
            uncertainty_func: function, optional
-                Function to calculate uncertainty. Defaults to ma.std
-                
+                Function to calculate uncertainty. Defaults to numpy.ma.std
+
            Returns
            -------
            combined_image: `~ccdproc.CCDData`

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from numpy import ma
 from .ccddata import CCDData
-from .core import trim_image
+from .core import trim_image, sigma_func
 
 from astropy.stats import median_absolute_deviation
 from astropy.nddata import StdDevUncertainty
@@ -247,7 +247,7 @@ class Combiner(object):
             self.data_arr.mask[mask] = True
 
     # set up the combining algorithms
-    def median_combine(self, median_func=ma.median, scale_to=None):
+    def median_combine(self, median_func=ma.median, scale_to=None, uncertainty_func=sigma_func):
         """Median combine a set of arrays.
 
            A `~ccdproc.CCDData` object is returned
@@ -267,6 +267,9 @@ class Combiner(object):
            scale_to : float, optional
                Scaling factor used in the average combined image. If given,
                it overrides ``CCDData.scaling``. Defaults to None.
+               
+           uncertainty_func : function, optional
+               Function to calculate uncertainty. Defaults to sigma_func
 
            Returns
            -------
@@ -294,8 +297,7 @@ class Combiner(object):
         mask = (mask == len(self.data_arr))
 
         # set the uncertainty
-        uncertainty = 1.4826 * median_absolute_deviation(self.data_arr.data,
-                                                         axis=0)
+        uncertainty = uncertainty_func(self.data_arr.data, axis=0)
 
         # create the combined image with a dtype matching the combiner
         combined_image = CCDData(np.asarray(data.data, dtype=self.dtype),
@@ -328,7 +330,10 @@ class Combiner(object):
            scale_to : float, optional
                Scaling factor used in the average combined image. If given,
                it overrides ``CCDData.scaling``. Defaults to None.
-
+               
+           uncertainty_func: function, optional
+                Function to calculate uncertainty. Defaults to ma.std
+                
            Returns
            -------
            combined_image: `~ccdproc.CCDData`

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -571,7 +571,7 @@ def transform_image(ccd, transform_func, **kwargs):
     return nccd
 
 
-def sigma_func(arr):
+def sigma_func(arr, axis=0):
     """
     Robust method for calculating the deviation of an array. ``sigma_func``
     uses the median absolute deviation to determine the standard deviation.
@@ -580,13 +580,16 @@ def sigma_func(arr):
     ----------
     arr : `~ccdproc.CCDData` or `~numpy.ndarray`
         Array whose deviation is to be calculated.
+        
+    axis : None or int or tuple of ints, optional
+        Axis or axes along which a sum is performed. The default (axis = None) is perform a sum over all the dimensions of the input array. axis may be negative, in which case it counts from the last to the first axis.
 
     Returns
     -------
     float
         standard deviation of array
     """
-    return 1.4826 * stats.median_absolute_deviation(arr)
+    return 1.4826 * stats.median_absolute_deviation(arr, 0)
 
 
 def setbox(x, y, mbox, xmax, ymax):

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -571,7 +571,7 @@ def transform_image(ccd, transform_func, **kwargs):
     return nccd
 
 
-def sigma_func(arr, axis=0):
+def sigma_func(arr, axis=None):
     """
     Robust method for calculating the deviation of an array. ``sigma_func``
     uses the median absolute deviation to determine the standard deviation.
@@ -580,16 +580,20 @@ def sigma_func(arr, axis=0):
     ----------
     arr : `~ccdproc.CCDData` or `~numpy.ndarray`
         Array whose deviation is to be calculated.
-        
+
     axis : None or int or tuple of ints, optional
-        Axis or axes along which a sum is performed. The default (axis = None) is perform a sum over all the dimensions of the input array. axis may be negative, in which case it counts from the last to the first axis.
+        Axis or axes along which the function is performed.
+        If ``None`` (the default) it is performed over all the dimensions of the input array.
+        The axis argument can also be negative, in this case it counts from
+        the last to the first axis.
+
 
     Returns
     -------
     float
         standard deviation of array
     """
-    return 1.4826 * stats.median_absolute_deviation(arr, 0)
+    return 1.482602218505602 * stats.median_absolute_deviation(arr)
 
 
 def setbox(x, y, mbox, xmax, ymax):

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -571,12 +571,6 @@ def test_header(ccd_data):
     assert ccd.meta == a
 
 
-def test_wcs(ccd_data):
-    ccd_data.wcs = 5
-    assert ccd_data.wcs == 5
-<<<<<<< HEAD
-
-
 def test_wcs_arithmetic(ccd_data):
     ccd_data.wcs = 5
     result = ccd_data.multiply(1.0)

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -574,6 +574,7 @@ def test_header(ccd_data):
 def test_wcs(ccd_data):
     ccd_data.wcs = 5
     assert ccd_data.wcs == 5
+<<<<<<< HEAD
 
 
 def test_wcs_arithmetic(ccd_data):
@@ -644,3 +645,7 @@ def test_write_read_multiextensionfits_custom_ext_names(ccd_data, tmpdir):
     np.testing.assert_array_equal(ccd_data.mask, ccd_after.mask)
     np.testing.assert_array_equal(ccd_data.uncertainty.array,
                                   ccd_after.uncertainty.array)
+
+def test_wcs(ccd_data):
+    ccd_data.wcs = 5
+    assert ccd_data.wcs == 5

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -332,14 +332,17 @@ def test_combine_limitedmem_scale_fitsimages():
 
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data, decimal = 4)
 
-
-#test that an uncertainty function in average_combine
-#can be passed optionally
+#test the optional uncertainty function in average_combine
 def test_average_combine_uncertainty(ccd_data):
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.average_combine(uncertainty_func=np.sum)
     assert np.all(ccd.uncertainty.array == np.sum(c.data_arr, 0))
     
-    
-    
+#test the optional uncertainty function in median_combine
+def test_median_combine_uncertainty(ccd_data):
+    ccd_list = [ccd_data, ccd_data, ccd_data]
+    c = Combiner(ccd_list)
+    ccd = c.median_combine(uncertainty_func=np.sum)
+    assert np.all(ccd.uncertainty.array == np.sum(c.data_arr, 0))
+ 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -296,7 +296,7 @@ def test_combine_average_ccddata():
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data)
 
 
-#test combiner convenience function reads fits file and 
+#test combiner convenience function reads fits file and
 # and combine as expected when asked to run in limited memory
 def test_combine_limitedmem_fitsimages():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
@@ -312,7 +312,7 @@ def test_combine_limitedmem_fitsimages():
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data)
 
 
-#test combiner convenience function reads fits file and 
+#test combiner convenience function reads fits file and
 # and combine as expected when asked to run in limited memory with scaling
 @pytest.mark.xfail(NUMPY_LT_1_9,
                    reason="numpy < 1.9 loses precision in np.ma.average")
@@ -337,12 +337,11 @@ def test_average_combine_uncertainty(ccd_data):
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.average_combine(uncertainty_func=np.sum)
-    assert np.all(ccd.uncertainty.array == np.sum(c.data_arr, 0))
-    
+    np.testing.assert_array_equal(ccd.uncertainty.array, np.sum(c.data_arr, 0))
+
 #test the optional uncertainty function in median_combine
 def test_median_combine_uncertainty(ccd_data):
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.median_combine(uncertainty_func=np.sum)
-    assert np.all(ccd.uncertainty.array == np.sum(c.data_arr, 0))
- 
+    np.testing.assert_array_equal(ccd.uncertainty.array, np.sum(c.data_arr, 0))

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -332,3 +332,14 @@ def test_combine_limitedmem_scale_fitsimages():
 
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data, decimal = 4)
 
+
+#test that an uncertainty function in average_combine
+#can be passed optionally
+def test_average_combine_uncertainty(ccd_data):
+    ccd_list = [ccd_data, ccd_data, ccd_data]
+    c = Combiner(ccd_list)
+    ccd = c.average_combine(uncertainty_func=np.sum)
+    assert np.all(ccd.uncertainty.array == np.sum(c.data_arr, 0))
+    
+    
+    


### PR DESCRIPTION
Added a default uncertainty function in average_combine of combiner.py so that an uncertainty function can be passed optionally. This closes part of issue #224. As for the other part would it be preferable to let the default uncertainty function in median_combine be median_absolute_deviation and then use a conditional to multiply by the factor of 1.4826 if the uncertainty function is the default using something like:  
 
def median_combine(self, median_func=ma.median, scale_to=None, uncertainty_func=median_absolute_deviation):
. . . 
if uncertainty_func is median_absolute_deviation:
    uncertainty_func *= 1.4826

or would it be better to define a function for median_absolute_deviation that does this multiplication so that uncertainty can simply be assigned the default or optionally passed function without having to worry about whether the factor of 1.4826 is applicable?