### PR TITLE
add dtype argument to combine-function.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,26 @@ Bug Fixes
 ^^^^^^^^^
 
 
+1.1.1 (Unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``combine`` now accepts a ``dtype`` argument which is passed to
+  ``Combiner.__init__``. [#391, #392]
+
+Bug Fixes
+^^^^^^^^^
+
+- The default dtype of the ``combine``-result doesn't depend on the dtype
+  of the first CCDData anymore. This also corrects the memory consumption
+  calculation. [#391, #392]
+
+
 1.1.0 (2016-08-01)
 ------------------
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -285,6 +285,25 @@ def test_combine_average_fitsimages():
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data)
 
 
+def test_combiner_result_dtype():
+    """Regression test: #391
+
+    The result should have the appropriate dtype not the dtype of the first
+    input."""
+    ccd = CCDData(np.ones((3, 3), dtype=np.uint16), unit='adu')
+    res = combine([ccd, ccd.multiply(2)])
+    # The default dtype of Combiner is float64
+    assert res.data.dtype == np.float64
+    ref = np.ones((3, 3)) * 1.5
+    np.testing.assert_array_almost_equal(res.data, ref)
+
+    res = combine([ccd, ccd.multiply(2), ccd.multiply(3)], dtype=int)
+    # The default dtype of Combiner is float64
+    assert res.data.dtype == np.int_
+    ref = np.ones((3, 3)) * 2
+    np.testing.assert_array_almost_equal(res.data, ref)
+
+
 #test combiner convenience function works with list of ccddata objects
 def test_combine_average_ccddata():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -298,7 +298,7 @@ def test_combiner_result_dtype():
     np.testing.assert_array_almost_equal(res.data, ref)
 
     res = combine([ccd, ccd.multiply(2), ccd.multiply(3)], dtype=int)
-    # The default dtype of Combiner is float64
+    # The result dtype should be integer:
     assert res.data.dtype == np.int_
     ref = np.ones((3, 3)) * 2
     np.testing.assert_array_almost_equal(res.data, ref)


### PR DESCRIPTION
Fixes #391 

This PR adds a ``dtype`` parameter which is passed to ``Combiner``.

This fixes two Bugs:

- if the dtype of the first ccd passed to `combine` isn't ``float64`` the result was downcast to the dtype of the first ccd.
- in that case also the memory consumption calculation was wrong because `Combiner` used `float64` while the calculation assumed the `dtype` to be the same as the one of the first ccd.

And also allows to optionally reduce the memory consumption by simple using a `dtype`.