### PR TITLE
Use axis when calculating median absolute deviation

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -898,7 +898,7 @@ def sigma_func(arr, axis=None):
     uncertainty : float
         uncertainty of array estimated from median absolute deviation.
     """
-    return stats.median_absolute_deviation(arr) * 1.482602218505602
+    return stats.median_absolute_deviation(arr, axis=axis) * 1.482602218505602
 
 
 def setbox(x, y, mbox, xmax, ymax):


### PR DESCRIPTION
The axis should be passed to stats.median_absolute_deviation in order to behave as explained in the docstring. 