### PR TITLE
Travis matrix changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,35 +30,34 @@ env:
         - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:
-        # Make sure that egg_info works without dependencies
+
         - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
 
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
+        # Try Astropy/NumPy development versions. This requires them to be
+        # compiled during setup which takes some time.
+        - python: 3.5
+          env: ASTROPY_VERSION=development NUMPY_VERSION=dev
+
+        # Do coverage tests for both latest Python versions
+        - python: 3.5
+          env: SETUP_CMD='test --coverage'
+
         - python: 2.7
           env: SETUP_CMD='test --coverage'
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
+        # Check for sphinx doc build warnings
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
-        - python: 3.5
-          env: ASTROPY_VERSION=development
 
         # Check compatibility with the current astropy LTS release
         - python: 2.7
           env: ASTROPY_VERSION=LTS
 
-        # Try older numpy versions
-        - python: 2.7
+        # Try older numpy, python versions
+        - python: 3.4
           env: NUMPY_VERSION=1.10
 
         # Try numpy pre-release version. This runs only when a pre-release

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -875,10 +875,8 @@ def test_wcs_project_onto_scale_wcs(ccd_data):
     assert new_ccd.wcs.wcs.compare(target_wcs.wcs)
 
     # Define a cutout from the new array that should match the old.
-    new_lower_bound = (np.array(new_ccd.shape) -
-                       np.array(ccd_data.shape)) / 2
-    new_upper_bound = (np.array(new_ccd.shape) +
-                       np.array(ccd_data.shape)) / 2
+    new_lower_bound = (np.array(new_ccd.shape) - np.array(ccd_data.shape)) // 2
+    new_upper_bound = (np.array(new_ccd.shape) + np.array(ccd_data.shape)) // 2
     data_cutout = new_ccd.data[new_lower_bound[0]:new_upper_bound[0],
                                new_lower_bound[1]:new_upper_bound[1]]
 
@@ -890,7 +888,7 @@ def test_wcs_project_onto_scale_wcs(ccd_data):
 
     # Mask should be true for four pixels (all nearest neighbors)
     # of the single pixel we masked initially.
-    new_center = new_ccd.wcs.wcs.crpix
+    new_center = np.array(new_ccd.wcs.wcs.crpix, dtype=int, copy=False)
     assert np.all(new_ccd.mask[new_center[0]:new_center[0]+2,
                                new_center[1]:new_center[1]+2])
 


### PR DESCRIPTION
This removes some of the tests in `.travis.yml`. I think I've incorporated all of them in the remaining tests.

It also adds one more test for numpy-dev (which will fail 😄 )

This reduces the build-time from 35m -> 25m.