### PR TITLE
Address units expected for calibration images in ccd_process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Other Changes and Additions
 
 - Auto-identify files with extension ``fts`` as FITS files. [#355, #364]
 
+- Raise more explicit exception if unit of uncalibrated image and master do
+  not match in ``subtract_bias`` or ``subtract_dark``. [#361, #366]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -13,6 +13,7 @@ from astropy.modeling import fitting
 from astropy import stats
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs.utils import proj_plane_pixel_area
+import astropy  # To get the version.
 
 from scipy import ndimage
 
@@ -649,11 +650,12 @@ def subtract_dark(ccd, master, dark_exposure=None, data_exposure=None,
             result = ccd.subtract(master_scaled)
         else:
             result = ccd.subtract(master)
-    except (u.UnitsError, ValueError) as e:
+    except (u.UnitsError, u.UnitConversionError, ValueError) as e:
         # Astropy LTS (v1) returns a ValueError, not a UnitsError, so catch
         # that if it appears to really be a UnitsError.
         if (isinstance(e, ValueError) and
-            'operand units' not in str(e)):
+                'operand units' not in str(e) and
+                astropy.__version__.startswith('1.0')):
             raise e
 
         # Make the error message a little more explicit than what is returned

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -649,7 +649,13 @@ def subtract_dark(ccd, master, dark_exposure=None, data_exposure=None,
             result = ccd.subtract(master_scaled)
         else:
             result = ccd.subtract(master)
-    except u.UnitsError:
+    except (u.UnitsError, ValueError) as e:
+        # Astropy LTS (v1) returns a ValueError, not a UnitsError, so catch
+        # that if it appears to really be a UnitsError.
+        if (isinstance(e, ValueError) and
+            'operand units' not in str(e)):
+            raise e
+
         # Make the error message a little more explicit than what is returned
         # by default.
         raise u.UnitsError("Unit '{}' of the uncalibrated image does not "

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -90,15 +90,21 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         Default is ``False``.
 
     master_bias : `~ccdproc.CCDData` or None, optional
-        A master bias frame to be subtracted from ccd.
+        A master bias frame to be subtracted from ccd. The unit of the
+        master bias frame should match the unit of the image **after
+        gain correction**.
         Default is ``None``.
 
     dark_frame : `~ccdproc.CCDData` or None, optional
-        A dark frame to be subtracted from the ccd.
+        A dark frame to be subtracted from the ccd. The unit of the
+        master dark frame should match the unit of the image **after
+        gain correction**.
         Default is ``None``.
 
     master_flat : `~ccdproc.CCDData` or None, optional
-        A master flat frame to be divided into ccd.
+        A master flat frame to be divided into ccd. The unit of the
+        master flat frame should match the unit of the image **after
+        gain correction**.
         Default is ``None``.
 
     bad_pixel_mask : `numpy.ndarray` or None, optional

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -383,7 +383,8 @@ def test_subtract_dark_fails(ccd_data):
     # Fail if units do not match...
 
     # ...when there is no scaling?
-    master = CCDData(ccd_data, unit="meter")
+    master = CCDData(ccd_data)
+    master.unit = u.meter
 
     with pytest.raises(u.UnitsError) as e:
         subtract_dark(ccd_data, master, exposure_time='exptime',

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -185,7 +185,7 @@ the overscan axis ends up being the *second* axis, which is numbered 1 in
 python zero-based numbering.
 
 With the arguments in this example the overscan is averaged over the overscan
-columns (i.e. 2000 through 2031) and then subtracted row-by-row from the
+columns (i.e. 200 through 231) and then subtracted row-by-row from the
 image. The ``median`` argument can be used to median combine instead.
 
 This example is not very realistic: typically one wants to fit a low-order
@@ -205,8 +205,8 @@ Trim an image
 +++++++++++++
 
 The overscan-subtracted image constructed above still contains the overscan
-portion. We are assuming came from a FITS file in which ``NAXIS1=2032`` and
-``NAXIS2=1000``, in which the last 32 columns along ``NAXIS1`` are overscan.
+portion. We are assuming came from a FITS file in which ``NAXIS1=232`` and
+``NAXIS2=100``, in which the last 32 columns along ``NAXIS1`` are overscan.
 
 Trim it using `~ccdproc.trim_image`,shown below in both python-
 style and FITS-style indexing:
@@ -299,15 +299,25 @@ Basic Processing
 ----------------
 
 All of the basic processing steps can be accomplished in a single step using
-`~ccdproc.ccd_process`.   This step will call overscan correct, trim, gain
-correct, add a bad pixel mask, create an uncertainty frame, subtract the master
-bias, and flat-field the image.  These can be run together as:
+`~ccdproc.ccd_process`. This step will call overscan correct, trim, gain
+correct, add a bad pixel mask, create an uncertainty frame, subtract the
+master bias, and flat-field the image. The unit of the master calibration
+frames must match that of the image *after* the gain, if any, is applied. In
+the example below, ``img`` has unit ``adu``, but the master frames have unit
+``electron``. These can be run together as:
 
      >>> ccd = ccdproc.CCDData(img, unit=u.adu)
-     >>> nccd = ccdproc.ccd_process(ccd, oscan='[1:10,1:100]', 
-     ...                            trim='[10:100, 1:100]',
-     ...                            error=True, gain=2.0*u.electron/u.adu,
-     ...                            readnoise = 5*u.electron) 
+     >>> ccd.header['exposure'] = 30.0  # for dark subtraction
+     >>> nccd = ccdproc.ccd_process(ccd, oscan='[201:232,1:100]',
+     ...                            trim='[1:200, 1:100]',
+     ...                            error=True,
+     ...                            gain=2.0*u.electron/u.adu,
+     ...                            readnoise=5*u.electron,
+     ...                            dark_frame=master_dark,
+     ...                            exposure_key='exposure',
+     ...                            exposure_unit=u.second,
+     ...                            dark_scale=True,
+     ...                            master_flat=master_flat)
 
 
 Reprojecting onto a different image footprint


### PR DESCRIPTION
This pull request address #361 in two ways:

1. The documentation for `ccd_process` now clearly states what the expected units of the calibration images are.
2. I've implement, for `subtract_bias`, a more explicit check for a units mismatch and raise a `UnitsError` instead of a `ValueError` in that case.

The error message looks like this: `UnitsError: Unit adu of the uncalibrated image do not match unit m of the calibration image`

@mrkite92 -- would this have been clearer in your case?

@crawfordsm -- if you like this approach, let me know and I'll do it for subtract dark also.