### PR TITLE
Add iraf_minmax_clipping method to give IRAF-like minmax clipping.

### DIFF
--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -214,9 +214,9 @@ class Combiner(object):
             combination.
             Default is ``None``.
         """
-        if nlow == None:
+        if nlow is None:
             nlow = 0
-        if nhigh == None:
+        if nhigh is None:
             nhigh = 0
         nimages = self.data_arr.mask.shape[0]
         nx = self.data_arr.mask.shape[1]

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -214,19 +214,21 @@ class Combiner(object):
             combination.
             Default is ``None``.
         """
-        if nlow == None: nlow=0
+        if nlow == None: nlow = 0
         if nhigh == None: nhigh = 0
         nimages = self.data_arr.mask.shape[0]
-#         if nlow+nhigh >= nimages:
-#             raise ValueError("Can not reject more pixels"\
-#                              " than there are images to combine")
+        nx = self.data_arr.mask.shape[1]
+        ny = self.data_arr.mask.shape[2]
 
-        newmask = np.zeros(self.data_arr.mask.shape, dtype=bool)
-        ind = np.argsort(self.data_arr.data, axis=0)
+        self.argsorted = np.argsort(self.data_arr.data, axis=0)
 
-        newmask[(ind < nlow)] = True
-        newmask[(ind >= nimages-nhigh)] = True
-        self.data_arr.mask[newmask] = True
+        for x in range(nx):
+            for y in range(ny):
+                for i in range(nimages-nhigh,nimages):
+                    self.data_arr.mask[self.argsorted[i,x,y],x,y] = True
+                for j in range(0,nlow):
+                    self.data_arr.mask[self.argsorted[j,x,y],x,y] = True
+
 
     # set up min/max clipping algorithms
     def minmax_clipping(self, min_clip=None, max_clip=None):

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -200,6 +200,14 @@ class Combiner(object):
         self.data_arr.sort(axis=0)
         nimages = self.data_arr.mask.shape[0]
         newmask = np.ndarray(self.data_arr.mask.shape, dtype=bool)
+
+        if nlow > nimages:
+            raise ValueError(
+                "Can not reject more pixels than there are images to combine")
+        if nhigh > nimages:
+            raise ValueError(
+                "Can not reject more pixels than there are images to combine")
+
         if nlow != None:
             for i in np.arange(0,nlow,1):
                 newmask[i,:,:] = True

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -178,7 +178,7 @@ class Combiner(object):
             self._scaling = self.scaling[:, np.newaxis, np.newaxis]
 
     # set up IRAF-like minmax clipping
