### PR TITLE
Scale uncertainty with the number of combined pixel during combination.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Bug Fixes
 
 - Adding/Subtracting a CCDData instance with a Quantity with a different unit
   produced wrong results. [#291]
+- The uncertainty resulting when combining CCDData will be divided by the
+  square root of the number of combined pixel [#309]
 
 
 0.3.2 (unreleased)

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -353,7 +353,7 @@ def test_median_combine_uncertainty(ccd_data):
 
 
 # test resulting uncertainty is corrected for the number of images
-def test_combiner_uncertainty_average(ccd_data):
+def test_combiner_uncertainty_average():
     ccd_list = [CCDData(np.ones((10, 10)), unit=u.adu),
                 CCDData(np.ones((10, 10))*2, unit=u.adu)]
     c = Combiner(ccd_list)
@@ -367,7 +367,7 @@ def test_combiner_uncertainty_average(ccd_data):
 
 
 # test resulting uncertainty is corrected for the number of images (with mask)
-def test_combiner_uncertainty_average_mask(ccd_data):
+def test_combiner_uncertainty_average_mask():
     mask = np.zeros((10, 10), dtype=np.bool_)
     mask[5, 5] = True
     ccd_with_mask = CCDData(np.ones((10, 10)), unit=u.adu, mask=mask)


### PR DESCRIPTION
Fixes #309 

Please review this carefully.

Some (remaining) open issues:
- Since you did not pass ``ddof`` to ``np.ma.std`` I didn't correct for finite populations either and just divided by ``np.sqrt(valid_pixel)``. This might not be exactly correct but I'm not too sure about statistics. The downside with such an finite population correction is also that the number of valid pixel could be 0 and then subtracting 1 and taking the square root ... not good.
- both combiners ignore scaling and weighting for the uncertainty computation.
- median combine ignores the masked values (probably because ``median_absolute_deviation`` cannot handle these. Therefore I corrected just with the whole number of pixel because these are used for uncertainty computation. It's inconsistent but I don't have time right now to validate what needs to be done to make that take masked arrays.

If you have any suggestions regarding these issues I would be very happy to include these and if not I can raise another issue for these.