### PR TITLE
removes a lonely a in the narrative docs

### DIFF
--- a/docs/ccdproc/image_combination.rst
+++ b/docs/ccdproc/image_combination.rst
@@ -72,7 +72,6 @@ deviations below the median with
     (in the case the number of frames in the combiner) is much smaller than
     the number of pixels.
 
-    A
 
 Extrema clipping
 ++++++++++++++++


### PR DESCRIPTION
This is some residual from a previous commit: https://github.com/astropy/ccdproc/commit/9e95902a0e54d1ba4ce0f3356d0aaebb8691ea11