### PR TITLE
Updated how the header is read in if the data is

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -360,7 +360,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, **kwd):
     hdu : int, optional
         FITS extension from which CCDData should be initialized.  If zero and
         and no data in the primary extention, it will search for the first
-        extension with data.
+        extension with data.  The header will be added to the primary header.
 
     unit : astropy.units.Unit, optional
         Units of the image data. If this argument is provided and there is a
@@ -395,7 +395,8 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, **kwd):
         for i in range(len(hdus)):
             if hdus.fileinfo(i)['datSpan'] > 0:
                 hdu = i
-                log.info("First HDU with data is exention {0}".format(hdu))
+                hdr = hdr + hdus[hdu].header
+                log.info("First HDU with data is exention {0}.".format(hdu))
                 break
 
     try:
@@ -419,7 +420,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, **kwd):
     # Test for success by checking to see if the wcs ctype has a non-empty
     # value.
     wcs = wcs if wcs.wcs.ctype[0] else None
-    ccd_data = CCDData(hdus[hdu].data, meta=hdus[hdu].header, unit=use_unit,
+    ccd_data = CCDData(hdus[hdu].data, meta=hdr, unit=use_unit,
                        wcs=wcs)
     hdus.close()
     return ccd_data

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -90,6 +90,8 @@ def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     ccd = CCDData.read(filename, unit='adu')
     # ccd should pick up the unit adu from the fits header...did it?
     np.testing.assert_array_equal(ccd.data, fake_img)
+    #check that the header is the combined header
+    assert hdu1.header+hdu2.header==ccd.header
 
 
 def test_initialize_from_fits_with_extension(tmpdir):


### PR DESCRIPTION
Updated how the header is read in if the data is not in the primary extension.  When reading in data and then writing it out, if the data is in the first extension rather than the primary extension all of the information in the primary extension is lost.

This fixes that problem by combining the header in the primary extension and the extension in which the data first appears in.  This data is then written out as a single header when the CCDData object is written out.  