### PR TITLE
Explicitly create HIERARCH cards in CCDData._insert_in_metadata_fits_safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ccdprocs core functions now explicitly add HIERARCH cards. [#359, #399, #413]
+
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -550,7 +550,8 @@ class CCDData(NDDataArray):
             # problems...
             # Shorten, sort of...
             short_name = _short_names[key]
-            self.meta[key] = (short_name, "Shortened name for ccdproc command")
+            self.meta['HIERARCH {0}'.format(key.upper())] = (
+                short_name, "Shortened name for ccdproc command")
             self.meta[short_name] = value
         else:
             self.meta[key] = value


### PR DESCRIPTION
Fixes #399, Fixes #359

I wasn't sure if a COMMENT card would be better, but that wouldn't be backwards compatible, so this just explicitly creates HIERARCH cards to avoid the annoying warnings.


```
>>> import ccdproc
>>> import numpy as np
>>> from astropy.io import fits
>>> ccd = ccdproc.CCDData(np.ones((5, 5)), meta=fits.Header(), unit='adu')
>>> ccd2 = ccdproc.subtract_bias(ccd, ccd)  # no warnings anymore
>>> ccd2.meta
HIERARCH SUBTRACT_BIAS = 'subbias ' / Shortened name for ccdproc command        
SUBBIAS = 'ccd=<CCDData>, master=<CCDData>'
```