### PR TITLE
Add slash so full path is correctly returned

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -257,7 +257,7 @@ class ImageFileCollection(object):
         filtered_files = self.summary_info['file'].compressed()
         self.summary_info['file'].mask = current_file_mask
         if include_path:
-            filtered_files = [self._location + f for f in filtered_files]
+            filtered_files = [self._location + '/' + f for f in filtered_files]
         return filtered_files
 
     def refresh(self):

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -257,7 +257,7 @@ class ImageFileCollection(object):
         filtered_files = self.summary_info['file'].compressed()
         self.summary_info['file'].mask = current_file_mask
         if include_path:
-            filtered_files = [self._location + '/' + f for f in filtered_files]
+            filtered_files = [os.path.join(self._location, f) for f in filtered_files]
         return filtered_files
 
     def refresh(self):

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -257,7 +257,7 @@ class ImageFileCollection(object):
         filtered_files = self.summary_info['file'].compressed()
         self.summary_info['file'].mask = current_file_mask
         if include_path:
-            filtered_files = [os.path.join(self._location, f) for f in filtered_files]
+            filtered_files = [path.join(self._location, f) for f in filtered_files]
         return filtered_files
 
     def refresh(self):


### PR DESCRIPTION
Without the slash, the filename is appended directly to the path string.

E.g. for the path returned by self._location: `C:\\Users\\EP_Guy\\images`, and an image file `M42_001.fits`, `filtered_files` returns `C:\\Users\\EP_Guy\\imagesM42_001.fits`