### PR TITLE
Fixes #343 by defaulting to OrderedDict in CCDData.meta.setter

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import copy
 import numbers
+from collections import OrderedDict
 
 import numpy as np
 
@@ -168,7 +169,7 @@ class CCDData(NDDataArray):
     @meta.setter
     def meta(self, value):
         if value is None:
-            self._meta = {}
+            self._meta = OrderedDict()
         else:
             if hasattr(value, 'keys'):
                 self._meta = value


### PR DESCRIPTION
See #343 

`CCDData.meta.setter` will initialize an empty `collections.OrderedDict` in case the new value is `None`. 

This is because `NDData` implements `meta`-checks as part of the setter itself (astropy >= 1.2) instead of during `__init__` (astropy < 1.2).