### PR TITLE
Allow ImageFileCollections to take a list of file names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 New Features
 ^^^^^^^^^^^^
 
+- Add an optional attribute named ``filenames`` to ``ImageFileCollection``,
+  so that users can pass a list of FITS files to the collection. [#374]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -34,7 +34,12 @@ class ImageFileCollection(object):
     Parameters
     ----------
     location : str or None, optional
-        path to directory containing FITS files.
+        Path to directory containing FITS files.
+        Default is ``None``.
+
+    filenames: str, list of str, or None, optional
+        List of the names of FITS files which will be added to the collection.
+        The filenames are assumed to be in ``location``.
         Default is ``None``.
 
     keywords : list of str, '*' or None, optional
@@ -57,11 +62,15 @@ class ImageFileCollection(object):
         Raised if keywords are set to a combination of '*' and any other
         value.
     """
-    def __init__(self, location=None, keywords=None, info_file=None):
+    def __init__(self, location=None, filenames=None, keywords=None,
+                 info_file=None):
         self._location = location
         self._files = []
         if location:
-            self._files = self._fits_files_in_directory()
+            if filenames:
+                self._files = filenames
+            else:
+                self._files = self._fits_files_in_directory()
         if self._files == []:
             warnings.warn("no FITS files in the collection.",
                           AstropyUserWarning)

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -309,7 +309,7 @@ class ImageFileCollection(object):
         """
         files = []
         if self._filenames:
-            if isinstance(self._filenames, str):
+            if isinstance(self._filenames, six.string_types):
                 files.append(self._filenames)
             else:
                 files = self._filenames

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -69,7 +69,7 @@ class ImageFileCollection(object):
         self._files = []
         if location:
             if self._filenames:
-                if type(self._filenames) is str:
+                if isinstance(self._filenames, str):
                     self._files.append(self._filenames)
                 else:
                     self._files = self._filenames
@@ -285,7 +285,7 @@ class ImageFileCollection(object):
         keywords = '*' if self._all_keywords else self.keywords
         # Re-load list of files
         if self._filenames:
-            if type(self._filenames) is str:
+            if isinstance(self._filenames, str):
                 self._files.append(self._filenames)
             else:
                 self._files = self._filenames

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -37,11 +37,6 @@ class ImageFileCollection(object):
         Path to directory containing FITS files.
         Default is ``None``.
 
-    filenames: str, list of str, or None, optional
-        List of the names of FITS files which will be added to the collection.
-        The filenames are assumed to be in ``location``.
-        Default is ``None``.
-
     keywords : list of str, '*' or None, optional
         Keywords that should be used as column headings in the summary table.
         If the value is or includes '*' then all keywords that appear in any
@@ -56,14 +51,19 @@ class ImageFileCollection(object):
         list.
         Default is ``None``.
 
+    filenames: str, list of str, or None, optional
+        List of the names of FITS files which will be added to the collection.
+        The filenames are assumed to be in ``location``.
+        Default is ``None``.
+
     Raises
     ------
     ValueError
         Raised if keywords are set to a combination of '*' and any other
         value.
     """
-    def __init__(self, location=None, filenames=None, keywords=None,
-                 info_file=None):
+    def __init__(self, location=None, keywords=None, info_file=None,
+                 filenames=None):
         self._location = location
         self._files = []
         if location:

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -69,7 +69,10 @@ class ImageFileCollection(object):
         self._files = []
         if location:
             if self._filenames:
-                self._files =  self._filenames
+                if type(self._filenames) is str:
+                    self._files.append(self._filenames)
+                else:
+                    self._files = self._filenames
             else:
                 self._files = self._fits_files_in_directory()
         if self._files == []:
@@ -282,7 +285,10 @@ class ImageFileCollection(object):
         keywords = '*' if self._all_keywords else self.keywords
         # Re-load list of files
         if self._filenames:
-            self._files = self._filenames
+            if type(self._filenames) is str:
+                self._files.append(self._filenames)
+            else:
+                self._files = self._filenames
         else:
             self._files = self._fits_files_in_directory()
         self._summary_info = self._fits_summary(header_keywords=keywords)

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -65,10 +65,11 @@ class ImageFileCollection(object):
     def __init__(self, location=None, keywords=None, info_file=None,
                  filenames=None):
         self._location = location
+        self._filenames = filenames
         self._files = []
         if location:
-            if filenames:
-                self._files = filenames
+            if self._filenames:
+                self._files =  self._filenames
             else:
                 self._files = self._fits_files_in_directory()
         if self._files == []:
@@ -280,7 +281,10 @@ class ImageFileCollection(object):
         """
         keywords = '*' if self._all_keywords else self.keywords
         # Re-load list of files
-        self._files = self._fits_files_in_directory()
+        if self._filenames:
+            self._files = self._filenames
+        else:
+            self._files = self._fits_files_in_directory()
         self._summary_info = self._fits_summary(header_keywords=keywords)
 
     def sort(self, keys=None):

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -68,13 +68,8 @@ class ImageFileCollection(object):
         self._filenames = filenames
         self._files = []
         if location:
-            if self._filenames:
-                if isinstance(self._filenames, str):
-                    self._files.append(self._filenames)
-                else:
-                    self._files = self._filenames
-            else:
-                self._files = self._fits_files_in_directory()
+            self._files = self._get_files()
+
         if self._files == []:
             warnings.warn("no FITS files in the collection.",
                           AstropyUserWarning)
@@ -284,13 +279,7 @@ class ImageFileCollection(object):
         """
         keywords = '*' if self._all_keywords else self.keywords
         # Re-load list of files
-        if self._filenames:
-            if isinstance(self._filenames, str):
-                self._files.append(self._filenames)
-            else:
-                self._files = self._filenames
-        else:
-            self._files = self._fits_files_in_directory()
+        self._files = self._get_files()
         self._summary_info = self._fits_summary(header_keywords=keywords)
 
     def sort(self, keys=None):
@@ -308,6 +297,26 @@ class ImageFileCollection(object):
         if len(self._summary_info) > 0:
             self._summary_info.sort(keys)
             self._files = list(self.summary_info['file'])
+
+    def _get_files(self):
+        """ Helper method which checks whether ``files`` should be set
+        to a subset of file names or to all file names in a directory.
+
+        Returns
+        -------
+        files : list or str
+            List of file names which will be added to the collection.
+        """
+        files = []
+        if self._filenames:
+            if isinstance(self._filenames, str):
+                files.append(self._filenames)
+            else:
+                files = self._filenames
+        else:
+            files = self._fits_files_in_directory()
+
+        return files
 
     def _dict_from_fits_header(self, file_name, input_summary=None,
                                missing_marker=None):

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -85,6 +85,13 @@ class TestImageFileCollection(object):
             location=triage_setup.test_dir, keywords=['imagetyp', 'filter'])
         assert img_collection.summary is img_collection.summary_info
 
+    def test_filenames_are_set_properly(self, triage_setup):
+        fn = ['filter_no_object_bias.fit', 'filter_object_light_foo.fit']
+        img_collection = image_collection.ImageFileCollection(
+            location=triage_setup.test_dir, filenames=fn, keywords=['filter'])
+        assert img_collection.files is fn
+        assert img_collection.summary is img_collection.summary_info
+
     def test_files_with_compressed(self, triage_setup):
         collection = image_collection.ImageFileCollection(
             location=triage_setup.test_dir)

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -91,6 +91,9 @@ class TestImageFileCollection(object):
             location=triage_setup.test_dir, filenames=fn, keywords=['filter'])
         assert img_collection.files is fn
 
+        img_collection.refresh()
+        assert img_collection.files is fn
+
     def test_files_with_compressed(self, triage_setup):
         collection = image_collection.ImageFileCollection(
             location=triage_setup.test_dir)

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -89,10 +89,15 @@ class TestImageFileCollection(object):
         fn = ['filter_no_object_bias.fit', 'filter_object_light_foo.fit']
         img_collection = image_collection.ImageFileCollection(
             location=triage_setup.test_dir, filenames=fn, keywords=['filter'])
-        assert img_collection.files is fn
+        assert img_collection.files == fn
 
         img_collection.refresh()
-        assert img_collection.files is fn
+        assert img_collection.files == fn
+
+        fn = 'filter_no_object_bias.fit'
+        img_collection = image_collection.ImageFileCollection(
+            location=triage_setup.test_dir, filenames=fn, keywords=['filter'])
+        assert img_collection.files == [fn]
 
     def test_files_with_compressed(self, triage_setup):
         collection = image_collection.ImageFileCollection(

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -90,7 +90,6 @@ class TestImageFileCollection(object):
         img_collection = image_collection.ImageFileCollection(
             location=triage_setup.test_dir, filenames=fn, keywords=['filter'])
         assert img_collection.files is fn
-        assert img_collection.summary is img_collection.summary_info
 
     def test_files_with_compressed(self, triage_setup):
         collection = image_collection.ImageFileCollection(


### PR DESCRIPTION
Implements #374.

I added an optional parameter named ``filenames``  which should contain the names of the FITS files in the directory which should be added to the collection. If ``filenames`` is ``None`` and ``location`` is not, then all FITS files in ``location`` are added to the collection.

Appreciate any feedback on this.