### PR TITLE
Adding licence to the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,3 +24,4 @@ The documentation for this package is here:
 
   authors_for_sphinx
   changelog
+  license

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,12 @@
+.. _license:
+
+********
+Licenses
+********
+
+Ccdproc License
+===============
+
+Ccdproc is licensed under a 3-clause BSD style license:
+
+.. include:: ../licenses/LICENSE.rst


### PR DESCRIPTION
I think somewhere in the docs we should mention the license