### PR TITLE
Ensure column order in ImageFileCollection matches the order of keywords in constructor

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -106,9 +106,22 @@ class ImageFileCollection(object):
         collection.
 
         Each keyword is a column heading. In addition, there is a column
-        called 'file' that contains the name of the FITS file. The directory
+        called ``file`` that contains the name of the FITS file. The directory
         is not included as part of that name.
-        """
+
+        The first column is always named ``file``.
+
+        The order of the remaining columns depends on how the summary was
+        constructed.
+
+        If a wildcard, ``*`` was used then the order is the order in which
+        the keywords appear in the FITS files from which the summary is
+        constructed.
+
+        If an explicit list of keywords was supplied in setting up the
+        collection then the order of the columns is the order of the
+        keywords.
+        """,
         return self._summary_info
 
     @property
@@ -160,6 +173,7 @@ class ImageFileCollection(object):
 
         # remove duplicates and force a copy
         new_keys = list(set(keywords))
+
         logging.debug('keywords after pruning %s', new_keys)
 
         full_new_keys = list(set(new_keys))
@@ -178,6 +192,8 @@ class ImageFileCollection(object):
                           ' '.join(self.keywords))
         else:
             logging.debug('should be building new table...')
+            # Reorder the keywords to match the initial ordering.
+            new_keys.sort(key=keywords.index)
             self._summary_info = self._fits_summary(header_keywords=new_keys)
 
     @property
@@ -248,8 +264,10 @@ class ImageFileCollection(object):
     def _dict_from_fits_header(self, file_name, input_summary=None,
                                missing_marker=None):
         """
-        Construct a dictionary whose keys are the header keywords and values
-        are a list of the values from this file and the input dictionary.
+        Construct an ordered dictionary whose keys are the header keywords
+        and values are a list of the values from this file and the input
+        dictionary. If the input dictionary is ordered then that order is
+        preserved.
 
         Parameters
         ----------
@@ -372,6 +390,8 @@ class ImageFileCollection(object):
         for file_name in file_name_column:
             file_path = path.join(self.location, file_name)
             try:
+                # Note: summary_dict is an OrderedDict, so should preserve
+                # the order of the keywords in the FITS header.
                 summary_dict = self._dict_from_fits_header(
                     file_path, input_summary=summary_dict,
                     missing_marker=missing_marker)
@@ -398,7 +418,11 @@ class ImageFileCollection(object):
             summary_table.add_column(all_masked)
 
         if '*' not in header_keys:
-            summary_table.keep_columns(header_keys)
+            # Rearrange table columns to match order of keywords.
+            # File always comes first.
+            header_keys -= set(['file'])
+            original_order = ['file'] + sorted(header_keys, key=header_keywords.index)
+            summary_table = summary_table[original_order]
 
         if not summary_table.masked:
             summary_table = Table(summary_table, masked=True)

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -373,8 +373,12 @@ class ImageFileCollection(object):
         if not self.files:
             return None
 
+        # Make sure we have a list...for example, in python 3, dict.keys()
+        # is not a list.
+        original_keywords = list(header_keywords)
+
         # Get rid of any duplicate keywords, also forces a copy.
-        header_keys = set(header_keywords)
+        header_keys = set(original_keywords)
         header_keys.add('file')
 
         file_name_column = MaskedColumn(name='file', data=self.files)
@@ -421,7 +425,8 @@ class ImageFileCollection(object):
             # Rearrange table columns to match order of keywords.
             # File always comes first.
             header_keys -= set(['file'])
-            original_order = ['file'] + sorted(header_keys, key=header_keywords.index)
+            original_order = ['file'] + sorted(header_keys,
+                                               key=original_keywords.index)
             summary_table = summary_table[original_order]
 
         if not summary_table.masked:

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -551,3 +551,9 @@ class TestImageFileCollection(object):
         new_len = len(ic.summary_info) - triage_setup.n_test['compressed']
         print(ic.summary_info['file'])
         assert new_len == 2 * original_len
+
+    def test_keyword_order_is_preserved(self, triage_setup):
+        keywords = ['imagetyp', 'exposure', 'filter']
+        ic = image_collection.ImageFileCollection(triage_setup.test_dir,
+                                                  keywords=keywords)
+        assert ic.keywords == ['file'] + keywords

--- a/docs/ccdproc/image_management.rst
+++ b/docs/ccdproc/image_management.rst
@@ -35,7 +35,7 @@ Most of the useful interaction with the image collection is via its
 file in the collection::
 
     >>> ic1.summary.colnames
-    ['file', 'filter', 'object', 'imagetyp', 'exposure']
+    ['file', 'imagetyp', 'object', 'filter', 'exposure']
     >>> ic_all.summary.colnames # doctest: +SKIP
     # long list of keyword names omitted
 


### PR DESCRIPTION
In addition, this clarifies the docstring a bit to explain how column order is determined.

The only case in which it is determined by the order of the keywords passed to the constructor is when the wildcard `*` is *not* used.

Otherwise the column order is the order in which the keywords appear in the first FITS file opened.