### PR TITLE
replace the trim_image call in combine with direct slicing to avoid logging.

### DIFF
--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -657,7 +657,7 @@ def combine(img_list, output_file=None,
                     imgccd = CCDData.read(image, **ccdkwargs)
 
                 # Trim image
-                ccd_list.append(trim_image(imgccd[x:xend, y:yend]))
+                ccd_list.append(imgccd[x:xend, y:yend])
 
             # Create Combiner for tile
             tile_combiner = Combiner(ccd_list, dtype=dtype)


### PR DESCRIPTION
Closes #390 

The reason why the exception in #390 occured was because for some reason (haven't investigated it) it wasn't possible to create a HIERARCH card for the compressed image. For normal calls to `ccdproc.core` functions one could disable logging by setting the `add_keywords` parameter but that's currently not possible for `ccdproc.combine`. 

However it's just not necessary to add the logging message for the trimming to Header because the trimming is not really done, it's just there to avoid using too much memory.

So instead of trimming the ccddata object it's just sliced in combine. This fixes the error locally but I haven't been able to create a test case for this.