### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
         - CONDA_DEPENDENCIES='scipy astroscrappy reproject'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test'
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:
         # Make sure that egg_info works without dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
                         # to the matrix section.
       CONDA_DEPENDENCIES: "scipy astroscrappy reproject"
       PIP_DEPENDENCIES: ""
+      CONDA_CHANNELS: "astropy"
 
   matrix:
 


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.