-    def iraf_minmax_clipping(self, nlow=0, nhigh=0):
+    def clip_extrema(self, nlow=0, nhigh=0):
         """Mask pixels using an IRAF-like minmax clipping algorithm.  The
         algorithm will mask the lowest nlow values and the highest nhigh values
         before combining the values to make up a single pixel in the resulting
@@ -445,7 +445,7 @@ class Combiner(object):
 
 def combine(img_list, output_file=None, method='average', weights=None,
             scale=None, mem_limit=16e9,
-            iraf_minmax_clip=False, nlow=1, nhigh=1,
+            clip_extrema=False, nlow=1, nhigh=1,
             minmax_clip=False, minmax_clip_min=None, minmax_clip_max=None,
             sigma_clip=False,
             sigma_clip_low_thresh=3, sigma_clip_high_thresh=3,
@@ -490,7 +490,7 @@ def combine(img_list, output_file=None, method='average', weights=None,
         Maximum memory which should be used while combining (in bytes).
         Default is ``16e9``.
 
-    iraf_minmax_clip : bool, optional
+    clip_extrema : bool, optional
         Set to True if you want to mask pixels using an IRAF-like minmax
         clipping algorithm.  The algorithm will mask the lowest nlow values and
         the highest nhigh values before combining the vlues to make up a single
@@ -498,8 +498,8 @@ def combine(img_list, output_file=None, method='average', weights=None,
         combination of Nimages-low-nhigh pixel values instead of the combination
         of Nimages.
 
-        Parameters below are valid only when iraf_minmax_clip is set to True,
-        see :meth:`Combiner.iraf_minmax_clipping` for the parameter description:
+        Parameters below are valid only when clip_extrema is set to True,
+        see :meth:`Combiner.clip_extrema` for the parameter description:
 
         - ``nlow`` : int or None, optional
         - ``nhigh`` : int or None, optional
@@ -614,8 +614,8 @@ def combine(img_list, output_file=None, method='average', weights=None,
         else:
             to_set_in_combiner['scaling'] = scale
 
-    if iraf_minmax_clip:
-        to_call_in_combiner['iraf_minmax_clipping'] = {'nlow': nlow,
+    if clip_extrema:
+        to_call_in_combiner['clip_extrema'] = {'nlow': nlow,
                                                        'nhigh': nhigh}
 
     if minmax_clip:

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -223,15 +223,16 @@ class Combiner(object):
         ny = self.data_arr.mask.shape[2]
 
         argsorted = np.argsort(self.data_arr.data, axis=0)
+        mg = np.mgrid[0:nx,0:ny]
         for i in range(nlow):
             where = (argsorted[i,:,:].ravel(),\
-                     np.mgrid[0:nx,0:ny][0].ravel(),\
-                     np.mgrid[0:nx,0:ny][1].ravel())
+                     mg[0].ravel(),\
+                     mg[1].ravel())
             self.data_arr.mask[where] = True
         for j in range(nimages-nhigh,nimages):
             where = (argsorted[j,:,:].ravel(),\
-                     np.mgrid[0:nx,0:ny][0].ravel(),\
-                     np.mgrid[0:nx,0:ny][1].ravel())
+                     mg[0].ravel(),\
+                     mg[1].ravel())
             self.data_arr.mask[where] = True
 
 

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -201,17 +201,16 @@ class Combiner(object):
         nimages = self.data_arr.mask.shape[0]
         newmask = np.ndarray(self.data_arr.mask.shape, dtype=bool)
 
-        if nlow > nimages:
-            raise ValueError(
-                "Can not reject more pixels than there are images to combine")
-        if nhigh > nimages:
-            raise ValueError(
-                "Can not reject more pixels than there are images to combine")
-
         if nlow != None:
+            if nlow > nimages:
+                raise ValueError("Can not reject more pixels"\
+                                 " than there are images to combine")
             for i in np.arange(0,nlow,1):
                 newmask[i,:,:] = True
         if nhigh != None:
+            if nhigh > nimages:
+                raise ValueError("Can not reject more pixels"\
+                                 " than there are images to combine")
             for i in np.arange(nimages-nhigh,nimages,1):
                 newmask[i,:,:] = True
         self.data_arr.mask[newmask] = True

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -218,20 +218,13 @@ class Combiner(object):
             nlow = 0
         if nhigh is None:
             nhigh = 0
-        nimages = self.data_arr.mask.shape[0]
-        nx = self.data_arr.mask.shape[1]
-        ny = self.data_arr.mask.shape[2]
+        nimages, nx, ny = self.data_arr.mask.shape
 
         argsorted = np.argsort(self.data_arr.data, axis=0)
         mg = np.mgrid[0:nx,0:ny]
-        for i in range(nlow):
-            where = (argsorted[i,:,:].ravel(),\
-                     mg[0].ravel(),\
-                     mg[1].ravel())
-            self.data_arr.mask[where] = True
-        for j in range(nimages-nhigh,nimages):
-            where = (argsorted[j,:,:].ravel(),\
-                     mg[0].ravel(),\
+        for i in range(-1*nhigh, nlow):
+            where = (argsorted[i,:,:].ravel(),
+                     mg[0].ravel(),
                      mg[1].ravel())
             self.data_arr.mask[where] = True
 

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -220,14 +220,14 @@ class Combiner(object):
         nx = self.data_arr.mask.shape[1]
         ny = self.data_arr.mask.shape[2]
 
-        self.argsorted = np.argsort(self.data_arr.data, axis=0)
+        argsorted = np.argsort(self.data_arr.data, axis=0)
 
         for x in range(nx):
             for y in range(ny):
                 for i in range(nimages-nhigh,nimages):
-                    self.data_arr.mask[self.argsorted[i,x,y],x,y] = True
+                    self.data_arr.mask[argsorted[i,x,y],x,y] = True
                 for j in range(0,nlow):
-                    self.data_arr.mask[self.argsorted[j,x,y],x,y] = True
+                    self.data_arr.mask[argsorted[j,x,y],x,y] = True
 
 
     # set up min/max clipping algorithms

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -223,13 +223,17 @@ class Combiner(object):
         ny = self.data_arr.mask.shape[2]
 
         argsorted = np.argsort(self.data_arr.data, axis=0)
-
-        for x in range(nx):
-            for y in range(ny):
-                for i in range(nimages-nhigh,nimages):
-                    self.data_arr.mask[argsorted[i,x,y],x,y] = True
-                for j in range(0,nlow):
-                    self.data_arr.mask[argsorted[j,x,y],x,y] = True
+        where = np.where((argsorted < nlow) | (argsorted >= nimages-nhigh))
+        for i in range(nlow):
+            where = (argsorted[i,:,:].ravel(),\
+                     np.mgrid[0:nx,0:ny][0].ravel(),\
+                     np.mgrid[0:nx,0:ny][1].ravel())
+            self.data_arr.mask[where] = True
+        for j in range(nimages-nhigh,nimages):
+            where = (argsorted[j,:,:].ravel(),\
+                     np.mgrid[0:nx,0:ny][0].ravel(),\
+                     np.mgrid[0:nx,0:ny][1].ravel())
+            self.data_arr.mask[where] = True
 
 
     # set up min/max clipping algorithms

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -178,12 +178,12 @@ class Combiner(object):
             self._scaling = self.scaling[:, np.newaxis, np.newaxis]
 
     # set up IRAF-like minmax clipping
-    def iraf_minmax_clipping(self, nlow=None, nhigh=None):
+    def iraf_minmax_clipping(self, nlow=0, nhigh=0):
         """Mask pixels using an IRAF-like minmax clipping algorithm.  The
         algorithm will mask the lowest nlow values and the highest nhigh values
         before combining the values to make up a single pixel in the resulting
         image.  For example, the image will be a combination of
