### PR TITLE
Make meta and header attributes separate objects

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -98,9 +98,9 @@ class CCDData(NDDataArray):
     This is useful, for example, when plotting a 2D image using
     matplotlib.
 
-        >>> from ccdproc import CCDData   
+        >>> from ccdproc import CCDData
         >>> from matplotlib import pyplot as plt   # doctest: +SKIP
-        >>> x = CCDData([[1,2,3], [4,5,6]], unit='adu') 
+        >>> x = CCDData([[1,2,3], [4,5,6]], unit='adu')
         >>> plt.imshow(x)   # doctest: +SKIP
 
     """
@@ -109,10 +109,17 @@ class CCDData(NDDataArray):
             kwd['meta'] = kwd.pop('header', None)
         if 'header' in kwd:
             raise ValueError("Can't have both header and meta")
-
+        self._header = None
+        self._dirty = None
         super(CCDData, self).__init__(*args, **kwd)
         if self.unit is None:
             raise ValueError("Unit for CCDData must be specified")
+        # CCDData's parent sets _meta directly; need to transform it
+        # in case we passed a fits.Header
+        if isinstance(self._meta, fits.Header):
+            self._header = self._meta
+            self._meta = {}
+            self._header2meta()
 
     @property
     def data(self):
@@ -155,14 +162,36 @@ class CCDData(NDDataArray):
 
     @property
     def header(self):
-        return self._meta
+        if self._dirty == 'meta':
+            self._meta2header()
+        if not isinstance(self._header, fits.Header):
+            self._meta2header()
+        self._dirty = 'header'
+        return self._header
 
     @header.setter
     def header(self, value):
-        self.meta = value
+        if value is None:
+            self._header = fits.Header()
+            self._meta = None
+        elif isinstance(value, fits.Header):
+            self._header = value
+            self._header2meta()
+        else:
+            if isinstance(value, dict):
+                self._meta = value
+                self._meta2header()
+            else:
+                raise TypeError("CCDData header attribute must be an "
+                                "`astropy.iofits.Header` or dict object")
 
     @property
     def meta(self):
+        if self._dirty == 'header':
+            self._header2meta()
+        if not isinstance(self._meta, dict):
+            self._header2meta()
+        self._dirty = 'meta'
         return self._meta
 
     @meta.setter
@@ -170,8 +199,12 @@ class CCDData(NDDataArray):
         if value is None:
             self._meta = {}
         else:
-            if hasattr(value, 'keys'):
+            if isinstance(value, dict):
                 self._meta = value
+                self._meta2header()
+            elif isinstance(value, fits.Header):
+                self._header = value
+                self._header2meta()
             else:
                 raise TypeError('CCDData meta attribute must be dict-like')
 
@@ -197,6 +230,51 @@ class CCDData(NDDataArray):
             self._uncertainty._parent_nddata = self
         else:
             self._uncertainty = value
+
+    def _meta2header(self):
+        if self._meta is None:
+            return
+        self._header = fits.Header()
+        for key, value in self._meta.items():
+            if key in ('comment', 'comments'):
+                if isinstance(value, list):
+                    for val in value:
+                        self._header.add_comment(val)
+                else:
+                    self._header.add_comment(value)
+            elif key == 'history':
+                if isinstance(value, list):
+                    for val in value:
+                        self._header.add_history(val)
+                else:
+                    self._header.add_history(value)
+            else:
+                from .core import _short_names
+
+                if key in _short_names:
+                    # This keyword was (hopefully) added by
+                    # autologging but the combination of it and its
+                    # value not FITS-compliant in two ways: the
+                    # keyword name may be more than 8 characters and
+                    # the value may be too long. FITS cannot handle
+                    # both of those problems at once, so this fixes
+                    # one of those problems...
+                    short_name = _short_names[key]
+                    self._header[key] = (short_name,
+                                         "Shortened name for ccdproc command")
+                    self._header[short_name] = value
+                else:
+                    self._header[key] = value
+
+    def _header2meta(self):
+        if self._header is None:
+            return
+        for key, value in self._header.items():
+            lkey = key.lower()
+            if key in ('HISTORY', 'COMMENT'):
+                self._meta.setdefault(lkey, []).append(value)
+            else:
+                self._meta[lkey] = value
 
     def to_hdu(self, hdu_mask='MASK', hdu_uncertainty='UNCERT',
                hdu_flags=None):
@@ -576,7 +654,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                 if hdus.fileinfo(i)['datSpan'] > 0:
                     hdu = i
                     hdr = hdr + hdus[hdu].header
-                    log.info("First HDU with data is exention {0}.".format(hdu))
+                    log.info("First HDU with data is extension {0}.".format(hdu))
                     break
 
         if 'bunit' in hdr:

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -50,7 +50,7 @@ def test_initialize_from_FITS(ccd_data, tmpdir):
     assert cd.size == 100
     assert np.issubdtype(cd.data.dtype, np.float)
     for k, v in hdu.header.items():
-        assert cd.meta[k] == v
+        assert cd.meta[k.lower()] == v
 
 
 def test_initialize_from_fits_with_unit_in_header(tmpdir):
@@ -91,7 +91,7 @@ def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     # ccd should pick up the unit adu from the fits header...did it?
     np.testing.assert_array_equal(ccd.data, fake_img)
     # check that the header is the combined header
-    assert hdu1.header + hdu2.header == ccd.header
+    assert set((hdu1.header + hdu2.header).items()) == set(ccd.header.items())
 
 
 def test_initialize_from_fits_with_extension(tmpdir):
@@ -171,7 +171,7 @@ def test_metafromheader(ccd_data):
     hdr['exptime'] = '3600'
 
     d1 = CCDData(np.ones((5, 5)), meta=hdr, unit=u.electron)
-    assert d1.meta['OBSERVER'] == 'Edwin Hubble'
+    assert d1.meta['observer'] == 'Edwin Hubble'
     assert d1.header['OBSERVER'] == 'Edwin Hubble'
 
 
@@ -188,7 +188,7 @@ def test_header2meta():
 
     d1 = CCDData(np.ones((5, 5)), unit=u.electron)
     d1.header = hdr
-    assert d1.meta['OBSERVER'] == 'Edwin Hubble'
+    assert d1.meta['observer'] == 'Edwin Hubble'
     assert d1.header['OBSERVER'] == 'Edwin Hubble'
 
 
@@ -459,7 +459,7 @@ def test_ccddata_header_does_not_corrupt_fits(ccd_data, tmpdir):
     # If all is well then reading the file we just wrote should result in an
     # identical header.
     ccd_reread = CCDData.read(rewritten, unit="adu")
-    assert ccd_reread.header == ccd_read.header
+    assert set(ccd_reread.header.items()) == set(ccd_read.header.items())
 
 
 def test_ccddata_with_fits_header_as_meta_works_with_autologging(ccd_data,

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -285,7 +285,7 @@ def test_subtract_bias(ccd_data):
     # Does the data we are left with have the correct average?
     np.testing.assert_almost_equal(no_bias.data.mean(), data_avg)
     # With logging turned off, metadata should not change
-    assert no_bias.header == ccd_data.header
+    assert set(no_bias.header.items()) == set(ccd_data.header.items())
     del no_bias.header['key']
     assert 'key' in ccd_data.header
     assert no_bias.header is not ccd_data.header
@@ -343,7 +343,7 @@ def test_subtract_dark(ccd_data, explicit_times, scale, exposure_keyword):
     np.testing.assert_array_equal(ccd_data.data - dark_scale * dark_level,
                                   dark_sub.data)
     # Headers should have the same content...do they?
-    assert dark_sub.header == ccd_data.header
+    assert set(dark_sub.header.items()) == set(ccd_data.header.items())
     # But the headers should not be the same object -- a copy was made
     assert dark_sub.header is not ccd_data.header
 
@@ -396,7 +396,7 @@ def test_flat_correct(ccd_data):
                                flat.data / flat.data.mean())
 
     # check that metadata is unchanged (since logging is turned off)
-    assert flat_data.header == ccd_data.header
+    assert set(flat_data.header.items()) == set(ccd_data.header.items())
 
 
 # test for flat correction with min_value

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -63,7 +63,8 @@ def test_log_bad_type_fails(ccd_data):
 def test_log_set_to_None_does_not_change_header(ccd_data):
     new = create_deviation(ccd_data, readnoise=3 * ccd_data.unit,
                           add_keyword=None)
-    assert new.meta.keys() == ccd_data.header.keys()
+    assert (sorted(new.meta.keys()) ==
+            sorted([key.lower() for key in ccd_data.header.keys()]))
 
 
 def test_implicit_logging(ccd_data):
@@ -74,8 +75,9 @@ def test_implicit_logging(ccd_data):
     bias = CCDData(np.zeros_like(ccd_data.data), unit="adu")
     result = subtract_bias(ccd_data, bias)
     assert "subtract_bias" in result.header
-    assert result.header['subtract_bias'] == "ccd=<CCDData>, master=<CCDData>"
+    assert result.header['subtract_bias'] == "subbias"
+    assert result.header['subbias'] == "ccd=<CCDData>, master=<CCDData>"
 
     result = create_deviation(ccd_data, readnoise=3 * ccd_data.unit)
     assert ("readnoise="+str(3 * ccd_data.unit) in
-            result.header['create_deviation'])
+            result.header['creatvar'])

--- a/docs/ccdproc/ccddata.rst
+++ b/docs/ccdproc/ccddata.rst
@@ -189,7 +189,7 @@ is between two `~ccdproc.ccddata.CCDData` objects.
     0.2
     >>> result.unit
     Unit("adu electron")
-    >>> result.header
+    >>> result.meta
     OrderedDict()
 
 .. note::


### PR DESCRIPTION
This PR is to provide an example for the discussion started in #336 

This PR ensures the `meta` and `header` attributes of a `CCDData` object are always a `dict` and a `astropy.io.fits.Header`, respectively. Under the hood, they are kept in sync through their properties; one is updated if the other has previously been accessed. (Updating `_meta` or `_header` directly may still keep them in sync, but this is definitely not guaranteed.)
- It's a rather dirty hack. Not sure if this is really the way to go, seen the amount of extra code needed.
  There's also some extra code necessary in `CCDData.__init__.py`; see the relevant comment.
- I had to adjust some unit tests.  `Header`s keep their key order, and can be compared with a simple `==` in assertions, but `dict`s don't keep their key order and can mess up the `header` attribute key order. 
  Alternatively, 
  - an `OrderedDict` could be used (less generic)
  - the various `result.meta` assignments in `subtract_bias` and the like could be changed to update `result.header` instead.
- On the order of keywords and `OrderedDict`.
  I see there is even the possibility to use a `CaseInsensitiveOrderedDict` (from `utils.collections`, which is otherwise nowhere used). If a user needs one of these classes (to maintain key order and/or be case-insensitive in `meta`), it should be possible to use this as value to the `meta` attribute or parameter: the property checks for `isinstance(value, dict)`.
  I haven't tested this, but it could be used as a user option/preference.
- I've borrowed the short_names alternative from `_insert_in_metadata_fits_safe`.
- Comments and history are stored as lists in `meta`.
- There are probably a few lines/sections that can disappear, such as `if isinstance(self.header, fits.Header)` in `to_hdu`, and the `_insert_in_metadata_fits_safe` function
- doc strings and extra unit tests are still missing
