### PR TITLE
Divide contained a Bug for compare_wcs=True

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -292,7 +292,6 @@ class CCDData(NDDataArray):
     def divide(self, other, compare_wcs=False):
         if isinstance(other, CCDData):
             nother = other.copy()
-            nother.wcs = self.wcs
             if not compare_wcs:
                 nother.wcs = self.wcs
             return super(CCDData, self).divide(nother)

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -570,8 +570,11 @@ def test_wcs_arithmetic_ccd(ccd_data, operation):
     assert ccd_data2.wcs is None
 
 
-def test_wcs_add_raise_ValueError(ccd_data):
+@pytest.mark.parametrize('operation',
+                         ['multiply', 'divide', 'add', 'subtract'])
+def test_wcs_add_raise_ValueError(ccd_data, operation):
     ccd_data2 = ccd_data.copy()
     ccd_data.wcs = 5
     with pytest.raises(ValueError):
-        result = ccd_data.add(ccd_data2, compare_wcs=True)
+        method = ccd_data.__getattribute__(operation)
+        method(ccd_data2, compare_wcs=True)


### PR DESCRIPTION
Division always set the other wcs to the one ``self`` had. This PR should fix this. The other arithmetics methods hadn't had this bug.