### PR TITLE
Use local scope variables in the helper function in FileCollection._dict_from_fits_header

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -317,12 +317,13 @@ class ImageFileCollection(object):
         """
         from collections import OrderedDict
 
-        def _add_val_to_dict(key, value, tbl_dict, n_prev):
+        def _add_val_to_dict(key, value, tbl_dict, n_previous, missing_marker):
+            key = key.lower()
             try:
-                tbl_dict[key.lower()].append(value)
+                tbl_dict[key].append(value)
             except KeyError:
-                tbl_dict[key.lower()] = [missing_marker] * n_previous
-                tbl_dict[key.lower()].append(value)
+                tbl_dict[key] = [missing_marker] * n_previous
+                tbl_dict[key].append(value)
 
         if input_summary is None:
             summary = OrderedDict()
@@ -359,12 +360,13 @@ class ImageFileCollection(object):
             else:
                 val = v
 
-            _add_val_to_dict(k, val, summary, n_previous)
+            _add_val_to_dict(k, val, summary, n_previous, missing_marker)
 
         for k, v in six.iteritems(multi_entry_keys):
             if v:
                 joined = ','.join(v)
-                _add_val_to_dict(k, joined, summary, n_previous)
+                _add_val_to_dict(k, joined, summary, n_previous,
+                                 missing_marker)
 
         for missing in missing_in_this_file:
             summary[missing].append(missing_marker)


### PR DESCRIPTION
The helper function has an argument ``n_prev`` but used ``n_previous``. This doesn't cause any bugs because the "not local" variable ``n_previous`` holds the same value. But I've renamed the function argument to ``n_previous`` (and added ``missing_marker``) so Python doesn't need to search in nonlocal scopes.

The third small change here was that the helper function now immediatly converts the key to lower-case so ``key.lower()`` is only called once even if the key wasn't present in the ``tbl_dict``.