### PR TITLE
Include an option to return the full path in ImageFileCollection.files_filtered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Add a new keyword to ImageFileCollection.files_filtered to return the full
+  path to a file [#275]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -234,6 +234,9 @@ class ImageFileCollection(object):
 
         ``**kwd`` is list of keywords and values the files must have.
 
+        If the keyword ``include_path=True`` is set, the returned list
+        contains not just the filename, but the full path to each file.
+
         The value '*' represents any value.
          A missing keyword is indicated by value ''
 
@@ -247,9 +250,14 @@ class ImageFileCollection(object):
         """
         # force a copy by explicitly converting to a list
         current_file_mask = list(self.summary_info['file'].mask)
+
+        include_path = kwd.pop('include_path', False)
+
         self._find_keywords_by_values(**kwd)
         filtered_files = self.summary_info['file'].compressed()
         self.summary_info['file'].mask = current_file_mask
+        if include_path:
+            filtered_files = [self._location + f for f in filtered_files]
         return filtered_files
 
     def refresh(self):

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -377,6 +377,13 @@ class TestImageFileCollection(object):
         should_not_be_zero = ic.files_filtered(naxis=1)
         assert len(should_not_be_zero) == triage_setup.n_test['files']
 
+    def test_files_filtered_with_full_path(self, triage_setup):
+        ic = image_collection.ImageFileCollection(triage_setup.test_dir, keywords=['naxis'])
+        files = ic.files_filtered(naxis=1, include_path=True)
+
+        for f in files:
+            assert f.startswith(triage_setup.test_dir)
+
     def test_unknown_generator_type_raises_error(self, triage_setup):
         ic = image_collection.ImageFileCollection(triage_setup.test_dir, keywords=['naxis'])
         with pytest.raises(ValueError):


### PR DESCRIPTION
This introduces a new keyword "include_path".
Note that this keyword can never clash with any fits header keyword, because
those are limited to 8 characters.