### PR TITLE
Astroscrappy cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='scipy'
-        - PIP_DEPENDENCIES='pytest-capturelog astroscrappy'
+        - CONDA_DEPENDENCIES='scipy astroscrappy'
+        - PIP_DEPENDENCIES='pytest-capturelog'
 
     matrix:
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ addons:
             - dvipng
 
 python:
-    - 2.6
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
 
@@ -56,12 +54,8 @@ matrix:
 
         # Try all python versions with the latest numpy available on that
         # python version.
-        - python: 2.6
-          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
-        - python: 3.3
-          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
         - python: 3.5
@@ -70,10 +64,6 @@ matrix:
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
 
 install:
 

--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -23,6 +23,7 @@ except NameError:
 
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['astroscrappy'] = 'astroscrappy'
     del PYTEST_HEADER_MODULES['h5py']
 except NameError:
     pass

--- a/docs/ccdproc/install.rst
+++ b/docs/ccdproc/install.rst
@@ -10,8 +10,10 @@ Ccdproc has the following requirements:
 - `Astropy`_ v0.4 or later
 - `Numpy <http://www.numpy.org/>`_
 - `Scipy <http://www.scipy.org/>`_
+- `astroscrappy <https://github.com/astropy/astroscrappy>`_
 
-One easy way to get these dependencies is to install a python distribution like `anaconda <http://continuum.io/>`_.
+One easy way to get these dependencies is to install a python distribution
+like `anaconda <http://continuum.io/>`_.
 
 Installing ccdproc
 ==================


### PR DESCRIPTION
This is to speed up travis a bit, and to mention the astroscrappy dependency in the docs.

Note that it's failing as no conda packages are available for older python/numpy versions. Waiting for the resolution of https://github.com/astropy/conda-builder-affiliated/issues/91 and then I'll either push another commit to install it from pip in those cases or there will be conda packages available.