### PR TITLE
compare_wcs will not work with astropy-dev

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -284,6 +284,11 @@ class CCDData(NDDataArray):
             nother = other.copy()
             if not compare_wcs:
                 nother.wcs = self.wcs
+            elif hasattr(self, '_arithmetic_wcs'):
+                # We want to compare the WCS but for astropy v1.2+ compare_wcs
+                # must be a callable which compares the wcs.
+                raise ValueError('Astropy Version > 1.2 does not support'
+                                 'CCDProcs "compare_wcs" parameter.')
             return super(CCDData, self).multiply(nother)
 
         return self._ccddata_arithmetic(other, np.multiply,
@@ -295,6 +300,9 @@ class CCDData(NDDataArray):
             nother.wcs = self.wcs
             if not compare_wcs:
                 nother.wcs = self.wcs
+            elif hasattr(self, '_arithmetic_wcs'):
+                raise ValueError('Astropy Version > 1.2 does not support'
+                                 'CCDProcs "compare_wcs" parameter.')
             return super(CCDData, self).divide(nother)
 
         return self._ccddata_arithmetic(other, np.divide,
@@ -305,6 +313,9 @@ class CCDData(NDDataArray):
             nother = other.copy()
             if not compare_wcs:
                 nother.wcs = self.wcs
+            elif hasattr(self, '_arithmetic_wcs'):
+                raise ValueError('Astropy Version > 1.2 does not support'
+                                 'CCDProcs "compare_wcs" parameter.')
             return super(CCDData, self).add(nother)
 
         return self._ccddata_arithmetic(other, np.add,
@@ -315,6 +326,9 @@ class CCDData(NDDataArray):
             nother = other.copy()
             if not compare_wcs:
                 nother.wcs = self.wcs
+            elif hasattr(self, '_arithmetic_wcs'):
+                raise ValueError('Astropy Version > 1.2 does not support'
+                                 'CCDProcs "compare_wcs" parameter.')
             return super(CCDData, self).subtract(nother)
 
         return self._ccddata_arithmetic(other, np.subtract,


### PR DESCRIPTION
For astropy v1.2 the refactoring of ``NDArithmeticMixin`` will produce problems with arithmetic operations of ``CCDData`` instances *when* one wants to compare the different ``WCS``. (see #287)

This solution is a not optimal and I'm a bit embarrassed to make this PR but I couldn't think of a better way to:
- Check which version of astropy is used. The ``hasattr(self, '_arithmetics_wcs')`` was the only way I found to distinguish between the NDData that compares the wcs and the NDData that needs a comparison function that compares different WCS'es
- Make the tests work without xfailing them and having a reminder for post-astropy-1.2 changes in there.