### PR TITLE
Astropy release changes

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -195,7 +195,7 @@ class CCDData(NDDataArray):
     def uncertainty(self, value):
         if value is not None:
             if isinstance(value, NDUncertainty):
-                if value._parent_nddata is not None:
+                if getattr(value, '_parent_nddata', None) is not None:
                     value = value.__class__(value, copy=False)
                 self._uncertainty = value
             elif isinstance(value, np.ndarray):

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -352,7 +352,7 @@ class CCDData(NDDataArray):
         try:
             return self.__class__(self, copy=True)
         except TypeError:
-            new = copy.deepcopy(self)
+            new = self.__class__(copy.deepcopy(self))
         return new
 
     def _ccddata_arithmetic(self, other, operation, scale_uncertainty=False):

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -195,6 +195,8 @@ class CCDData(NDDataArray):
     def uncertainty(self, value):
         if value is not None:
             if isinstance(value, NDUncertainty):
+                if value._parent_nddata is not None:
+                    value = value.__class__(value, copy=False)
                 self._uncertainty = value
             elif isinstance(value, np.ndarray):
                 if value.shape != self.shape:
@@ -206,7 +208,7 @@ class CCDData(NDDataArray):
             else:
                 raise TypeError("uncertainty must be an instance of a "
                                 "NDUncertainty object or a numpy array.")
-            self._uncertainty._parent_nddata = self
+            self._uncertainty.parent_nddata = self
         else:
             self._uncertainty = value
 
@@ -316,7 +318,11 @@ class CCDData(NDDataArray):
         """
         Return a copy of the CCDData object.
         """
-        return copy.deepcopy(self)
+        try:
+            return self.__class__(self, copy=True)
+        except TypeError:
+            new = copy.deepcopy(self)
+        return new
 
     def _ccddata_arithmetic(self, other, operation, scale_uncertainty=False):
         """


### PR DESCRIPTION
Astropy 1.2 will have numerous changes for NDData and some tests are failing here because of it.

This PR fixes the failure and also fixes all failures related to the fix. Unfortunatly these failures are somewhat entangled and it's not possible to seperate them easily.

# Why this ParentNDDataDescriptor

The cyclic reference between `CCDData` and `uncertainty` results in a memory leak where neither of both can be deallocated. So the parent_nddata must save the uncertainty as weakref. A descriptor is just a `property` in this case: `__get__` is the `getter` and `__set__` the `setter`.

This is an ugly monkey-patch... and it only works for those `StdDevUncertainties` that are created after `ccdproc` is imported... But I couldn't think of a way to fix the memory leak without requiring astropy 1.2. If your next release would require astropy 1.2 the descriptor would be unnecessary. Given that the memory leak is very ugly requiring astropy 1.2 would make sense.

See also:

- https://github.com/astropy/astropy/pull/4862
- https://github.com/astropy/astropy/issues/4825#issuecomment-216257115

# Why the changes in `uncertainty.setter`

The first one with the ``if getattr(value, '_parent_nddata', None) is not None:`` is required so that using an uncertainty from one CCDData as uncertainty for another doesn't get them in an inconsistent state:

```
# current behaviour:
ndd1 = CCDData(1, unit='adu', uncertainty=np.array(1))
ndd2 = CCDData(2, unit='adu', uncertainty=ndd1.uncertainty)
ndd1.uncertainty.parent_nddata.data # = array(2) 
# so the uncertainty of ndd1 now thinks it's parent is ndd2
```
see also:

-  https://github.com/astropy/astropy/pull/4799#discussion_r62743167

The second change from setting `_parent_nddata` to `parent_nddata` is so that the weakref descriptor is used.

# Why the changes in copy?

I had to investigate why I got so many test failures even though I fixed the memory leak and the stolen-parent Bug and I found out that `copy` is to be blamed.

`deepcopy(self)` will copy the CCDData (good), uncertainty (good) but will also copy ``uncertainty._parent_nddata`` (bad) this means that the copy has an uncertainty linking to the original and not to the new one. This change is using the `__init__` with copy of astropy 1.2 or if `copy` is not allowed (before astropy 1.2) it will copy `self` but pass it through the `__init__` again so the uncertainty.setter is used to link it correctly.

# Feedback required !

This PR is just about fixing the test failures and Bugs that I already fixed upstream. It's a bit messy, so I'd appreciate any help making it saner. :smile: 