### PR TITLE
add scikit-image to rtd-requirements

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,5 @@
 numpy>=1.9
 scipy
+scikit-image
 numpydoc
 astropy>=1.0


### PR DESCRIPTION
I don't know if that would fix the failing readthedocs builds (http://readthedocs.org/projects/ccdproc/builds/) but I did forget to add it there.