### PR TITLE
cast uncertainty to plain numpy array after combining.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,11 +22,13 @@ Other Changes and Additions
 Bug Fixes
 ^^^^^^^^^
 
+- ``Combiner`` creates plain array uncertainties when using``average_combine``
+  or ``median_combine``. [#351]
 
 1.0.1 (2016-03-15)
 ------------------
 
-The 1.0.1 release was a release to fix some minor packaging issues.  
+The 1.0.1 release was a release to fix some minor packaging issues.
 
 
 1.0.0 (2016-03-15)

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -307,6 +307,12 @@ class Combiner(object):
         # median_absolute_deviation ignores the mask... so it
         # would yield inconsistent results.
         uncertainty /= math.sqrt(len(self.data_arr))
+        # Convert uncertainty to plain numpy array (#351)
+        # There is no need to care about potential masks because the
+        # uncertainty was calculated based on the data so potential masked
+        # elements are also masked in the data. No need to keep two identical
+        # masks.
+        uncertainty = np.asarray(uncertainty)
 
         # create the combined image with a dtype matching the combiner
         combined_image = CCDData(np.asarray(data.data, dtype=self.dtype),
@@ -370,6 +376,8 @@ class Combiner(object):
         uncertainty = uncertainty_func(self.data_arr, axis=0)
         # Divide uncertainty by the number of pixel (#309)
         uncertainty /= np.sqrt(len(self.data_arr) - masked_values)
+        # Convert uncertainty to plain numpy array (#351)
+        uncertainty = np.asarray(uncertainty)
 
         # create the combined image with a dtype that matches the combiner
         combined_image = CCDData(np.asarray(data.data, dtype=self.dtype),

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -383,3 +383,13 @@ def test_combiner_uncertainty_average_mask():
     ref_uncertainty[5, 5] = np.std([2, 3]) / np.sqrt(2)
     np.testing.assert_array_almost_equal(ccd.uncertainty.array,
                                          ref_uncertainty)
+
+
+@pytest.mark.parametrize('comb_func', ['average_combine', 'median_combine'])
+def test_writeable_after_combine(ccd_data, tmpdir, comb_func):
+    tmp_file = tmpdir.join('tmp.fits')
+    from ..combiner import Combiner
+    combined = Combiner([ccd_data for _ in range(3)])
+    ccd2 = getattr(combined, comb_func)()
+    # This should not fail because the resulting uncertainty has a mask
+    ccd2.write(tmp_file.strpath)


### PR DESCRIPTION
Fixes #351, https://github.com/mwcraig/reducer/issues/117

I think just casting the uncertainty to a plain numpy array after the combination is enough to fix the problem. The uncertainty is created by applying a ``numpy.ma.ufunc`` on the **data** so any masked pixels are already masked in the data so there should be no need to keep track of an identical mask on the uncertainty.

FYI: 1 minute to fix the Bug, 20 to figure out how I could make the tests pass ... ugly fixtures and tmpfiles.