### PR TITLE
Fix typos and unify wording in image_management

### DIFF
--- a/docs/ccdproc/image_management.rst
+++ b/docs/ccdproc/image_management.rst
@@ -31,7 +31,7 @@ collection to use all keywords in the headers::
     >>> ic_all = ImageFileCollection('.', keywords='*')
 
 Most of the useful interaction with the image collection is via its
-``.summary`` property, an :class:`~astropy.table.Table` of the value of each keyword for each
+``.summary`` property, a :class:`~astropy.table.Table` of the value of each keyword for each
 file in the collection::
 
     >>> ic1.summary.colnames
@@ -54,7 +54,7 @@ the I band with exposure time less than 60 seconds you could do::
 The column ``file`` is added automatically when the image collection is created.
 
 For more simple selection, when you just want files whose keywords exactly
-match particular values, say all 'I' band images with exposure time of 30
+match particular values, say all I band images with exposure time of 30
 seconds, there is a convenience method ``.files_filtered``::
 
     >>> my_files = ic1.files_filtered(filter='I', exposure=30)
@@ -68,7 +68,7 @@ Iterating over hdus, headers or data
 Three methods are provided for iterating over the images in the collection,
 optionally filtered by keyword values.
 
-For example, to iterate over all of the I band light images with exposure of
+For example, to iterate over all of the I band images with exposure of
 30 seconds, performing some basic operation on the data (very contrived
 example)::
 
@@ -91,7 +91,7 @@ hdu (or header or data)::
     ...    hdu.data = hdu.data - hdu.data.mean()
     ...    hdu.writeto(fname + '.new')
 
-That last use case, doing something to several files and wanting to same them
+That last use case, doing something to several files and saving them
 somewhere afterwards, is common enough that the iterators provide arguments to
 automate it.
 
@@ -102,7 +102,7 @@ There are three ways of triggering automatic saving.
 
 1. One is with the argument ``save_with_name``; it adds the value of the
 argument to the file name between the original base name and extension. The
-example below has (almsot) the same effect of the example above, subtracting
+example below has (almost) the same effect of the example above, subtracting
 the mean from each image and saving to a new file::
 
     >>> for hdu in ic1.hdus(save_with_name='_new',
@@ -118,8 +118,8 @@ file, in the same directory, called ``input001_new.fit`` would be created.
 2. You can also provide the directory to which you want to save the files with
 ``save_location``; note that you do not need to actually do anything to the
 hdu (or header or data) to cause the copy to be made. The example below copies
-all of the I-band light files with 30 second exposure from the original
-location to ``"other_dir"``::
+all of the I band images with 30 second exposure from the original
+location to ``other_dir``::
 
     >>> for hdu in ic1.hdus(save_location='other_dir',
     ...                     imagetyp='LiGhT', filter='I', exposure=30):
@@ -129,8 +129,8 @@ This option can be combined with the previous one to also give the files a
 new name.
 
 3. Finally, if you want to live dangerously, you can overwrite the files in
-the location with the ``overwrite`` argument; use it carefully because it
-preserves no backup. The example below replaces each of the I-band light files
+the same location with the ``overwrite`` argument; use it carefully because it
+preserves no backup. The example below replaces each of the I band images
 with 30 second exposure with a file that has had the mean subtracted::
 
     >>> for hdu in ic1.hdus(overwrite=True,


### PR DESCRIPTION
I tried to make the naming a little more uniform. Sometimes it was `I band images` sometimes it was "I-band light", `I-band light` or `'I' band light`.