### PR TITLE
Copy Meta in ccd_process when "subtract_bias" image

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Other Changes and Additions
 Bug Fixes
 ^^^^^^^^^
 
+- ``ccd_process`` now copies the meta of the input when subtracting the
+  master bias. [#404]
+
 
 1.1.1 (Unreleased)
 ------------------

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -228,7 +228,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
 
     # subtracting the master bias
     if isinstance(master_bias, CCDData):
-        nccd = nccd.subtract(master_bias)
+        nccd = subtract_bias(nccd, master_bias)
     elif master_bias is None:
         pass
     else:

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -877,6 +877,7 @@ def test_ccd_process():
     # test the through ccd_process
     ccd_data = CCDData(10.0 * np.ones((100, 100)), unit=u.adu)
     ccd_data.data[:, -10:] = 2
+    ccd_data.meta['testkw'] = 100
 
     mask = np.zeros((100, 90))
 
@@ -905,3 +906,5 @@ def test_ccd_process():
                                   occd.uncertainty.array)
     np.testing.assert_array_equal(mask, occd.mask)
     assert(occd.unit == u.electron)
+    # Make sure the original keyword is still present. Regression test for #401
+    assert occd.meta['testkw'] == 100


### PR DESCRIPTION
I identified one place where the `meta` could be lost when calling `ccd_process` (#401).

Maybe @crawfordsm or @RogueAstro could confirm if this PR fixes the issue.

Closes #401