### PR TITLE
Allow combination of images using WCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='scipy astroscrappy'
+        - CONDA_DEPENDENCIES='scipy astroscrappy reproject'
         - PIP_DEPENDENCIES='pytest-capturelog'
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    - "conda install -c astropy astroscrappy"
+    - "conda install -c astropy astroscrappy reproject"
 
 # Not a .NET project, we build astroplan in the install step instead
 build: false

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -12,7 +12,7 @@ from astropy.stats import median_absolute_deviation
 from astropy.nddata import StdDevUncertainty
 from astropy import log
 
-__all__ = ['Combiner', 'combine', 'wcs_combine']
+__all__ = ['Combiner', 'combine']
 
 
 class Combiner(object):
@@ -573,34 +573,3 @@ def combine(img_list, output_file=None, method='average', weights=None, scale=No
         ccd.write(output_file)
 
     return ccd
-
-
-def wcs_combine(image_list, target_wcs):
-    """
-    Given a list of CCDData images, project them onto a common WCS and
-    return a new CCDData image.
-
-    Any mask, flags, weight, or uncertainty are ignored in doing the
-    combination.
-
-    Parameters
-    ----------
-
-    image_list : list of images
-        The list can have any number of images.
-
-    target_wcs: `astropy.wcs.WCS` object
-        WCS onto which all images should be projected.
-    """
-    from reproject import reproject_interp
-
-    # Build up a list of reprojected images
-    reprojected_images = []
-    for image in image_list:
-        projected_image_raw, footprint = reproject_interp(image, target_wcs)
-        projected_image = CCDData(projected_image_raw, wcs=target_wcs,
-                                  header=image.header)
-        reprojected_images.append(projected_image)
-
-    combined_projected = Combiner(reprojected_images)
-    return combined_projected.average_combine()

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -40,6 +40,7 @@ _short_names = {
     'subtract_overscan': 'suboscan',
     'trim_image': 'trimim',
     'transform_image': 'tranim',
+    'wcs_project': 'wcsproj'
 }
 
 
@@ -578,18 +579,18 @@ def wcs_project(ccd, target_wcs, target_shape=None, order='bilinear'):
     Given a CCDData image with WCS, project it onto a target WCS and
     return the reprojected data as a new CCDData image.
 
-    Any mask, flags, weight, or uncertainty are ignored in doing the
-    combination.
+    Any flags, weight, or uncertainty are ignored in doing the
+    reprojection.
 
     Parameters
     ----------
     ccd : `~ccdproc.CCDData`
-        Data to be flatfield corrected
-    target_wcs: `astropy.wcs.WCS` object
+        Data to be projected.
 
+    target_wcs : `astropy.wcs.WCS` object
         WCS onto which all images should be projected.
 
-    target_shape: two element list-like, optional
+    target_shape : two element list-like, optional
         Shape of the output image. If omitted, defaults to the shape of the
         input image.
 
@@ -604,7 +605,7 @@ def wcs_project(ccd, target_wcs, target_shape=None, order='bilinear'):
 
     Returns
     -------
-    ccd :  `~ccdproc.CCDData`
+    ccd : `~ccdproc.CCDData`
         A transformed CCDData object
     """
     from reproject import reproject_interp

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -9,7 +9,6 @@ from astropy.units.quantity import Quantity
 import astropy.units as u
 from astropy.wcs import WCS
 
-
 from astropy.nddata import StdDevUncertainty
 
 from numpy.testing import assert_array_equal
@@ -643,9 +642,9 @@ def test_transform_image_does_not_change_input(ccd_data):
     assert original.unit == ccd_data.unit
 
 
-def wcs_for_testing(ccd_data):
+def wcs_for_testing(shape):
     # Set up a simply WCS, details are cut/pasted from astropy WCS docs,
-    # mostly. I did change the crpix location.
+    # mostly. CRPIX is set to the center of shape, rounded down.
 
     # Create a new WCS object.  The number of axes must be set
     # from the start
@@ -653,7 +652,7 @@ def wcs_for_testing(ccd_data):
 
     # Set up an "Airy's zenithal" projection
     # Vector properties may be set with Python lists, or Numpy arrays
-    w.wcs.crpix = [ccd_data.shape[0] // 2, ccd_data.shape[1] // 2]
+    w.wcs.crpix = [shape[0] // 2, shape[1] // 2]
     w.wcs.cdelt = np.array([-0.066667, 0.066667])
     w.wcs.crval = [0, -90]
     w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
@@ -662,8 +661,105 @@ def wcs_for_testing(ccd_data):
     return w
 
 
-def test_wcs_project(ccd_data):
-    target_wcs = wcs_for_testing(ccd_data)
-    ccd_data.wcs = wcs_for_testing(ccd_data)
+def test_wcs_project_onto_same_wcs(ccd_data):
+    # The trivial case.
+    target_wcs = wcs_for_testing(ccd_data.shape)
+    ccd_data.wcs = wcs_for_testing(ccd_data.shape)
+    ccd_data.mask = np.random.choice([0, 1], size=ccd_data.shape)
+
     new_ccd = wcs_project(ccd_data, target_wcs)
+
+    # Make sure new image has correct WCS.
     assert new_ccd.wcs.wcs.compare(target_wcs.wcs)
+
+    # Make sure data matches within some reasonable tolerance.
+    print((ccd_data.data-new_ccd.data).max())
+    np.testing.assert_allclose(ccd_data.data, new_ccd.data, rtol=1e-5)
+
+    # Make sure data matches within some reasonable tolerance.
+    print((ccd_data.mask != new_ccd.mask).sum())
+    np.testing.assert_array_equal(ccd_data.mask, new_ccd.mask)
+
+
+def test_wcs_project_onto_shifted_wcs(ccd_data):
+    # Just make the target WCS the same as the initial with the center
+    # pixel shifted by 1 in x and y.
+
+    ccd_data.wcs = wcs_for_testing(ccd_data.shape)
+    target_wcs = wcs_for_testing(ccd_data.shape)
+    target_wcs.wcs.crpix += [1, 1]
+
+    ccd_data.mask = np.random.choice([0, 1], size=ccd_data.shape)
+
+    new_ccd = wcs_project(ccd_data, target_wcs)
+
+    # Make sure new image has correct WCS.
+    assert new_ccd.wcs.wcs.compare(target_wcs.wcs)
+
+    # Make sure data matches within some reasonable tolerance, keeping in mind
+    # that the pixels should all be shifted.
+    np.testing.assert_allclose(ccd_data.data[:-1, :-1],
+                               new_ccd.data[1:, 1:], rtol=1e-5)
+
+    # The masks should all be shifted too.
+    np.testing.assert_array_equal(ccd_data.mask[:-1, :-1],
+                                  new_ccd.mask[1:, 1:])
+
+
+# Use an odd number of pixels to make a well-defined center pixel
+@pytest.mark.data_size(3)
+def test_wcs_project_onto_scale_wcs(ccd_data):
+    # Make the target WCS with half the pixel scale and number of pixels
+    # and the values should drop by a factor of 4.
+
+    ccd_data.wcs = wcs_for_testing(ccd_data.shape)
+
+    # Make sure wcs is centered at the center of the center pixel.
+    ccd_data.wcs.wcs.crpix += 0.5
+
+    # Use uniform input data value for simplicity.
+    ccd_data.data = np.ones_like(ccd_data.data)
+
+    # Make mask zero...
+    ccd_data.mask = np.zeros_like(ccd_data.data)
+    # ...except the center pixel, which is one.
+    ccd_data.mask[ccd_data.wcs.wcs.crpix[0], ccd_data.wcs.wcs.crpix[1]] = 1
+
+    target_wcs = wcs_for_testing(ccd_data.shape)
+    target_wcs.wcs.cdelt /= 2
+
+    # Choice below ensures we are really at the center pixel of an odd range.
+    target_shape = 2 * np.array(ccd_data.shape) + 1
+    target_wcs.wcs.crpix = 2 * target_wcs.wcs.crpix + 1 + 0.5
+
+    # Explicitly set the interpolation method so we know what to
+    # expect for the mass.
+    new_ccd = wcs_project(ccd_data, target_wcs,
+                          target_shape=target_shape,
+                          order='nearest-neighbor')
+
+    # Make sure new image has correct WCS.
+    assert new_ccd.wcs.wcs.compare(target_wcs.wcs)
+
+    # Define a cutout from the new array that should match the old.
+    new_lower_bound = (np.array(new_ccd.shape) -
+                       np.array(ccd_data.shape)) / 2
+    new_upper_bound = (np.array(new_ccd.shape) +
+                       np.array(ccd_data.shape)) / 2
+    data_cutout = new_ccd.data[new_lower_bound[0]:new_upper_bound[0],
+                               new_lower_bound[1]:new_upper_bound[1]]
+
+    # Make sure data matches within some reasonable tolerance, keeping in mind
+    # that the pixels have been scaled.
+    np.testing.assert_allclose(ccd_data.data / 4,
+                               data_cutout,
+                               rtol=1e-5)
+
+    # Mask should be true for four pixels (all nearest neighbors)
+    # of the single pixel we masked initially.
+    new_center = new_ccd.wcs.wcs.crpix
+    assert np.all(new_ccd.mask[new_center[0]:new_center[0]+2,
+                               new_center[1]:new_center[1]+2])
+
+    # Those are the only pixels that should be masked.
+    assert new_ccd.mask.sum() == 4

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -641,3 +641,29 @@ def test_transform_image_does_not_change_input(ccd_data):
     ccd = transform_image(ccd_data,np.sqrt)
     np.testing.assert_array_equal(original.data, ccd_data)
     assert original.unit == ccd_data.unit
+
+
+def wcs_for_testing(ccd_data):
+    # Set up a simply WCS, details are cut/pasted from astropy WCS docs,
+    # mostly. I did change the crpix location.
+
+    # Create a new WCS object.  The number of axes must be set
+    # from the start
+    w = WCS(naxis=2)
+
+    # Set up an "Airy's zenithal" projection
+    # Vector properties may be set with Python lists, or Numpy arrays
+    w.wcs.crpix = [ccd_data.shape[0] // 2, ccd_data.shape[1] // 2]
+    w.wcs.cdelt = np.array([-0.066667, 0.066667])
+    w.wcs.crval = [0, -90]
+    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
+    w.wcs.set_pv([(2, 1, 45.0)])
+
+    return w
+
+
+def test_wcs_project(ccd_data):
+    target_wcs = wcs_for_testing(ccd_data)
+    ccd_data.wcs = wcs_for_testing(ccd_data)
+    new_ccd = wcs_project(ccd_data, target_wcs)
+    assert new_ccd.wcs.wcs.compare(target_wcs.wcs)

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -11,6 +11,8 @@ from astropy.stats import median_absolute_deviation as mad
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.compat import NUMPY_LT_1_9
+from astropy.wcs import WCS
+
 from ..ccddata import CCDData
 from ..combiner import *
 

--- a/docs/ccdproc/image_combination.rst
+++ b/docs/ccdproc/image_combination.rst
@@ -149,11 +149,15 @@ First, reproject each image onto the same footprint using
 information and another image (or WCS) onto which you want to project your
 images:
 
+.. doctest-skip::
+
     >>> from ccdproc import wcs_project
     >>> reprojected_image = wcs_project(input_image, target_wcs)
 
 Repeat this for each of the images you want to combine, building up a list of
 reprojected images:
+
+.. doctest-skip::
 
     >>> reprojected = []
     >>> for img in my_list_of_images:
@@ -161,6 +165,8 @@ reprojected images:
     ...     reprojected.append(new_image)
 
 Then, combine the images as described above for any set of images:
+
+.. doctest-skip::
 
     >>> combiner = Combiner(reprojected)
     >>> stacked_image = combiner.average_combine()

--- a/docs/ccdproc/image_combination.rst
+++ b/docs/ccdproc/image_combination.rst
@@ -100,7 +100,7 @@ excluding any pixels mapped by clipping:
 
 Performing a median combination is also straightforward,
 
-    >>> combined_median = combiner.median_combine()  # can be slow, see below 
+    >>> combined_median = combiner.median_combine()  # can be slow, see below
 
 
 
@@ -119,7 +119,50 @@ underlying images are *not* scaled; scaling is only done as part of combining
 using `~ccdproc.Combiner.average_combine` or
 `~ccdproc.Combiner.median_combine`).
 
+
+.. _reprojection:
+
 With image transformation
 -------------------------
 
+.. note::
 
+    **Flux conservation** Whether flux is conserved in performing the
+    reprojection depends on the method you use for reprojecting and the
+    extent to which pixel area varies across the image.
+    `~ccdproc.wcs_project` rescales counts by the ratio of pixel area
+    *of the pixel indicated by the keywords* ``CRPIX`` of the input and
+    output images.
+
+    The reprojection methods available are described in detail in the
+    documentation for the `reproject project`_; consult those
+    documents for details.
+
+    You should carefully check whether flux conservation provided in CCDPROC
+    is adequate for your needs. Suggestions for improvement are welcome!
+
+Align and then combine images based on World Coordinate System (WCS)
+information in the image headers in two steps.
+
+First, reproject each image onto the same footprint using
+`~ccdproc.wcs_project`. The example below assumes you have an image with WCS
+information and another image (or WCS) onto which you want to project your
+images:
+
+    >>> from ccdproc import wcs_project
+    >>> reprojected_image = wcs_project(input_image, target_wcs)
+
+Repeat this for each of the images you want to combine, building up a list of
+reprojected images:
+
+    >>> reprojected = []
+    >>> for img in my_list_of_images:
+    ...     new_image = wcs_project(img, target_wcs)
+    ...     reprojected.append(new_image)
+
+Then, combine the images as described above for any set of images:
+
+    >>> combiner = Combiner(reprojected)
+    >>> stacked_image = combiner.average_combine()
+
+.. _reproject project: http://reproject.readthedocs.org/

--- a/docs/ccdproc/index.rst
+++ b/docs/ccdproc/index.rst
@@ -15,6 +15,9 @@ The `ccdproc` package provides:
 + A set of functions performing common CCD data reduction steps (e.g. dark
   subtraction, flat field correction) with a flexible mechanism for logging
   reduction steps in the image metadata.
++ A function for reprojecting an image onto another WCS, useful for stacking
+  science images. The actual reprojectino is done by the
+  `reproject package <http://reproject.readthedocs.org/en/stable/>`_.
 + A class for combining and/or clipping images, `~ccdproc.Combiner`, and
   associated functions.
 + A class, `~ccdproc.ImageFileCollection`, for working with a directory of
@@ -90,6 +93,8 @@ correction, in which one image is divided by another:
 
 In addition to doing the necessary division, `~ccdproc.flat_correct` propagates
 uncertainties (if they are set).
+
+The function `~ccdproc.wcs_project` allows you to reproject an image onto a different WCS. For more details see
 
 To make applying the same operations to a set of files in a directory easier,
 use an `~ccdproc.image_collection.ImageFileCollection`. It constructs, given a directory, an `~astropy.table.Table` containing the values of user-selected keywords in the directory. It also provides methods for iterating over the files. The example below was used to find an image in which the sky background was high for use in a talk:

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -88,7 +88,7 @@ LACosmic
 
 The lacosmic technique identifies cosmic rays by identifying pixels based on a
 variation of the Laplacian edge detection.  The algorithm is an implementation
-of the code describe in van Dokkum (2001) [1]_ as implemented 
+of the code describe in van Dokkum (2001) [1]_ as implemented
 in [astroscrappy](https://github.com/astropy/astroscrappy) [2]_.
 
 Use this technique with `~ccdproc.cosmicray_lacosmic`:
@@ -296,11 +296,20 @@ are replaced with ``min_value``):
     ...                                      min_value=0.9)
 
 
+Reprojecting onto a different image footprint
+---------------------------------------------
+
+An image with coordinate information (WCS) can be reprojected onto a different
+image footprint. The underlying functionality is proved by the `reproject
+project`_. Please see :ref:reprojection for more details.
+
+
 .. [1] van Dokkum, P; 2001, "Cosmic-Ray Rejection by Laplacian Edge
        Detection". The Publications of the Astronomical Society of the
        Pacific, Volume 113, Issue 789, pp. 1420-1427.
        doi: 10.1086/323894
 
-.. [2] McCully, C., 2014, "Astro-SCRAPPY", 
+.. [2] McCully, C., 2014, "Astro-SCRAPPY",
        https://github.com/astropy/astroscrappy
 
+.. _reproject project: http://reproject.readthedocs.org/


### PR DESCRIPTION
Closes #129 

Needs:
- [x] Documentation, including warning that flux conservation is not guaranteed (or at least that the user really ought to carefully check whether flux is conserved well enough for their purposes).
- [x] Proper handling of pixels in the result for which there was not a corresponding pixel in the input image.
