### PR TITLE
Add a 'sort' method to ImageFileCollection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bug Fixes
 New Features
 ^^^^^^^^^^^^
 
+- add a ``sort`` method to ImageFileCollection [#274]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -269,6 +269,21 @@ class ImageFileCollection(object):
         self._files = self._fits_files_in_directory()
         self._summary_info = self._fits_summary(header_keywords=keywords)
 
+    def sort(self, keys=None):
+        """Sort the list of files to determine the order of iteration.
+
+        Sort the table of files according to one or more keys. This does not
+        create a new object, instead is sorts in place.
+
+        Parameters
+        ----------
+        keys : str or list of str
+            The key(s) to order the table by.
+        """
+        if len(self._summary_info) > 0:
+            self._summary_info.sort(keys)
+            self._files = list(self.summary_info['file'])
+
     def _dict_from_fits_header(self, file_name, input_summary=None,
                                missing_marker=None):
         """
@@ -540,6 +555,7 @@ class ImageFileCollection(object):
         for extension in full_extensions:
             files.extend(fnmatch.filter(all_files, '*' + extension))
 
+        files.sort()
         return files
 
     def _generator(self, return_type,

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -571,3 +571,20 @@ class TestImageFileCollection(object):
         ic = image_collection.ImageFileCollection(triage_setup.test_dir,
                                                   keywords=keywords)
         assert ic.keywords == ['file'] + keywords
+
+    def test_sorting(self, triage_setup):
+        collection = image_collection.ImageFileCollection(location=triage_setup.test_dir,
+                                             keywords=['imagetyp',
+                                                       'filter',
+                                                       'object'])
+
+        all_elements = []
+        for hdu, fname in collection.hdus(return_fname=True):
+            all_elements.append((str(hdu.header), fname))
+        # Now sort
+        collection.sort(keys=['filter', 'object'])
+        # and check it's all still right
+        for hdu, fname in collection.hdus(return_fname=True):
+            assert((str(hdu.header), fname) in all_elements)
+        for i in range(len(collection.summary)):
+            assert(collection.summary['file'][i] == collection.files[i])

--- a/docs/ccdproc/image_management.rst
+++ b/docs/ccdproc/image_management.rst
@@ -62,6 +62,16 @@ seconds, there is a convenience method ``.files_filtered``::
 The optional arguments to ``files_filtered`` are used to filter the list of
 files.
 
+Sorting files
+-------------
+Sometimes it is useful to bring the files into a specific order, e.g. if you
+make a plot for each object you probably want all images of the same object
+next to each other. To do this, the images in a collection can be sorted with
+the ``sort`` method using the fits header keys in the same way you would sort a
+:class:`~astropy.table.Table`::
+
+    >>> ic1.sort(['object', 'filter'])
+
 Iterating over hdus, headers or data
 ------------------------------------
 


### PR DESCRIPTION
This uses the underlying table structure to do that sort, it also updates
the separate self._files accordingly.
This method allows me to set a the order in which the files are processed,
e.g. I can iterate over all files and make plots sorted alphabetically by
'OBJECT' or by 'OBS-TIME' or 'FILTER'.

A related change is to sort the file list when reading files from a
directory. This sorting is alphabetical, if the user does not like it
they can always use the new 'sort' function later.
This change makes the order of files that are read in reproducible, which is useful
when the iterators are used to make plots of each file - I want the same order
when I re-run my script.
(Without this change the order of files seems to change randomly at times.)