### PR TITLE
trim_image calls CCDData slicing even if fits_section is given.

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -299,11 +299,7 @@ def trim_image(ccd, fits_section=None):
     trimmed = ccd.copy()
     if fits_section:
         python_slice = slice_from_string(fits_section, fits_convention=True)
-        trimmed.data = trimmed.data[python_slice]
-        if trimmed.mask is not None:
-            trimmed.mask = trimmed.mask[python_slice]
-        if trimmed.uncertainty is not None:
-            trimmed.uncertainty.array = trimmed.uncertainty.array[python_slice]
+        trimmed = trimmed[python_slice]
 
     return trimmed
 


### PR DESCRIPTION
From a discussion in https://github.com/astropy/ccdproc/issues/281#issuecomment-171936763.

I think it would be best to rely on ``CCDData.__getdata__`` instead of trying to the same inside the ``trim_image`` function itself.