-        Nimages-low-nhigh pixel values instead of the combination of Nimages.
+        Nimages-nlow-nhigh pixel values instead of the combination of Nimages.
 
         Note that this differs slightly from the nominal IRAF behavior when
         other masks are in use.  For example, if the nhigh>=1 and any
@@ -207,12 +207,12 @@ class Combiner(object):
         nlow : int or None, optional
             If not None, the number of low values to reject from the
             combination.
-            Default is ``None``.
+            Default is 0.
 
         nhigh : int or None, optional
             If not None, the number of high values to reject from the
             combination.
-            Default is ``None``.
+            Default is 0.
         """
         if nlow is None:
             nlow = 0

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -223,7 +223,6 @@ class Combiner(object):
         ny = self.data_arr.mask.shape[2]
 
         argsorted = np.argsort(self.data_arr.data, axis=0)
-        where = np.where((argsorted < nlow) | (argsorted >= nimages-nhigh))
         for i in range(nlow):
             where = (argsorted[i,:,:].ravel(),\
                      np.mgrid[0:nx,0:ny][0].ravel(),\

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -185,17 +185,34 @@ class Combiner(object):
         image.  For example, the image will be a combination of
         Nimages-low-nhigh pixel values instead of the combination of Nimages.
 
-         Parameters
-         -----------
-         nlow : int or None, optional
-             If not None, the number of low values to reject from the
-             combination.
-             Default is ``None``.
+        Note that this differs slightly from the nominal IRAF behavior when
+        other masks are in use.  For example, if the nhigh>=1 and the highest
+        pixel is already masked for some other reason, then this algorithm will
+        count the masking of that pixel toward the count of nhigh masked pixels.
+        IRAF behaves slightly diifferently in this case (see IRAF help for that
+        behavior): http://stsdas.stsci.edu/cgi-bin/gethelp.cgi?imcombine
+        
+        Here is a copy of the relevant IRAF help text:
+        
+        nlow = 1, nhigh = (minmax)
+            The number of low and high pixels to be rejected by the "minmax"
+            algorithm. These numbers are converted to fractions of the total
+            number of input images so that if no rejections have taken place
+            the specified number of pixels are rejected while if pixels have
+            been rejected by masking, thresholding, or nonoverlap, then the
+            fraction of the remaining pixels, truncated to an integer, is used.
+        
+        Parameters
+        -----------
+        nlow : int or None, optional
+            If not None, the number of low values to reject from the
+            combination.
+            Default is ``None``.
 
-         nhigh : int or None, optional
-             If not None, the number of high values to reject from the
-             combination.
-             Default is ``None``.
+        nhigh : int or None, optional
+            If not None, the number of high values to reject from the
+            combination.
+            Default is ``None``.
         """
         self.data_arr.sort(axis=0)
         nimages = self.data_arr.mask.shape[0]

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -214,8 +214,10 @@ class Combiner(object):
             combination.
             Default is ``None``.
         """
-        if nlow == None: nlow = 0
-        if nhigh == None: nhigh = 0
+        if nlow == None:
+            nlow = 0
+        if nhigh == None:
+            nhigh = 0
         nimages = self.data_arr.mask.shape[0]
         nx = self.data_arr.mask.shape[1]
         ny = self.data_arr.mask.shape[2]

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -408,8 +408,7 @@ def test_iraf_minmax_masking():
     c = Combiner(ccdlist)
     c.iraf_minmax_clipping(nlow=1, nhigh=1)
     result = c.average_combine()
-    expected = [[ 30.,  22.5, 30. , 30., 30.],\
-                [ 30. , 30. , 47.5, 30., 30.],\
+    expected = [[ 30.,  22.5, 30. , 30., 30.],
+                [ 30. , 30. , 47.5, 30., 30.],
                 [ 47.5, 30. , 30. , 30., 30.]]
-    expected = np.array(expected)
-    assert (result == expected).all()
+    np.testing.assert_array_equal(result, expected)

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -393,3 +393,22 @@ def test_writeable_after_combine(ccd_data, tmpdir, comb_func):
     ccd2 = getattr(combined, comb_func)()
     # This should not fail because the resulting uncertainty has a mask
     ccd2.write(tmp_file.strpath)
+
+def test_iraf_minmax_masking():
+    ccdlist = [CCDData(np.ones((3, 3))*90., unit="adu"),\
+               CCDData(np.ones((3, 3))*20., unit="adu"),\
+               CCDData(np.ones((3, 3))*10., unit="adu"),\
+               CCDData(np.ones((3, 3))*40., unit="adu"),\
+               CCDData(np.ones((3, 3))*25., unit="adu"),\
+               CCDData(np.ones((3, 3))*35., unit="adu"),\
+              ]
+    ccdlist[0].data[0,0] = 3.1
+    ccdlist[1].data[1,1] = 100.1
+    c = Combiner(ccdlist)
+    c.iraf_minmax_clipping(nlow=1, nhigh=1)
+    result = c.average_combine()
+    expected = [[ 22.5, 30. , 30. ],\
+                [ 30. , 47.5, 30. ],\
+                [ 30. , 30. , 30. ]]
+    expected = np.array(expected)
+    assert (result == expected).all()

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -394,7 +394,7 @@ def test_writeable_after_combine(ccd_data, tmpdir, comb_func):
     # This should not fail because the resulting uncertainty has a mask
     ccd2.write(tmp_file.strpath)
 
-def test_iraf_minmax_masking():
+def test_clip_extrema():
     ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
                CCDData(np.ones((3, 5))*20., unit="adu"),\
                CCDData(np.ones((3, 5))*10., unit="adu"),\
@@ -406,14 +406,14 @@ def test_iraf_minmax_masking():
     ccdlist[1].data[1,2] = 100.1
     ccdlist[1].data[2,0] = 100.1
     c = Combiner(ccdlist)
-    c.iraf_minmax_clipping(nlow=1, nhigh=1)
+    c.clip_extrema(nlow=1, nhigh=1)
     result = c.average_combine()
     expected = [[ 30.,  22.5, 30. , 30., 30.],
                 [ 30. , 30. , 47.5, 30., 30.],
                 [ 47.5, 30. , 30. , 30., 30.]]
     np.testing.assert_array_equal(result, expected)
 
-def test_iraf_minmax_masking_via_combine():
+def test_clip_extrema_via_combine():
     ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
                CCDData(np.ones((3, 5))*20., unit="adu"),\
                CCDData(np.ones((3, 5))*10., unit="adu"),\
@@ -424,14 +424,14 @@ def test_iraf_minmax_masking_via_combine():
     ccdlist[0].data[0,1] = 3.1
     ccdlist[1].data[1,2] = 100.1
     ccdlist[1].data[2,0] = 100.1
-    result = combine(ccdlist, iraf_minmax_clip=True, nlow=1, nhigh=1,)
+    result = combine(ccdlist, clip_extrema=True, nlow=1, nhigh=1,)
     expected = [[ 30.,  22.5, 30. , 30., 30.],
                 [ 30. , 30. , 47.5, 30., 30.],
                 [ 47.5, 30. , 30. , 30., 30.]]
     np.testing.assert_array_equal(result, expected)
 
 
-def test_iraf_minmax_with_other_rejection():
+def test_clip_extrema_with_other_rejection():
     ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
                CCDData(np.ones((3, 5))*20., unit="adu"),\
                CCDData(np.ones((3, 5))*10., unit="adu"),\
@@ -448,7 +448,7 @@ def test_iraf_minmax_with_other_rejection():
     ## Reject ccdlist[1].data[1,2] by other means
     c.data_arr.mask[3,0,0] = True
 
-    c.iraf_minmax_clipping(nlow=1, nhigh=1)
+    c.clip_extrema(nlow=1, nhigh=1)
     result = c.average_combine()
     expected = [[ 80./3.,  22.5, 30. , 30., 30.],
                 [ 30. , 30. , 47.5, 30., 30.],

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -395,22 +395,21 @@ def test_writeable_after_combine(ccd_data, tmpdir, comb_func):
     ccd2.write(tmp_file.strpath)
 
 def test_iraf_minmax_masking():
-    ccdlist = [CCDData(np.ones((3, 3))*90., unit="adu"),\
-               CCDData(np.ones((3, 3))*20., unit="adu"),\
-               CCDData(np.ones((3, 3))*10., unit="adu"),\
-               CCDData(np.ones((3, 3))*40., unit="adu"),\
-               CCDData(np.ones((3, 3))*25., unit="adu"),\
-               CCDData(np.ones((3, 3))*35., unit="adu"),\
+    ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
+               CCDData(np.ones((3, 5))*20., unit="adu"),\
+               CCDData(np.ones((3, 5))*10., unit="adu"),\
+               CCDData(np.ones((3, 5))*40., unit="adu"),\
+               CCDData(np.ones((3, 5))*25., unit="adu"),\
+               CCDData(np.ones((3, 5))*35., unit="adu"),\
               ]
     ccdlist[0].data[0,1] = 3.1
     ccdlist[1].data[1,2] = 100.1
+    ccdlist[1].data[2,0] = 100.1
     c = Combiner(ccdlist)
     c.iraf_minmax_clipping(nlow=1, nhigh=1)
     result = c.average_combine()
-    expected = [[ 30.,  22.5, 30. ],\
-                [ 30. , 30. , 47.5],\
-                [ 30. , 30. , 30. ]]
+    expected = [[ 30.,  22.5, 30. , 30., 30.],\
+                [ 30. , 30. , 47.5, 30., 30.],\
+                [ 47.5, 30. , 30. , 30., 30.]]
     expected = np.array(expected)
-    print(expected)
-    print(result)
     assert (result == expected).all()

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -402,13 +402,15 @@ def test_iraf_minmax_masking():
                CCDData(np.ones((3, 3))*25., unit="adu"),\
                CCDData(np.ones((3, 3))*35., unit="adu"),\
               ]
-    ccdlist[0].data[0,0] = 3.1
-    ccdlist[1].data[1,1] = 100.1
+    ccdlist[0].data[0,1] = 3.1
+    ccdlist[1].data[1,2] = 100.1
     c = Combiner(ccdlist)
     c.iraf_minmax_clipping(nlow=1, nhigh=1)
     result = c.average_combine()
-    expected = [[ 22.5, 30. , 30. ],\
-                [ 30. , 47.5, 30. ],\
+    expected = [[ 30.,  22.5, 30. ],\
+                [ 30. , 30. , 47.5],\
                 [ 30. , 30. , 30. ]]
     expected = np.array(expected)
+    print(expected)
+    print(result)
     assert (result == expected).all()

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -413,6 +413,24 @@ def test_iraf_minmax_masking():
                 [ 47.5, 30. , 30. , 30., 30.]]
     np.testing.assert_array_equal(result, expected)
 
+def test_iraf_minmax_masking_via_combine():
+    ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
+               CCDData(np.ones((3, 5))*20., unit="adu"),\
+               CCDData(np.ones((3, 5))*10., unit="adu"),\
+               CCDData(np.ones((3, 5))*40., unit="adu"),\
+               CCDData(np.ones((3, 5))*25., unit="adu"),\
+               CCDData(np.ones((3, 5))*35., unit="adu"),\
+              ]
+    ccdlist[0].data[0,1] = 3.1
+    ccdlist[1].data[1,2] = 100.1
+    ccdlist[1].data[2,0] = 100.1
+    result = combine(ccdlist, iraf_minmax_clip=True, nlow=1, nhigh=1,)
+    expected = [[ 30.,  22.5, 30. , 30., 30.],
+                [ 30. , 30. , 47.5, 30., 30.],
+                [ 47.5, 30. , 30. , 30., 30.]]
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_iraf_minmax_with_other_rejection():
     ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
                CCDData(np.ones((3, 5))*20., unit="adu"),\

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -412,3 +412,27 @@ def test_iraf_minmax_masking():
                 [ 30. , 30. , 47.5, 30., 30.],
                 [ 47.5, 30. , 30. , 30., 30.]]
     np.testing.assert_array_equal(result, expected)
+
+def test_iraf_minmax_with_other_rejection():
+    ccdlist = [CCDData(np.ones((3, 5))*90., unit="adu"),\
+               CCDData(np.ones((3, 5))*20., unit="adu"),\
+               CCDData(np.ones((3, 5))*10., unit="adu"),\
+               CCDData(np.ones((3, 5))*40., unit="adu"),\
+               CCDData(np.ones((3, 5))*25., unit="adu"),\
+               CCDData(np.ones((3, 5))*35., unit="adu"),\
+              ]
+    ccdlist[0].data[0,1] = 3.1
+    ccdlist[1].data[1,2] = 100.1
+    ccdlist[1].data[2,0] = 100.1
+    c = Combiner(ccdlist)
+    ## Reject ccdlist[1].data[1,2] by other means
+    c.data_arr.mask[1,1,2] = True
+    ## Reject ccdlist[1].data[1,2] by other means
+    c.data_arr.mask[3,0,0] = True
+
+    c.iraf_minmax_clipping(nlow=1, nhigh=1)
+    result = c.average_combine()
+    expected = [[ 80./3.,  22.5, 30. , 30., 30.],
+                [ 30. , 30. , 47.5, 30., 30.],
+                [ 47.5, 30. , 30. , 30., 30.]]
+    np.testing.assert_array_equal(result, expected)

--- a/docs/ccdproc/image_combination.rst
+++ b/docs/ccdproc/image_combination.rst
@@ -78,9 +78,9 @@ Extrema clipping
 ++++++++++++++++
 
 For each pixel position in the input arrays, the algorithm will mask the
-highest `nhigh` and lowest `nlow` pixel values.  The resulting image will be a
-combination of `Nimages-nlow-nhigh` pixel values instead of the combination of
-`Nimages` worth of pixel values.
+highest ``nhigh`` and lowest ``nlow`` pixel values.  The resulting image will be
+a combination of ``Nimages-nlow-nhigh`` pixel values instead of the combination
+of ``Nimages`` worth of pixel values.
 
 You can mask the lowest pixel value and the highest two pixel values with:
 

--- a/docs/ccdproc/image_combination.rst
+++ b/docs/ccdproc/image_combination.rst
@@ -29,7 +29,7 @@ individual images via several clipping techniques and combination of images.
 Image masks/clipping
 --------------------
 
-There are currently two methods of clipping. Neither affects the data
+There are currently three methods of clipping. None affect the data
 directly; instead each constructs a mask that is applied when images are
 combined.
 
@@ -73,6 +73,19 @@ deviations below the median with
     the number of pixels.
 
     A
+
+Extrema clipping
+++++++++++++++++
+
+For each pixel position in the input arrays, the algorithm will mask the
+highest `nhigh` and lowest `nlow` pixel values.  The resulting image will be a
+combination of `Nimages-nlow-nhigh` pixel values instead of the combination of
+`Nimages` worth of pixel values.
+
+You can mask the lowest pixel value and the highest two pixel values with:
+
+    >>> combiner.clip_extrema(nlow=1, nhigh=2)
+
 
 Iterative clipping
 ++++++++++++++++++


### PR DESCRIPTION
This is a quick attempt at adding the rejection method described in issue #356 

This rejection method needs a better name.  There could be confusion due to people coming from the IRAF "minmax" terminology.  I've put in a cumbersome name of iraf_minmax_clipping for now.

Note that this method changes the combiner object's self.data_arr in place by doing a numpy sort.  Is this a problem?  Will it interact badly with other parts of ccdproc?

Edit: closes #356