### PR TITLE
Add axis keyword to call to median_absolute_deviation

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -654,7 +654,6 @@ def wcs_project(ccd, target_wcs, target_shape=None, order='bilinear'):
     return nccd
 
 
-
 def sigma_func(arr, axis=None):
     """
     Robust method for calculating the deviation of an array. ``sigma_func``
@@ -667,17 +666,18 @@ def sigma_func(arr, axis=None):
 
     axis : None or int or tuple of ints, optional
         Axis or axes along which the function is performed.
-        If ``None`` (the default) it is performed over all the dimensions of the input array.
-        The axis argument can also be negative, in this case it counts from
-        the last to the first axis.
+        If ``None`` (the default) it is performed over all the dimensions of
+        the input array. The axis argument can also be negative, in this case
+        it counts from the last to the first axis.
 
 
     Returns
     -------
     float
-        standard deviation of array
+        uncertainty of array estimated from median absolute deviation.
     """
-    return 1.482602218505602 * stats.median_absolute_deviation(arr)
+
+    return 1.482602218505602 * stats.median_absolute_deviation(arr, axis=axis)
 
 
 def setbox(x, y, mbox, xmax, ymax):


### PR DESCRIPTION
When the option of specifying an `uncertainty_function` was added I think this was overlooked.

I'd be inclined to include it in 0.4 and so have milestoned it there. No changelog entry because the real change (adding the `uncertainty_function`) is included already in #323 
