### PR TITLE
Ignore wcs

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -112,11 +112,11 @@ class CCDData(NDDataArray):
     @data.setter
     def data(self, value):
         self._data = value
-        
+
     @property
     def wcs(self):
         return self._wcs
-    
+
     @wcs.setter
     def wcs(self, value):
         self._wcs = value
@@ -282,7 +282,8 @@ class CCDData(NDDataArray):
     def multiply(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
             nother = other.copy()
-            if not compare_wcs: nother.wcs = self.wcs
+            if not compare_wcs:
+                nother.wcs = self.wcs
             return super(CCDData, self).multiply(nother)
 
         return self._ccddata_arithmetic(other, np.multiply,
@@ -292,7 +293,8 @@ class CCDData(NDDataArray):
         if isinstance(other, CCDData):
             nother = other.copy()
             nother.wcs = self.wcs
-            if not compare_wcs: nother.wcs = self.wcs
+            if not compare_wcs:
+                nother.wcs = self.wcs
             return super(CCDData, self).divide(nother)
 
         return self._ccddata_arithmetic(other, np.divide,
@@ -301,7 +303,8 @@ class CCDData(NDDataArray):
     def add(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
             nother = other.copy()
-            if not compare_wcs: nother.wcs = self.wcs
+            if not compare_wcs:
+                nother.wcs = self.wcs
             return super(CCDData, self).add(nother)
 
         return self._ccddata_arithmetic(other, np.add,
@@ -310,7 +313,8 @@ class CCDData(NDDataArray):
     def subtract(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
             nother = other.copy()
-            if not compare_wcs: nother.wcs = self.wcs
+            if not compare_wcs:
+                nother.wcs = self.wcs
             return super(CCDData, self).subtract(nother)
 
         return self._ccddata_arithmetic(other, np.subtract,

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -279,30 +279,39 @@ class CCDData(NDDataArray):
                          meta=new_meta, wcs=new_wcs)
         return result
 
-    def multiply(self, other):
+    def multiply(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
-            return super(CCDData, self).multiply(other)
+            nother = other.copy()
+            if not compare_wcs: nother.wcs = self.wcs
+            return super(CCDData, self).multiply(nother)
 
         return self._ccddata_arithmetic(other, np.multiply,
                                         scale_uncertainty=True)
 
-    def divide(self, other):
+    def divide(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
-            return super(CCDData, self).divide(other)
+            nother = other.copy()
+            nother.wcs = self.wcs
+            if not compare_wcs: nother.wcs = self.wcs
+            return super(CCDData, self).divide(nother)
 
         return self._ccddata_arithmetic(other, np.divide,
                                         scale_uncertainty=True)
 
-    def add(self, other):
+    def add(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
-            return super(CCDData, self).add(other)
+            nother = other.copy()
+            if not compare_wcs: nother.wcs = self.wcs
+            return super(CCDData, self).add(nother)
 
         return self._ccddata_arithmetic(other, np.add,
                                         scale_uncertainty=False)
 
-    def subtract(self, other):
+    def subtract(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
-            return super(CCDData, self).subtract(other)
+            nother = other.copy()
+            if not compare_wcs: nother.wcs = self.wcs
+            return super(CCDData, self).subtract(nother)
 
         return self._ccddata_arithmetic(other, np.subtract,
                                         scale_uncertainty=False)

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -90,8 +90,8 @@ def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     ccd = CCDData.read(filename, unit='adu')
     # ccd should pick up the unit adu from the fits header...did it?
     np.testing.assert_array_equal(ccd.data, fake_img)
-    #check that the header is the combined header
-    assert hdu1.header+hdu2.header==ccd.header
+    # check that the header is the combined header
+    assert hdu1.header + hdu2.header == ccd.header
 
 
 def test_initialize_from_fits_with_extension(tmpdir):
@@ -544,7 +544,7 @@ def test_wcs_attribute(ccd_data, tmpdir):
 
 def test_header(ccd_data):
     a = {'Observer': 'Hubble'}
-    ccd = CCDData(ccd_data, header = a)
+    ccd = CCDData(ccd_data, header=a)
     assert ccd.meta == a
 
 
@@ -552,19 +552,23 @@ def test_wcs(ccd_data):
     ccd_data.wcs = 5
     assert ccd_data.wcs == 5
 
+
 def test_wcs_arithmetic(ccd_data):
     ccd_data.wcs = 5
     result = ccd_data.multiply(1.0)
     assert result.wcs == 5
 
-@pytest.mark.parametrize('operation', ['multiply', 'divide', 'add', 'subtract'])
+
+@pytest.mark.parametrize('operation',
+                         ['multiply', 'divide', 'add', 'subtract'])
 def test_wcs_arithmetic_ccd(ccd_data, operation):
     ccd_data2 = ccd_data.copy()
     ccd_data.wcs = 5
     method = ccd_data.__getattribute__(operation)
     result = method(ccd_data2)
     assert result.wcs == ccd_data.wcs
-    assert ccd_data2.wcs is None 
+    assert ccd_data2.wcs is None
+
 
 def test_wcs_add_raise_ValueError(ccd_data):
     ccd_data2 = ccd_data.copy()

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -556,3 +556,18 @@ def test_wcs_arithmetic(ccd_data):
     ccd_data.wcs = 5
     result = ccd_data.multiply(1.0)
     assert result.wcs == 5
+
+@pytest.mark.parametrize('operation', ['multiply', 'divide', 'add', 'subtract'])
+def test_wcs_arithmetic_ccd(ccd_data, operation):
+    ccd_data2 = ccd_data.copy()
+    ccd_data.wcs = 5
+    method = ccd_data.__getattribute__(operation)
+    result = method(ccd_data2)
+    assert result.wcs == ccd_data.wcs
+    assert ccd_data2.wcs is None 
+
+def test_wcs_add_raise_ValueError(ccd_data):
+    ccd_data2 = ccd_data.copy()
+    ccd_data.wcs = 5
+    with pytest.raises(ValueError):
+        result = ccd_data.add(ccd_data2, compare_wcs=True)


### PR DESCRIPTION
For arithmetic between two CCDData objects, this will ignore any difference between WCS unless compare_wcs is set to True 