### PR TITLE
Fix ImageFileCollection tests on Windows 

### DIFF
--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -141,7 +141,11 @@ def triage_setup(request):
     def teardown():
         for key in n_test.keys():
             n_test[key] = 0
-        rmtree(test_dir)
+        try: 
+            rmtree(test_dir)
+        except OSError:
+            # If we cannot clean up just keep going.
+            pass
         os.chdir(original_dir)
     request.addfinalizer(teardown)
 


### PR DESCRIPTION
Most of the tests were failing because the pytest fixture used by the tests tries to clean up after itself by deleting the temporary directories it makes. On Windows that fails apparently because of a race condition, so the deletion is simply skipped if there is raises an error.

One test required further modification (Windows does not understand chmod), and one still does not pass on Windows. Essentially I think overwriting files on Windows is error-prone.
