### PR TITLE
Update changelog/authors in preparation for 1.1 release

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,13 +14,16 @@ Project Coordinators
 Alphabetical list of contributors
 ---------------------------------
 
+* Javier Blasco (@javierblasco)
 * Christoph Deil (@cdeil)
 * Carlos Gomez (@carlgogo)
 * Hans Moritz Günther (@hamogu)
 * Forrest Gasdia (@EP-Guy)
 * Nathan Heidt (@heidtha)
+* Elias Holte (@Sondanaa)
 * Anthony Horton (@AnthonyHorton)
 * Jennifer Karr (@JenniferKarr)
+* James McCormac (@jmccormac01)
 * Stefan Nelson (@pulsestaysconstant)
 * Joe Philip Ninan (@indiajoe)
 * Punyaslok Pattnaik (@Punyaslok)
@@ -32,6 +35,7 @@ Alphabetical list of contributors
 * Connor Stotts (@stottsco)
 * Ole Streicher (@olebole)
 * Erik Tollerud (@eteq)
+* Josh Walawender (@joshwalawender)
 * Nathan Walker (@walkerna22)
 
 (If you have contributed to the ccdproc project and your name is missing,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Bug Fixes
 New Features
 ^^^^^^^^^^^^
 
-- Add an additional combination method, `clip_extrema`, that drops the highest
+- Add an additional combination method, ``clip_extrema``, that drops the highest
   and/or lowest pixels in an image stack. [#356, #358]
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 
-1.1.0 (Unreleased)
+1.2.0 (Unreleased)
 ------------------
 
 New Features
@@ -8,24 +8,31 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Auto-identify files with extension ``fts`` as FITS files. [#355, #364]
-
-- Raise more explicit exception if unit of uncalibrated image and master do
-  not match in ``subtract_bias`` or ``subtract_dark``. [#361, #366]
-
-- Updated the ``Combiner`` class so that it could process images with >2 
-  dimensions. [#340, #375]
-
 Bug Fixes
 ^^^^^^^^^
 
-1.0.2 (Unreleased)
+
+1.1.0 (Unreleased)
 ------------------
+
+New Features
+^^^^^^^^^^^^
+
+- Add an additional combination method, `clip_extrema`, that drops the highest
+  and/or lowest pixels in an image stack. [#356, #358]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``cosmicray_lacosmic`` default ``satlevel`` changed from 65536 to 65535. [#347]
+
+- Auto-identify files with extension ``fts`` as FITS files. [#355, #364]
+
+- Raise more explicit exception if unit of uncalibrated image and master do
+  not match in ``subtract_bias`` or ``subtract_dark``. [#361, #366]
+
+- Updated the ``Combiner`` class so that it could process images with >2
+  dimensions. [#340, #375]
 
 Bug Fixes
 ^^^^^^^^^
@@ -34,6 +41,9 @@ Bug Fixes
   or ``median_combine``. [#351]
 
 - ``flat_correct`` does not properly scale uncertainty in the flat. [#345, #363]
+
+- Error message in weights setter fixed. [#376]
+
 
 1.0.1 (2016-03-15)
 ------------------


### PR DESCRIPTION
I'm letting the CI run since the changelog and authors are integrating into the docs.