### PR TITLE
Add Shutter Correction Functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,35 +30,34 @@ env:
         - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:
-        # Make sure that egg_info works without dependencies
+
         - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
 
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
+        # Try Astropy/NumPy development versions. This requires them to be
+        # compiled during setup which takes some time.
+        - python: 3.5
+          env: ASTROPY_VERSION=development NUMPY_VERSION=dev
+
+        # Do coverage tests for both latest Python versions
+        - python: 3.5
+          env: SETUP_CMD='test --coverage'
+
         - python: 2.7
           env: SETUP_CMD='test --coverage'
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
+        # Check for sphinx doc build warnings
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
-        - python: 3.5
-          env: ASTROPY_VERSION=development
 
         # Check compatibility with the current astropy LTS release
         - python: 2.7
           env: ASTROPY_VERSION=LTS
 
-        # Try older numpy versions
-        - python: 2.7
+        # Try older numpy, python versions
+        - python: 3.4
           env: NUMPY_VERSION=1.10
 
         # Try numpy pre-release version. This runs only when a pre-release

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ New Features
 - Added ``block_replicate``, ``block_reduce`` and ``block_average`` functions.
   [#402]
 
+- Added ``median_filter`` function. [#420]
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ New Features
 
 - Added ``median_filter`` function. [#420]
 
+- Added ``shutter_correction`` functions.
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ ccdproc has now the following additional dependency:
 New Features
 ^^^^^^^^^^^^
 
+- Add an optional attribute named ``filenames`` to ``ImageFileCollection``,
+  so that users can pass a list of FITS files to the collection. [#374]
+
 - Added ``block_replicate``, ``block_reduce`` and ``block_average`` functions.
   [#402]
 
@@ -19,28 +22,9 @@ Other Changes and Additions
 
 - ccdprocs core functions now explicitly add HIERARCH cards. [#359, #399, #413]
 
-
-Bug Fixes
-^^^^^^^^^
-
-- ``ccd_process`` now copies the meta of the input when subtracting the
-  master bias. [#404]
-
-
-1.1.1 (Unreleased)
-------------------
-
-New Features
-^^^^^^^^^^^^
-
-- Add an optional attribute named ``filenames`` to ``ImageFileCollection``,
-  so that users can pass a list of FITS files to the collection. [#374]
-
-Other Changes and Additions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 - ``combine`` now accepts a ``dtype`` argument which is passed to
   ``Combiner.__init__``. [#391, #392]
+
 
 Bug Fixes
 ^^^^^^^^^
@@ -48,6 +32,9 @@ Bug Fixes
 - The default dtype of the ``combine``-result doesn't depend on the dtype
   of the first CCDData anymore. This also corrects the memory consumption
   calculation. [#391, #392]
+
+- ``ccd_process`` now copies the meta of the input when subtracting the
+  master bias. [#404]
 
 
 1.1.0 (2016-08-01)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New Features
 
 - Added ``median_filter`` function. [#420]
 
-- Added ``shutter_correction`` functions.
+- Added ``shutter_correction`` functions. [#419]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -17,3 +17,4 @@ if not _ASTROPY_SETUP_:
     from .ccddata import *
     from .combiner import *
     from .image_collection import *
+    from .shutter_correction import *

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -27,7 +27,8 @@ __all__ = ['background_deviation_box', 'background_deviation_filter',
            'ccd_process', 'cosmicray_median', 'cosmicray_lacosmic',
            'create_deviation', 'flat_correct', 'gain_correct', 'rebin',
            'sigma_func', 'subtract_bias', 'subtract_dark', 'subtract_overscan',
-           'transform_image', 'trim_image', 'wcs_project', 'Keyword']
+           'transform_image', 'trim_image', 'wcs_project', 'Keyword',
+           'median_filter']
 
 # The dictionary below is used to translate actual function names to names
 # that are FITS compliant, i.e. 8 characters or less.
@@ -1228,6 +1229,22 @@ def _blkavg(data, newshape):
         [')'] + ['.mean(%d)' % (i + 1) for i in range(lenShape)]
 
     return eval(''.join(evList))
+
+
+def median_filter(data, *args, **kwargs):
+    """See `scipy.ndimage.median_filter` for arguments.
+
+    If the ``data`` is a `~ccdproc.CCDData` object the result will be another
+    `~ccdproc.CCDData` object with the median filtered data as ``data`` and
+    copied ``unit`` and ``meta``.
+    """
+    if isinstance(data, CCDData):
+        out_kwargs = {'meta': data.meta.copy(),
+                      'unit': data.unit}
+        result = ndimage.median_filter(data.data, *args, **kwargs)
+        return CCDData(result, **out_kwargs)
+    else:
+        return ndimage.median_filter(data, *args, **kwargs)
 
 
 def cosmicray_lacosmic(ccd, sigclip=4.5, sigfrac=0.3,

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -235,7 +235,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         pass
     else:
         raise TypeError(
-            'master_bias is not None, numpy.ndarray, or a CCDData object.')
+            'master_bias is not None or a CCDData object.')
 
     # subtract the dark frame
     if isinstance(dark_frame, CCDData):
@@ -257,7 +257,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         pass
     else:
         raise TypeError(
-            'master_flat is not None, numpy.ndarray, or a CCDData object.')
+            'master_flat is not None or a CCDData object.')
 
     return nccd
 

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -3,12 +3,90 @@ from __future__ import (print_function, division, absolute_import,
 
 import os
 
-from .core import *
+import numpy as np
+import astropy.units as u
+from astropy.nddata import StdDevUncertainty
+
+from .core import CCDData, subtract_bias
+from .ccddata import fits_ccddata_reader, fits_ccddata_writer
+from .combiner import combine
 from .image_collection import ImageFileCollection
+
+
+def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
+                       normalizer=lambda flat: flat.data.max(),
+                       output=None):
+    '''
+    Determine the shutter correction given a set of input bias subtracted flats.
+    
+    Parameters
+    ----------
+    combined_flats : `list` containing `~ccdproc.CCDData` objects
+        Set of bias subtracted flats of different exposure times taken under
+        constant illumination.
+    
+    exptimekey : `string`, defaults to 'EXPTIME'
+        The header keyword which contains the exposure time of the image in
+        seconds.
+
+    Notes
+    -----
+    This code follows the implementation described in Surma, P. (1993) 
+    "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
+    (ISSN 0004-6361), 278, 654–658.
+
+    Returns
+    -------
+    shutter_map : `~ccdproc.CCDData`
+        The shutter correction map in units of seconds.
+    '''
+    assert 'GAIN' in combined_flats[0].header.keys()
+    gain = combined_flats[0].header['GAIN']
+
+#     def nflat(flat, size=(10,10)):
+#         mflat = ndimage.filters.median_filter(flat.data, size=size)
+#         print(flat.data.max(), np.percentile(flat.data, 99), mflat.max())
+#         return mflat.max()
+
+
+    a = gain*np.sum([normalizer(f) for f in combined_flats])
+    b = gain*np.sum([normalizer(f)/float(f.header[exptimekey]) for f in combined_flats])
+    c = gain*np.sum([normalizer(f)/float(f.header[exptimekey])**2 for f in combined_flats])
+
+    Dijcomb = combine(combined_flats, method='average')
+    Dij = gain*Dijcomb.data*len(combined_flats)
+
+    Eijm = [CCDData(data=f.data/float(f.header[exptimekey]), unit=f.unit)
+            for f in combined_flats]
+    Eijcomb = combine(Eijm, method='average')
+    Eij = gain*Eijcomb.data*len(combined_flats)
+
+    alpha_ij = 1.0 / (a*c - b**2) * (c*Dij - b*Eij)
+    delta_alpha = np.sqrt( c / (a*c - b**2) )
+    beta_ij = 1.0 / (a*c - b**2) * (a*Eij - b*Dij)
+    delta_beta = np.sqrt( a / (a*c - b**2) )
+
+    SF = beta_ij / alpha_ij  # SF = -t_SH * (1-SH_ij) in the paper terminology
+    delta_SF = np.sqrt( (alpha_ij**-1 * delta_beta)**2 + 
+                        (beta_ij * alpha_ij**-2 * delta_alpha)**2 )
+    SNR = np.mean(abs(SF)/delta_SF)
+
+    shutter_map = CCDData(data=SF,
+                          uncertainty=StdDevUncertainty(delta_SF),
+                          unit=u.second,
+                          meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
+
+    if output:
+        if os.path.exists(output):
+            os.remove(output)
+        fits_ccddata_writer(shutter_map, output)
+
+    return shutter_map
 
 
 def calculate_shutter_correction_map(files, biases=None,
                                      exptimekey='EXPTIME',
+                                     normalizer=lambda flat: flat.data.max(),
                                      keywordguide = {'keyword': 'IMAGETYP',
                                                      'flatvalue': 'Flat Field',
                                                      'biasvalue': 'Bias Frame'},
@@ -28,10 +106,10 @@ def calculate_shutter_correction_map(files, biases=None,
     biases = bytype.groups[bytype.groups.keys[keywordguide['keyword']]\
                            == keywordguide['biasvalue']]
 
-    if len(biases) > 0:
+    bias_images = [fits_ccddata_reader(os.path.join(files.location, f))
+                   for f in biases['file']]
+    if len(bias_images) > 0:
         ## Generate master bias to subtract from each flat
-        bias_images = [fits_ccddata_reader(os.path.join(files.location, f))
-                       for f in biases['file']]
         if len(bias_images) > 1:
             master_bias = combine(bias_images, combine='median')
         else:
@@ -48,55 +126,25 @@ def calculate_shutter_correction_map(files, biases=None,
         if len(flat_images) > 1:
             # Bias subtract flats
             if len(biases) > 0:
-                flat_images = [ccd.subtract_bias(im, master_bias) for im in flat_images]
-            sigma_clip = len(files) > 5  # perform sigma clipping if >5 files
-            combined_flat = ccd.combine(images, method='average',
+                flat_images = [subtract_bias(im, master_bias) for im in flat_images]
+            sigma_clip = len(flat_images) > 5  # perform sigma clipping if >5 files
+            combined_flat = combine(flat_images, method='average',
                                         sigma_clip=sigma_clip,
                                         sigma_clip_low_thresh=5,
                                         sigma_clip_high_thresh=5)
             combined_flats.append(combined_flat)
-            assert combined_flat.shape == flats[0].shape
+            assert combined_flat.shape == combined_flats[0].shape
         else:
             combined_flats.append(flat_images[0])
 
-    def nflat(flat, delta=25):
-        nl, nc = flat.data.shape
-        normalization_factor = np.median(flat.data[nl-delta:nl+delta,nc-delta:nc+delta])
-        nflat = flat.data / normalization_factor
-        return nflat
+    shutter_map = shutter_correction_algorithm(combined_flats, output=output)
+    return shutter_map
 
-    a = gain*np.sum([nflat(f) for f in combined_flats])
-    b = gain*np.sum([nflat(f)/float(f.header[exptimekey]) for f in combined_flats])
-    c = gain*np.sum([nflat(f)/float(f.header[exptimekey])**2 for f in combined_flats])
 
-    Dijcomb = ccd.combine(combined_flats, method='average')
-    Dij = gain*Dijcomb.data*len(combined_flats)
-
-    Eijm = [ccd.CCDData(data=f.data/float(f.header[exptimekey]), unit=f.unit)
-            for f in combined_flats]
-    Eijcomb = ccd.combine(Eijm, method='average')
-    Eij = gain*Eijcomb.data*len(combined_flats)
-
-    alpha_ij = 1.0 / (a*c - b**2) * (c*Dij - b*Eij)
-    delta_alpha = np.sqrt( c / (a*c - b**2) )
-    beta_ij = 1.0 / (a*c - b**2) * (a*Eij - b*Dij)
-    delta_beta = np.sqrt( a / (a*c - b**2) )
-
-    SF = beta_ij / alpha_ij  # SF = -t_SH * (1-SH_ij) in the paper terminology
-    delta_SF = np.sqrt( (alpha_ij**-1 * delta_beta)**2 + 
-                        (beta_ij * alpha_ij**-2 * delta_alpha)**2 )
-    SNR = np.mean(abs(SF)/delta_SF)
-    print('Typical pixel SNR of correction = {:.1f}'.format(SNR))
-    ShutterMap = ccd.CCDData(data=SF, uncertainty=delta_SF, unit=u.second,
-                     meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
-
-    if output:
-        if os.path.exists(output):
-            os.remove(output)
-        ccd.fits_ccddata_writer(ShutterMap, output)
-
-    return ShutterMap
-
+def apply_shutter_correction(image, shutter_map, exptimekey='EXPTIME'):
+    exptime_map = shutter_map.add(image.header[exptimekey]*u.second)
+    result = image.divide(exptime_map)
+    return result
 
 
 if __name__ == '__main__':

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -2,6 +2,7 @@ from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
 import os
+import sys
 
 import numpy as np
 import astropy.units as u
@@ -14,61 +15,10 @@ from .combiner import combine
 from .image_collection import ImageFileCollection
 
 
-def fit_shutter_bias(combined_flats, exptimekey='EXPTIME',
-                     normalizer=lambda flat: flat.data.max(),
-                     verbose=False):
-    '''
-    Determine the shutter correction given a set of input bias subtracted flats.
-    This algorithm assumes that the input light level for all files is constant,
-    so this should be run on data such as dome flats and not twilight flats.
-
-    Parameters
-    ----------
-    combined_flats : `list` containing `~ccdproc.CCDData` objects
-        Set of bias subtracted flats of different exposure times taken under
-        constant illumination.
-
-    exptimekey : `string`, defaults to 'EXPTIME'
-        The header keyword which contains the exposure time of the image in
-        seconds.
-
-    normalizer : function, optional
-        The algorithm requires a measurement of the light levels in the images
-        which represent the maximum exposure level.  Without noise, this would
-        simply be the maximum pixel level, so this defaults to the maximum
-        pixel value in the input image.  The user may specify a different
-        function here (see Examples below).
-
-    Returns
-    -------
-    bias : `float`
-        The value (in seconds) of the bias between the fitted exposure time and
-        the exposure time listed in the header.
-    '''
-    flux = [normalizer(f) for f in combined_flats]
-    time = [f.header[exptimekey] for f in combined_flats]
-    line0 = models.Linear1D(slope=1, intercept=0)
-    fitter = fitting.LinearLSQFitter()
-    line = fitter(line0, time, flux)
-    bias = line.intercept.value/line.slope.value
-    if verbose:
-        print('Shutter Bias = {:.3f}'.format(bias))
-    return bias
-
-
-
-
-def Surma1993_algorithm(combined_flats, exptimekey='EXPTIME',
-                        shutter_bias=0,
-                        normalizer=lambda flat: flat.data.max(),
-                        verbose=False, output=None):
+def GaladiEnriqez1995(combined_flats, exptimekey='EXPTIME', output=None):
     '''
     Determine the shutter correction map given a set of input bias subtracted
-    flats.  This algorithm assumes that the header exposure time values are
-    accurate -- that they represent the maximum typical exposure time in each
-    image.  If this is not the case, then the resulting shutter correction map
-    will be incorrect.  The `fit_shutter_bias` can be used to check this
-    assumption and correct the files as neeed.
+    flats.
     
     Parameters
     ----------
@@ -79,19 +29,6 @@ def Surma1993_algorithm(combined_flats, exptimekey='EXPTIME',
     exptimekey : `string`, defaults to 'EXPTIME'
         The header keyword which contains the exposure time of the image in
         seconds.
-
-    shutter_bias=0 : `float`, optional
-        The shutter bias value in seconds.  This is the difference between the
-        header exposure time and the actual exposure time for the pixels in the
-        image which get the maximum exposure time.  This value can be measured
-        using the `fit_shutter_bias` method.
-
-    normalizer : function, optional
-        The algorithm requires a measurement of the light levels in the images
-        which represent the maximum exposure level.  Without noise, this would
-        simply be the maximum pixel level, so this defaults to the maximum
-        pixel value in the input image.  The user may specify a different
-        function here (see Examples below).
 
     output : `str`, optional
         The filename to write the output shutter map to.  This will be a FITS
@@ -100,92 +37,49 @@ def Surma1993_algorithm(combined_flats, exptimekey='EXPTIME',
 
     Notes
     -----
-    This code follows the implementation described in Surma, P. (1993) 
-    "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
-    (ISSN 0004-6361), 278, 654–658.
+    This code follows the implementation described in Galadi-Enriquez, D.,
+    Jordi, C., & Trullols, E. (1995). "Effects of Shutter Timing on CCD
+    Photometry". IAU Symposium No. 167, 167, 327.
 
     Returns
     -------
     shutter_map : `~ccdproc.CCDData`
         The shutter correction map in units of seconds.
-
-    Examples
-    --------
-    Calling `Surma1993_algorithm` with normalizer that uses the maximum value
-    in an image that has been median filtered by a 10x10 box:
-    
-    >>> result = Surma1993_algorithm(combined_flats,
-                 normalizer=lambda f: median_filter(f.data, size=(10,10)).max())
     '''
-    assert 'GAIN' in combined_flats[0].header.keys()
-    gain = combined_flats[0].header['GAIN']
-
-    normflats = [normalizer(f) for f in combined_flats]
-    a = gain*np.sum(normflats)
-    b = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)
-                    for i,f in enumerate(combined_flats)])
-    c = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)**2
-                    for i,f in enumerate(combined_flats)])
-
-    Dijcomb = combine(combined_flats, method='average')
-    Dij = gain*Dijcomb.data*len(combined_flats)
-
-    Eijm = [CCDData(data=f.data/float(f.header[exptimekey]+shutter_bias), unit=f.unit)
-            for f in combined_flats]
-    Eijcomb = combine(Eijm, method='average')
-    Eij = gain*Eijcomb.data*len(combined_flats)
-
-    alpha_ij = 1.0 / (a*c - b**2) * (c*Dij - b*Eij)
-    delta_alpha = np.sqrt( c / (a*c - b**2) )
-    beta_ij = 1.0 / (a*c - b**2) * (a*Eij - b*Dij)
-    delta_beta = np.sqrt( a / (a*c - b**2) )
-
-    SF = beta_ij / alpha_ij  # SF = -t_SH * (1-SH_ij) in the paper terminology
-    delta_SF = np.sqrt( (alpha_ij**-1 * delta_beta)**2 + 
-                        (beta_ij * alpha_ij**-2 * delta_alpha)**2 )
-    SNR = np.mean(abs(SF)/delta_SF)
-
-    shutter_map = CCDData(data=SF,
-                          uncertainty=StdDevUncertainty(delta_SF),
-                          unit=u.second,
-                          meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
-
-    if verbose:
-        print('Shutter Map (min, mean, median, max, stddev) = '\
-              '{:.3f} {:.3f} {:.3f} {:.3f} {:.3f}'.format(
-              shutter_map.data.min(), shutter_map.data.mean(),
-              np.median(shutter_map.data), shutter_map.data.max(),
-              np.std(shutter_map.data) ))
-        print('Fraction of Shutter Map Pixels > 0: {:d}/{:d} = {:.3f}'.format(
-              np.sum(shutter_map.data > 0),
-              shutter_map.data.size,
-              np.sum(shutter_map.data > 0) / shutter_map.data.size))
+    n = len(combined_flats)
+    exptimes = np.ma.MaskedArray([f.header[exptimekey] for f in combined_flats],
+                                 mask=np.zeros(n, dtype=bool))
+    wmax = np.argmax(exptimes)
+    exptimes.mask[wmax] = True
+    cflats = np.array([f.data for i,f in enumerate(combined_flats) if i != wmax])
+    R = np.sum(cflats, axis=0) / combined_flats[wmax].data
+    delta = (exptimes.data[wmax]*R - exptimes.sum()) / (n-1 - R)
+    shutter_map = CCDData(delta, unit=u.second)
     if output:
         if os.path.exists(output):
             os.remove(output)
         fits_ccddata_writer(shutter_map, output)
-
     return shutter_map
 
 
-def apply_shutter_map(image, shutter_map, shutter_bias=0, exptimekey='EXPTIME'):
-    exptime_map = shutter_map.add((image.header[exptimekey]+shutter_bias)*u.second)
+def apply_shutter_map(image, shutter_map, exptimekey='EXPTIME'):
+    exptime_map = shutter_map.add(image.header[exptimekey]*u.second)
     result = image.divide(exptime_map)
     return result
 
 
 def get_shutter_map(files, biases=None, normalizer=lambda flat: flat.data.max(),
-                    check_shutter_bias=True, exptimekey='EXPTIME',
-                    min_files_to_sigma_clip=5, sigma_clip_low_thresh=5,
-                    sigma_clip_high_thresh=5,
+                    exptimekey='EXPTIME', min_files_to_sigma_clip=5,
+                    sigma_clip_low_thresh=5, sigma_clip_high_thresh=5,
+                    Surma1993=False,
                     keywordguide = {'keyword': 'IMAGETYP',
                                     'flatvalue': 'Flat Field',
                                     'biasvalue': 'Bias Frame'},
                     verbose=False, output=None):
     '''
-    Uses Surma1993_algorithm to determine the shutter correction map given
-    input files.  The input files are assumed to contain flat fields taken under
-    constant illumination (no twilight flats) and bias frames.
+    Determine the shutter correction map given input files.  The input files are
+    assumed to contain flat fields taken under constant illumination (no
+    twilight flats) and bias frames.
     
     The bias frames are median combined in to a master bias which is subtracted
     from each flat frame.
@@ -195,7 +89,8 @@ def get_shutter_map(files, biases=None, normalizer=lambda flat: flat.data.max(),
     exposure time.
     
     The resulting list of bias subtracted master flats at various exposure times
-    are passed to `Surma1993_algorithm` to determine the shutter map.
+    are passed to either `GaladiEnriqez1995` or `Surma1993` to determine the
+    shutter map.
 
     Parameters
     ----------
@@ -211,29 +106,10 @@ def get_shutter_map(files, biases=None, normalizer=lambda flat: flat.data.max(),
         The header keyword which contains the exposure time of the image in
         seconds.
 
-    shutter_bias=0 : `float`, optional
-        The shutter bias value in seconds.  This is the difference between the
-        header exposure time and the actual exposure time for the pixels in the
-        image which get the maximum exposure time.  This value can be measured
-        using the `fit_shutter_bias` method.
-
-    normalizer : function, optional
-        The algorithm requires a measurement of the light levels in the images
-        which represent the maximum exposure level.  Without noise, this would
-        simply be the maximum pixel level, so this defaults to the maximum
-        pixel value in the input image.  The user may specify a different
-        function here (see Examples below).
-
     output : `str`, optional
         The filename to write the output shutter map to.  This will be a FITS
         file with two extensions.  The first contains the shutter map values
         (in seconds) and the second contains the uncertainty in those values.
-
-    Notes
-    -----
-    This code follows the implementation described in Surma, P. (1993) 
-    "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
-    (ISSN 0004-6361), 278, 654–658.
 
     Returns
     -------
@@ -287,12 +163,230 @@ def get_shutter_map(files, biases=None, normalizer=lambda flat: flat.data.max(),
         else:
             combined_flats.append(flat_images[0])
 
-    if check_shutter_bias:
-        shutter_bias = fit_shutter_bias(combined_flats, verbose=verbose)
+    if Surma1993:
+        measured_bias = fit_shutter_bias(combined_flats)
+        shutter_map = Surma1993(combined_flats, shutter_bias=measured_bias,
+                                output=output)
     else:
-        shutter_bias = 0
-    shutter_map = Surma1993_algorithm(combined_flats, normalizer=normalizer,
-                              shutter_bias=shutter_bias, output=output,
-                              verbose=verbose)
+        shutter_map = GaladiEnriqez1995(combined_flats, output=output)
     return shutter_map
+
+
+def Surma1993(combined_flats, exptimekey='EXPTIME',
+              shutter_bias=0,
+              normalizer=lambda flat: flat.data.max(),
+              verbose=False, output=None):
+    '''
+    Determine the shutter correction map given a set of input bias subtracted
+    flats.  This algorithm assumes that the header exposure time values are
+    accurate -- that they represent the maximum typical exposure time in each
+    image.  If this is not the case, then the resulting shutter correction map
+    will be incorrect.  The `fit_shutter_bias` can be used to check this
+    assumption and correct the files as neeed.
+    
+    Parameters
+    ----------
+    combined_flats : `list` containing `~ccdproc.CCDData` objects
+        Set of bias subtracted flats of different exposure times taken under
+        constant illumination.
+    
+    exptimekey : `string`, defaults to 'EXPTIME'
+        The header keyword which contains the exposure time of the image in
+        seconds.
+
+    shutter_bias=0 : `float`, optional
+        The shutter bias value in seconds.  This is the difference between the
+        header exposure time and the actual exposure time for the pixels in the
+        image which get the maximum exposure time.  This value can be measured
+        using the `fit_shutter_bias` method.
+
+    normalizer : function, optional
+        The algorithm requires a measurement of the light levels in the images
+        which represent the maximum exposure level.  Without noise, this would
+        simply be the maximum pixel level, so this defaults to the maximum
+        pixel value in the input image.  The user may specify a different
+        function here (see Examples below).
+
+    output : `str`, optional
+        The filename to write the output shutter map to.  This will be a FITS
+        file with two extensions.  The first contains the shutter map values
+        (in seconds) and the second contains the uncertainty in those values.
+
+    Notes
+    -----
+    This code follows the implementation described in Surma, P. (1993) 
+    "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
+    (ISSN 0004-6361), 278, 654–658.
+
+    Returns
+    -------
+    shutter_map : `~ccdproc.CCDData`
+        The shutter correction map in units of seconds.
+
+    Examples
+    --------
+    Calling `Surma1993` with normalizer that uses the maximum value
+    in an image that has been median filtered by a 10x10 box:
+    
+    >>> result = Surma1993(combined_flats,
+                 normalizer=lambda f: median_filter(f.data, size=(10,10)).max())
+    '''
+    assert 'GAIN' in combined_flats[0].header.keys()
+    gain = combined_flats[0].header['GAIN']
+
+    normflats = [normalizer(f) for f in combined_flats]
+    a = gain*np.sum(normflats)
+    b = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)
+                    for i,f in enumerate(combined_flats)])
+    c = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)**2
+                    for i,f in enumerate(combined_flats)])
+
+    Dijcomb = combine(combined_flats, method='average')
+    Dij = gain*Dijcomb.data*len(combined_flats)
+
+    Eijm = [CCDData(data=f.data/float(f.header[exptimekey]+shutter_bias), unit=f.unit)
+            for f in combined_flats]
+    Eijcomb = combine(Eijm, method='average')
+    Eij = gain*Eijcomb.data*len(combined_flats)
+
+    alpha_ij = 1.0 / (a*c - b**2) * (c*Dij - b*Eij)
+    delta_alpha = np.sqrt( c / (a*c - b**2) )
+    beta_ij = 1.0 / (a*c - b**2) * (a*Eij - b*Dij)
+    delta_beta = np.sqrt( a / (a*c - b**2) )
+
+    SF = beta_ij / alpha_ij  # SF = -t_SH * (1-SH_ij) in the paper terminology
+    delta_SF = np.sqrt( (alpha_ij**-1 * delta_beta)**2 + 
+                        (beta_ij * alpha_ij**-2 * delta_alpha)**2 )
+    SNR = np.mean(abs(SF)/delta_SF)
+
+    shutter_map = CCDData(data=SF,
+                          uncertainty=StdDevUncertainty(delta_SF),
+                          unit=u.second,
+                          meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
+    shutter_map = shutter_map.add(shutter_bias*u.second)
+
+    if verbose:
+        print('Shutter Map (min, mean, median, max, stddev) = '\
+              '{:.3f} {:.3f} {:.3f} {:.3f} {:.3f}'.format(
+              shutter_map.data.min(), shutter_map.data.mean(),
+              np.median(shutter_map.data), shutter_map.data.max(),
+              np.std(shutter_map.data) ))
+        print('Fraction of Shutter Map Pixels > 0: {:d}/{:d} = {:.3f}'.format(
+              np.sum(shutter_map.data > 0),
+              shutter_map.data.size,
+              np.sum(shutter_map.data > 0) / shutter_map.data.size))
+    if output:
+        if os.path.exists(output):
+            os.remove(output)
+        fits_ccddata_writer(shutter_map, output)
+
+    return shutter_map
+
+
+def fit_shutter_bias(combined_flats, exptimekey='EXPTIME',
+                     normalizer=lambda flat: flat.data.max(),
+                     verbose=False):
+    '''
+    Determine the shutter correction given a set of input bias subtracted flats.
+    This algorithm assumes that the input light level for all files is constant,
+    so this should be run on data such as dome flats and not twilight flats.
+
+    Parameters
+    ----------
+    combined_flats : `list` containing `~ccdproc.CCDData` objects
+        Set of bias subtracted flats of different exposure times taken under
+        constant illumination.
+
+    exptimekey : `string`, defaults to 'EXPTIME'
+        The header keyword which contains the exposure time of the image in
+        seconds.
+
+    normalizer : function, optional
+        The algorithm requires a measurement of the light levels in the images
+        which represent the maximum exposure level.  Without noise, this would
+        simply be the maximum pixel level, so this defaults to the maximum
+        pixel value in the input image.  The user may specify a different
+        function here (see Examples below).
+
+    Returns
+    -------
+    bias : `float`
+        The value (in seconds) of the bias between the fitted exposure time and
+        the exposure time listed in the header.
+    '''
+    flux = [normalizer(f) for f in combined_flats]
+    time = [f.header[exptimekey] for f in combined_flats]
+    line0 = models.Linear1D(slope=1, intercept=0)
+    fitter = fitting.LinearLSQFitter()
+    line = fitter(line0, time, flux)
+    bias = line.intercept.value/line.slope.value
+    if verbose:
+        print('Shutter Bias = {:.3f}'.format(bias))
+    return bias
+
+
+def check_shutter_bias(shutter_map, plot_histogram=False):
+    '''
+    Estimate a correction to the shutter bias value from the shutter map itself.
+    
+    If the shutter bias value is correct, then in the absence of noise, the
+    largest value in the shutter map should be zero.  With some noise, however,
+    we expect some pixels in the shutter map to be larger than 0.  To estimate
+    the shutter bias value, we postulate that the time value where the second
+    derivative of the histogram of shutter map values is maximum and the first
+    derivative is negative represents the transition from a noise dominated
+    regime to a signal dominated regime.  Thus, this time value is the
+    correction we should apply to the shutter bias value.
+
+    The binsize for the shutter_map histogram is the mean value of the
+    uncertainty divided by 2.  The signal to noise ratio for the estimate of the
+    correction to the shutter bias is simply the correction value divided by the
+    binsize.
+
+    Parameters
+    ----------
+    shutter_map : `~ccdproc.CCDData`
+        The shutter correction map to be evaluated.
+
+    Returns
+    -------
+    result : `tuple`
+        The first element of the tuple is the value in seconds of the estimated
+        shutter correction.  The second element is a boolean value indicating
+        whether the correction is considered "significant".  If this value is
+        True, then the shutter map can be considered to have passed this test,
+        if not, updating the shutter bias value and re-running the shutter map
+        algorithm is something for the user to consider.
+
+    '''
+    binsize = np.mean(shutter_map.uncertainty.array) / 2.
+    bins = np.arange(shutter_map.data.min(), shutter_map.data.max(), binsize)
+    hist, bin_edges = np.histogram(shutter_map.data, bins=bins)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2.
+
+    derivative = np.gradient(hist)
+    second_derivative = np.gradient(derivative)
+    w_neg_der = np.where(derivative < 0)[0]
+    w = w_neg_der[second_derivative[w_neg_der].argmax()]
+    correction = bin_centers[w]
+
+    if plot_histogram:
+        if type(plot_histogram) == str:
+            filename = plot_histogram
+        else:
+            filename = 'histogram.png'
+        import matplotlib as mpl
+        mpl.use('Agg')
+        from matplotlib import pyplot as plt
+        if os.path.exists(filename): os.remove(filename)
+        plt.plot(bin_centers, hist, 'k-')
+        plt.plot(bin_centers, derivative, 'g-')
+        plt.plot(bin_centers, second_derivative, 'r-')
+        plt.plot([bin_centers[w], bin_centers[w]], [0, max(hist)], 'b-', alpha=0.6)
+        plt.xlim(-0.3, -0.2)
+        plt.savefig(filename)
+
+    SNR = abs(correction)/(binsize*2.)
+
+    return correction, binsize*2., SNR < 1
 

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -246,7 +246,8 @@ def Surma1993(combined_flats, exptimekey='EXPTIME',
         which represent the maximum exposure level.  Without noise, this would
         simply be the maximum pixel level, so this defaults to the maximum
         pixel value in the input image.  The user may specify a different
-        function here (see Examples below).
+        function here.  For example: 
+        `normalizer=lambda f: median_filter(f.data, size=(10,10)).max())`
 
     output : `str`, optional
         The filename to write the output shutter map to.  This will be a FITS
@@ -263,14 +264,6 @@ def Surma1993(combined_flats, exptimekey='EXPTIME',
     -------
     shutter_map : `~ccdproc.CCDData`
         The shutter correction map in units of seconds.
-
-    Examples
-    --------
-    Calling `Surma1993` with normalizer that uses the maximum value
-    in an image that has been median filtered by a 10x10 box:
-    
-    >>> result = Surma1993(combined_flats,
-                 normalizer=lambda f: median_filter(f.data, size=(10,10)).max())
     '''
     assert 'GAIN' in combined_flats[0].header.keys()
     gain = combined_flats[0].header['GAIN']

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import astropy.units as u
 from astropy.nddata import StdDevUncertainty
+from astropy.modeling import models, fitting
 
 from .core import CCDData, subtract_bias
 from .ccddata import fits_ccddata_reader, fits_ccddata_writer
@@ -13,11 +14,61 @@ from .combiner import combine
 from .image_collection import ImageFileCollection
 
 
-def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
-                       normalizer=lambda flat: flat.data.max(),
-                       output=None):
+def fit_shutter_bias(combined_flats, exptimekey='EXPTIME',
+                     normalizer=lambda flat: flat.data.max(),
+                     verbose=False):
     '''
     Determine the shutter correction given a set of input bias subtracted flats.
+    This algorithm assumes that the input light level for all files is constant,
+    so this should be run on data such as dome flats and not twilight flats.
+
+    Parameters
+    ----------
+    combined_flats : `list` containing `~ccdproc.CCDData` objects
+        Set of bias subtracted flats of different exposure times taken under
+        constant illumination.
+
+    exptimekey : `string`, defaults to 'EXPTIME'
+        The header keyword which contains the exposure time of the image in
+        seconds.
+
+    normalizer : function, optional
+        The algorithm requires a measurement of the light levels in the images
+        which represent the maximum exposure level.  Without noise, this would
+        simply be the maximum pixel level, so this defaults to the maximum
+        pixel value in the input image.  The user may specify a different
+        function here (see Examples below).
+
+    Returns
+    -------
+    bias : `float`
+        The value (in seconds) of the bias between the fitted exposure time and
+        the exposure time listed in the header.
+    '''
+    flux = [normalizer(f) for f in combined_flats]
+    time = [f.header[exptimekey] for f in combined_flats]
+    line0 = models.Linear1D(slope=1, intercept=0)
+    fitter = fitting.LinearLSQFitter()
+    line = fitter(line0, time, flux)
+    bias = line.intercept.value/line.slope.value
+    if verbose:
+        print('Shutter Bias = {:.3f}'.format(bias))
+    return bias
+
+
+
+
+def Surma1993_algorithm(combined_flats, exptimekey='EXPTIME',
+                        shutter_bias=0,
+                        normalizer=lambda flat: flat.data.max(),
+                        verbose=False, output=None):
+    '''
+    Determine the shutter correction map given a set of input bias subtracted
+    flats.  This algorithm assumes that the header exposure time values are
+    accurate -- that they represent the maximum typical exposure time in each
+    image.  If this is not the case, then the resulting shutter correction map
+    will be incorrect.  The `fit_shutter_bias` can be used to check this
+    assumption and correct the files as neeed.
     
     Parameters
     ----------
@@ -29,6 +80,24 @@ def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
         The header keyword which contains the exposure time of the image in
         seconds.
 
+    shutter_bias=0 : `float`, optional
+        The shutter bias value in seconds.  This is the difference between the
+        header exposure time and the actual exposure time for the pixels in the
+        image which get the maximum exposure time.  This value can be measured
+        using the `fit_shutter_bias` method.
+
+    normalizer : function, optional
+        The algorithm requires a measurement of the light levels in the images
+        which represent the maximum exposure level.  Without noise, this would
+        simply be the maximum pixel level, so this defaults to the maximum
+        pixel value in the input image.  The user may specify a different
+        function here (see Examples below).
+
+    output : `str`, optional
+        The filename to write the output shutter map to.  This will be a FITS
+        file with two extensions.  The first contains the shutter map values
+        (in seconds) and the second contains the uncertainty in those values.
+
     Notes
     -----
     This code follows the implementation described in Surma, P. (1993) 
@@ -39,24 +108,29 @@ def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
     -------
     shutter_map : `~ccdproc.CCDData`
         The shutter correction map in units of seconds.
+
+    Examples
+    --------
+    Calling `Surma1993_algorithm` with normalizer that uses the maximum value
+    in an image that has been median filtered by a 10x10 box:
+    
+    >>> result = Surma1993_algorithm(combined_flats,
+                 normalizer=lambda f: median_filter(f.data, size=(10,10)).max())
     '''
     assert 'GAIN' in combined_flats[0].header.keys()
     gain = combined_flats[0].header['GAIN']
 
-#     def nflat(flat, size=(10,10)):
-#         mflat = ndimage.filters.median_filter(flat.data, size=size)
-#         print(flat.data.max(), np.percentile(flat.data, 99), mflat.max())
-#         return mflat.max()
-
-
-    a = gain*np.sum([normalizer(f) for f in combined_flats])
-    b = gain*np.sum([normalizer(f)/float(f.header[exptimekey]) for f in combined_flats])
-    c = gain*np.sum([normalizer(f)/float(f.header[exptimekey])**2 for f in combined_flats])
+    normflats = [normalizer(f) for f in combined_flats]
+    a = gain*np.sum(normflats)
+    b = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)
+                    for i,f in enumerate(combined_flats)])
+    c = gain*np.sum([normflats[i]/float(f.header[exptimekey]+shutter_bias)**2
+                    for i,f in enumerate(combined_flats)])
 
     Dijcomb = combine(combined_flats, method='average')
     Dij = gain*Dijcomb.data*len(combined_flats)
 
-    Eijm = [CCDData(data=f.data/float(f.header[exptimekey]), unit=f.unit)
+    Eijm = [CCDData(data=f.data/float(f.header[exptimekey]+shutter_bias), unit=f.unit)
             for f in combined_flats]
     Eijcomb = combine(Eijm, method='average')
     Eij = gain*Eijcomb.data*len(combined_flats)
@@ -76,6 +150,16 @@ def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
                           unit=u.second,
                           meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
 
+    if verbose:
+        print('Shutter Map (min, mean, median, max, stddev) = '\
+              '{:.3f} {:.3f} {:.3f} {:.3f} {:.3f}'.format(
+              shutter_map.data.min(), shutter_map.data.mean(),
+              np.median(shutter_map.data), shutter_map.data.max(),
+              np.std(shutter_map.data) ))
+        print('Fraction of Shutter Map Pixels > 0: {:d}/{:d} = {:.3f}'.format(
+              np.sum(shutter_map.data > 0),
+              shutter_map.data.size,
+              np.sum(shutter_map.data > 0) / shutter_map.data.size))
     if output:
         if os.path.exists(output):
             os.remove(output)
@@ -84,13 +168,79 @@ def shutter_correction_algorithm(combined_flats, exptimekey='EXPTIME',
     return shutter_map
 
 
-def calculate_shutter_correction_map(files, biases=None,
-                                     exptimekey='EXPTIME',
-                                     normalizer=lambda flat: flat.data.max(),
-                                     keywordguide = {'keyword': 'IMAGETYP',
-                                                     'flatvalue': 'Flat Field',
-                                                     'biasvalue': 'Bias Frame'},
-                                     output=None):
+def apply_shutter_map(image, shutter_map, shutter_bias=0, exptimekey='EXPTIME'):
+    exptime_map = shutter_map.add((image.header[exptimekey]+shutter_bias)*u.second)
+    result = image.divide(exptime_map)
+    return result
+
+
+def get_shutter_map(files, biases=None, normalizer=lambda flat: flat.data.max(),
+                    check_shutter_bias=True, exptimekey='EXPTIME',
+                    min_files_to_sigma_clip=5, sigma_clip_low_thresh=5,
+                    sigma_clip_high_thresh=5,
+                    keywordguide = {'keyword': 'IMAGETYP',
+                                    'flatvalue': 'Flat Field',
+                                    'biasvalue': 'Bias Frame'},
+                    verbose=False, output=None):
+    '''
+    Uses Surma1993_algorithm to determine the shutter correction map given
+    input files.  The input files are assumed to contain flat fields taken under
+    constant illumination (no twilight flats) and bias frames.
+    
+    The bias frames are median combined in to a master bias which is subtracted
+    from each flat frame.
+    
+    Any flat frames with the same exposure time are averaged (possibly with
+    sigma clipping, see min_files_to_sigma_clip) to make a master flat at each
+    exposure time.
+    
+    The resulting list of bias subtracted master flats at various exposure times
+    are passed to `Surma1993_algorithm` to determine the shutter map.
+
+    Parameters
+    ----------
+    files : `ccdproc.ImageFilecollection` or `list` or `str`
+        If input is a `ccdproc.ImageFilecollection` object, then this is used to
+        select flat and bias files.  
+        
+        If input is a list ...
+        
+        If input is a string ...
+    
+    exptimekey : `string`, defaults to 'EXPTIME'
+        The header keyword which contains the exposure time of the image in
+        seconds.
+
+    shutter_bias=0 : `float`, optional
+        The shutter bias value in seconds.  This is the difference between the
+        header exposure time and the actual exposure time for the pixels in the
+        image which get the maximum exposure time.  This value can be measured
+        using the `fit_shutter_bias` method.
+
+    normalizer : function, optional
+        The algorithm requires a measurement of the light levels in the images
+        which represent the maximum exposure level.  Without noise, this would
+        simply be the maximum pixel level, so this defaults to the maximum
+        pixel value in the input image.  The user may specify a different
+        function here (see Examples below).
+
+    output : `str`, optional
+        The filename to write the output shutter map to.  This will be a FITS
+        file with two extensions.  The first contains the shutter map values
+        (in seconds) and the second contains the uncertainty in those values.
+
+    Notes
+    -----
+    This code follows the implementation described in Surma, P. (1993) 
+    "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
+    (ISSN 0004-6361), 278, 654–658.
+
+    Returns
+    -------
+    shutter_map : `~ccdproc.CCDData`
+        The shutter correction map in units of seconds.
+
+    '''
     if type(files) is str:
         sys.exit(1)
     elif type(files) is list:
@@ -127,33 +277,22 @@ def calculate_shutter_correction_map(files, biases=None,
             # Bias subtract flats
             if len(biases) > 0:
                 flat_images = [subtract_bias(im, master_bias) for im in flat_images]
-            sigma_clip = len(flat_images) > 5  # perform sigma clipping if >5 files
+            sigma_clip = len(flat_images) > min_files_to_sigma_clip
             combined_flat = combine(flat_images, method='average',
-                                        sigma_clip=sigma_clip,
-                                        sigma_clip_low_thresh=5,
-                                        sigma_clip_high_thresh=5)
+                                    sigma_clip=sigma_clip,
+                                    sigma_clip_low_thresh=sigma_clip_low_thresh,
+                                    sigma_clip_high_thresh=sigma_clip_high_thresh)
             combined_flats.append(combined_flat)
             assert combined_flat.shape == combined_flats[0].shape
         else:
             combined_flats.append(flat_images[0])
 
-    shutter_map = shutter_correction_algorithm(combined_flats, output=output)
+    if check_shutter_bias:
+        shutter_bias = fit_shutter_bias(combined_flats, verbose=verbose)
+    else:
+        shutter_bias = 0
+    shutter_map = Surma1993_algorithm(combined_flats, normalizer=normalizer,
+                              shutter_bias=shutter_bias, output=output,
+                              verbose=verbose)
     return shutter_map
 
-
-def apply_shutter_correction(image, shutter_map, exptimekey='EXPTIME'):
-    exptime_map = shutter_map.add(image.header[exptimekey]*u.second)
-    result = image.divide(exptime_map)
-    return result
-
-
-if __name__ == '__main__':
-    filepath = '/Users/jwalawender/Data/VYSOS/ShutterMap/V5/20161027UT'
-    keywords = ['EXPTIME', 'SET-TEMP', 'CCD-TEMP', 'XBINNING', 'YBINNING', 
-                'IMAGETYP', 'OBJECT', 'DATE-OBS']
-    ifc = ImageFileCollection(location=filepath, keywords=keywords)
-    bytype = ifc.summary.group_by('IMAGETYP')
-    flats = bytype.groups[bytype.groups.keys['IMAGETYP'] == 'Flat Field']
-    biases = bytype.groups[bytype.groups.keys['IMAGETYP'] == 'Bias Frame']
-    print(flats)
-    print(biases)

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -257,7 +257,7 @@ def Surma1993(combined_flats, exptimekey='EXPTIME',
     -----
     This code follows the implementation described in Surma, P. (1993) 
     "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics
-    (ISSN 0004-6361), 278, 654–658.
+    (ISSN 0004-6361), 278, 654-658.
 
     Returns
     -------

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -2,7 +2,6 @@ from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
 
 import os
-import sys
 
 import numpy as np
 import astropy.units as u

--- a/ccdproc/shutter_correction.py
+++ b/ccdproc/shutter_correction.py
@@ -1,0 +1,111 @@
+from __future__ import (print_function, division, absolute_import,
+                        unicode_literals)
+
+import os
+
+from .core import *
+from .image_collection import ImageFileCollection
+
+
+def calculate_shutter_correction_map(files, biases=None,
+                                     exptimekey='EXPTIME',
+                                     keywordguide = {'keyword': 'IMAGETYP',
+                                                     'flatvalue': 'Flat Field',
+                                                     'biasvalue': 'Bias Frame'},
+                                     output=None):
+    if type(files) is str:
+        sys.exit(1)
+    elif type(files) is list:
+        sys.exit(1)
+    elif type(files) is ImageFileCollection:
+        pass
+    else:
+        sys.exit(1)
+
+    bytype = files.summary.group_by(keywordguide['keyword'])
+    flats = bytype.groups[bytype.groups.keys[keywordguide['keyword']]\
+                          == keywordguide['flatvalue']]
+    biases = bytype.groups[bytype.groups.keys[keywordguide['keyword']]\
+                           == keywordguide['biasvalue']]
+
+    if len(biases) > 0:
+        ## Generate master bias to subtract from each flat
+        bias_images = [fits_ccddata_reader(os.path.join(files.location, f))
+                       for f in biases['file']]
+        if len(bias_images) > 1:
+            master_bias = combine(bias_images, combine='median')
+        else:
+            master_bias = bias_images[0]
+
+    assert exptimekey in flats.keys()
+    flats = flats.group_by(exptimekey)
+    combined_flats = []
+    for exptime in flats.groups.keys[exptimekey]:
+        thisexptime = flats.groups[flats.groups.keys[exptimekey] == exptime]
+        ## Combine each group of flats with same exposure times
+        flat_images = [fits_ccddata_reader(os.path.join(files.location, f))
+                       for f in thisexptime['file']]
+        if len(flat_images) > 1:
+            # Bias subtract flats
+            if len(biases) > 0:
+                flat_images = [ccd.subtract_bias(im, master_bias) for im in flat_images]
+            sigma_clip = len(files) > 5  # perform sigma clipping if >5 files
+            combined_flat = ccd.combine(images, method='average',
+                                        sigma_clip=sigma_clip,
+                                        sigma_clip_low_thresh=5,
+                                        sigma_clip_high_thresh=5)
+            combined_flats.append(combined_flat)
+            assert combined_flat.shape == flats[0].shape
+        else:
+            combined_flats.append(flat_images[0])
+
+    def nflat(flat, delta=25):
+        nl, nc = flat.data.shape
+        normalization_factor = np.median(flat.data[nl-delta:nl+delta,nc-delta:nc+delta])
+        nflat = flat.data / normalization_factor
+        return nflat
+
+    a = gain*np.sum([nflat(f) for f in combined_flats])
+    b = gain*np.sum([nflat(f)/float(f.header[exptimekey]) for f in combined_flats])
+    c = gain*np.sum([nflat(f)/float(f.header[exptimekey])**2 for f in combined_flats])
+
+    Dijcomb = ccd.combine(combined_flats, method='average')
+    Dij = gain*Dijcomb.data*len(combined_flats)
+
+    Eijm = [ccd.CCDData(data=f.data/float(f.header[exptimekey]), unit=f.unit)
+            for f in combined_flats]
+    Eijcomb = ccd.combine(Eijm, method='average')
+    Eij = gain*Eijcomb.data*len(combined_flats)
+
+    alpha_ij = 1.0 / (a*c - b**2) * (c*Dij - b*Eij)
+    delta_alpha = np.sqrt( c / (a*c - b**2) )
+    beta_ij = 1.0 / (a*c - b**2) * (a*Eij - b*Dij)
+    delta_beta = np.sqrt( a / (a*c - b**2) )
+
+    SF = beta_ij / alpha_ij  # SF = -t_SH * (1-SH_ij) in the paper terminology
+    delta_SF = np.sqrt( (alpha_ij**-1 * delta_beta)**2 + 
+                        (beta_ij * alpha_ij**-2 * delta_alpha)**2 )
+    SNR = np.mean(abs(SF)/delta_SF)
+    print('Typical pixel SNR of correction = {:.1f}'.format(SNR))
+    ShutterMap = ccd.CCDData(data=SF, uncertainty=delta_SF, unit=u.second,
+                     meta={'SNR': (SNR, 'Mean signal to noise per pixel')})
+
+    if output:
+        if os.path.exists(output):
+            os.remove(output)
+        ccd.fits_ccddata_writer(ShutterMap, output)
+
+    return ShutterMap
+
+
+
+if __name__ == '__main__':
+    filepath = '/Users/jwalawender/Data/VYSOS/ShutterMap/V5/20161027UT'
+    keywords = ['EXPTIME', 'SET-TEMP', 'CCD-TEMP', 'XBINNING', 'YBINNING', 
+                'IMAGETYP', 'OBJECT', 'DATE-OBS']
+    ifc = ImageFileCollection(location=filepath, keywords=keywords)
+    bytype = ifc.summary.group_by('IMAGETYP')
+    flats = bytype.groups[bytype.groups.keys['IMAGETYP'] == 'Flat Field']
+    biases = bytype.groups[bytype.groups.keys['IMAGETYP'] == 'Bias Frame']
+    print(flats)
+    print(biases)

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -875,10 +875,8 @@ def test_wcs_project_onto_scale_wcs(ccd_data):
     assert new_ccd.wcs.wcs.compare(target_wcs.wcs)
 
     # Define a cutout from the new array that should match the old.
-    new_lower_bound = (np.array(new_ccd.shape) -
-                       np.array(ccd_data.shape)) / 2
-    new_upper_bound = (np.array(new_ccd.shape) +
-                       np.array(ccd_data.shape)) / 2
+    new_lower_bound = (np.array(new_ccd.shape) - np.array(ccd_data.shape)) // 2
+    new_upper_bound = (np.array(new_ccd.shape) + np.array(ccd_data.shape)) // 2
     data_cutout = new_ccd.data[new_lower_bound[0]:new_upper_bound[0],
                                new_lower_bound[1]:new_upper_bound[1]]
 
@@ -890,7 +888,7 @@ def test_wcs_project_onto_scale_wcs(ccd_data):
 
     # Mask should be true for four pixels (all nearest neighbors)
     # of the single pixel we masked initially.
-    new_center = new_ccd.wcs.wcs.crpix
+    new_center = np.array(new_ccd.wcs.wcs.crpix, dtype=int, copy=False)
     assert np.all(new_ccd.mask[new_center[0]:new_center[0]+2,
                                new_center[1]:new_center[1]+2])
 

--- a/ccdproc/tests/test_shutter_correction.py
+++ b/ccdproc/tests/test_shutter_correction.py
@@ -4,33 +4,73 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
+from astropy.extern.six import moves
+from scipy.ndimage.filters import median_filter
 
 from ..core import *
 from ..shutter_correction import *
 
-def test_shutter_correction_algorithm():
-    def model_image(exptime=1.0):
-        shape = (16,32)
-        flux = np.ones(shape)*1000
-        for line in range(flux.shape[0]):
-            flux[line,:] -= 20*line
-        exptime_arr = np.ones(shape)*exptime
-        # Model shutter takes time to open by sliding across image columns and
-        # closes instantaneously.  Leads to a 0.05 second gradient per pixel
-        for col in range(exptime_arr.shape[1]):
-            exptime_arr[:,col] -= 0.050*col
-        data = np.array(flux*exptime_arr, dtype=np.int)
-        correct_im = CCDData(flux, unit='adu',
-                             meta={'EXPTIME': exptime, 'GAIN': 1.0})
-        im = CCDData(data, unit='adu',
-                     meta={'EXPTIME': exptime, 'GAIN': 1.0})
-        return im, correct_im
 
-    input_data = [model_image(exptime=e) for e in range(2,11,2)]
+def model_image(exptime=1.0, bias=0.0, shape=(16,32), gradient=0.050):
+    '''
+    Generate simple model image data given an exposure time.
+    '''
+    flux = np.ones(shape)*1000
+    for line in range(flux.shape[0]):
+        flux[line,:] -= 20*line
+    exptime_arr = np.ones(shape)*(exptime+bias)
+    # Model shutter takes time to open by sliding across image columns and
+    # closes instantaneously.  Leads to a 0.05 second gradient per pixel.
+    for col in range(exptime_arr.shape[1]):
+        exptime_arr[:,col] -= gradient*col
+    data = np.array(flux*exptime_arr, dtype=np.int)
+    correct_im = CCDData(flux, unit='adu',
+                         meta={'EXPTIME': exptime, 'GAIN': 1.0})
+    im = CCDData(data, unit='adu',
+                 meta={'EXPTIME': exptime, 'GAIN': 1.0})
+    return im, correct_im
+
+
+def test_fit_shutter_bias():
+    shutter_bias = 0.125
+    input_data = [model_image(exptime=e, bias=shutter_bias)
+                  for e in moves.range(2,11,2)]
+    flats = [x[0] for x in input_data]
+    measured_bias = fit_shutter_bias(flats)
+    assert_almost_equal(measured_bias, shutter_bias, decimal=5)
+
+
+def test_fit_shutter_bias_with_normalizer():
+    shutter_bias = 0.125
+    input_data = [model_image(exptime=e, bias=shutter_bias, shape=(64,64), gradient=0.001)
+                  for e in moves.range(2,11,2)]
+    flats = [x[0] for x in input_data]
+    measured_bias = fit_shutter_bias(flats, verbose=True,
+        normalizer=lambda f: median_filter(f.data, size=(3,3)).max())
+    assert_almost_equal(measured_bias, shutter_bias, decimal=2)
+
+
+def test_Surma1993_algorithm():
+    input_data = [model_image(exptime=e) for e in moves.range(2,11,2)]
     flats = [x[0] for x in input_data]
     correct = [x[1] for x in input_data]
-    shutter_map = shutter_correction_algorithm(flats)
+    shutter_map = Surma1993_algorithm(flats)
     for i in range(len(flats)):
-        repaired = apply_shutter_correction(flats[i], shutter_map, exptimekey='EXPTIME')
+        repaired = apply_shutter_map(flats[i], shutter_map, exptimekey='EXPTIME')
+        assert_allclose(repaired.data, correct[i].data, rtol=1e-3)
+
+
+def test_Surma1993_algorithm_with_bias():
+    shutter_bias = 0.125
+    input_data = [model_image(exptime=e, bias=shutter_bias)
+                  for e in moves.range(2,11,2)]
+    flats = [x[0] for x in input_data]
+    correct = [x[1] for x in input_data]
+    measured_bias = fit_shutter_bias(flats)
+    assert_almost_equal(measured_bias, shutter_bias, decimal=5)
+    shutter_map = Surma1993_algorithm(flats, shutter_bias=measured_bias)
+    for i in range(len(flats)):
+        repaired = apply_shutter_map(flats[i], shutter_map,
+                         shutter_bias=measured_bias, exptimekey='EXPTIME')
         assert_allclose(repaired.data, correct[i].data, rtol=1e-3)

--- a/ccdproc/tests/test_shutter_correction.py
+++ b/ccdproc/tests/test_shutter_correction.py
@@ -68,7 +68,7 @@ def test_fit_shutter_bias_with_normalizer():
     input_data = [model_image(exptime=e, bias=shutter_bias, shape=(64,64), gradient=0.001)
                   for e in moves.range(2,11,2)]
     flats = [x[0] for x in input_data]
-    measured_bias = fit_shutter_bias(flats, verbose=True,
+    measured_bias = fit_shutter_bias(flats,
         normalizer=lambda f: median_filter(f.data, size=(3,3)).max())
     assert_almost_equal(measured_bias, shutter_bias, decimal=2)
 

--- a/ccdproc/tests/test_shutter_correction.py
+++ b/ccdproc/tests/test_shutter_correction.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# This module implements the base CCDData class.
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from ..core import *
+
+def test_shutter_correction_ifc(flatsIFC, biasesIFC):
+    pass
+
+def test_shutter_correction_ifc(flats_filenames, biases_filenames):
+    pass
+

--- a/ccdproc/tests/test_shutter_correction.py
+++ b/ccdproc/tests/test_shutter_correction.py
@@ -4,12 +4,33 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 from ..core import *
+from ..shutter_correction import *
 
-def test_shutter_correction_ifc(flatsIFC, biasesIFC):
-    pass
+def test_shutter_correction_algorithm():
+    def model_image(exptime=1.0):
+        shape = (16,32)
+        flux = np.ones(shape)*1000
+        for line in range(flux.shape[0]):
+            flux[line,:] -= 20*line
+        exptime_arr = np.ones(shape)*exptime
+        # Model shutter takes time to open by sliding across image columns and
+        # closes instantaneously.  Leads to a 0.05 second gradient per pixel
+        for col in range(exptime_arr.shape[1]):
+            exptime_arr[:,col] -= 0.050*col
+        data = np.array(flux*exptime_arr, dtype=np.int)
+        correct_im = CCDData(flux, unit='adu',
+                             meta={'EXPTIME': exptime, 'GAIN': 1.0})
+        im = CCDData(data, unit='adu',
+                     meta={'EXPTIME': exptime, 'GAIN': 1.0})
+        return im, correct_im
 
-def test_shutter_correction_ifc(flats_filenames, biases_filenames):
-    pass
-
+    input_data = [model_image(exptime=e) for e in range(2,11,2)]
+    flats = [x[0] for x in input_data]
+    correct = [x[1] for x in input_data]
+    shutter_map = shutter_correction_algorithm(flats)
+    for i in range(len(flats)):
+        repaired = apply_shutter_correction(flats[i], shutter_map, exptimekey='EXPTIME')
+        assert_allclose(repaired.data, correct[i].data, rtol=1e-3)

--- a/ccdproc/tests/test_wrapped_external_funcs.py
+++ b/ccdproc/tests/test_wrapped_external_funcs.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from astropy.nddata import StdDevUncertainty
+
+from scipy import ndimage
+
+from ..ccddata import CCDData
+from .. import core
+
+
+def test_medianfilter_correct():
+    ccd = CCDData([[2, 6, 6, 1, 7, 2, 4, 5, 9, 1],
+                   [10, 10, 9, 0, 2, 10, 8, 3, 9, 7],
+                   [2, 4, 0, 4, 4, 10, 0, 5, 6, 5],
+                   [7, 10, 8, 7, 7, 0, 5, 3, 5, 9],
+                   [9, 6, 3, 8, 6, 9, 2, 8, 10, 10],
+                   [6, 5, 1, 7, 8, 0, 8, 2, 9, 3],
+                   [0, 6, 0, 6, 3, 10, 8, 9, 7, 8],
+                   [5, 8, 3, 2, 3, 0, 2, 0, 3, 5],
+                   [9, 6, 3, 7, 1, 0, 5, 4, 8, 3],
+                   [5, 6, 9, 9, 0, 4, 9, 1, 7, 8]], unit='adu')
+    result = core.median_filter(ccd, 3)
+    assert isinstance(result, CCDData)
+    assert np.all(result.data == [[6, 6, 6, 6, 2, 4, 4, 5, 5, 7],
+                                  [4, 6, 4, 4, 4, 4, 5, 5, 5, 6],
+                                  [7, 8, 7, 4, 4, 5, 5, 5, 5, 7],
+                                  [7, 6, 6, 6, 7, 5, 5, 5, 6, 9],
+                                  [7, 6, 7, 7, 7, 6, 3, 5, 8, 9],
+                                  [6, 5, 6, 6, 7, 8, 8, 8, 8, 8],
+                                  [5, 5, 5, 3, 3, 3, 2, 7, 5, 5],
+                                  [6, 5, 6, 3, 3, 3, 4, 5, 5, 5],
+                                  [6, 6, 6, 3, 2, 2, 2, 4, 4, 5],
+                                  [6, 6, 7, 7, 4, 4, 4, 7, 7, 8]])
+    assert result.unit == 'adu'
+    assert all(getattr(result, attr) is None
+               for attr in ['mask', 'uncertainty', 'wcs', 'flags'])
+    # The following test could be deleted if log_to_metadata is also applied.
+    assert not result.meta
+
+
+def test_medianfilter_unusued():
+    ccd = CCDData(np.ones((3, 3)), unit='adu',
+                  mask=np.ones((3, 3)),
+                  uncertainty=StdDevUncertainty(np.ones((3, 3))),
+                  wcs=np.ones((3, 3)),
+                  flags=np.ones((3, 3)))
+    result = core.median_filter(ccd, 3)
+    assert isinstance(result, CCDData)
+    assert result.unit == 'adu'
+    assert all(getattr(result, attr) is None
+               for attr in ['mask', 'uncertainty', 'wcs', 'flags'])
+    # The following test could be deleted if log_to_metadata is also applied.
+    assert not result.meta
+
+
+def test_medianfilter_ndarray():
+    arr = np.random.random((5, 5))
+    result = core.median_filter(arr, 3)
+    reference = ndimage.median_filter(arr, 3)
+    # It's a wrapped function so we can use the equal comparison.
+    np.testing.assert_array_equal(result, reference)

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -328,6 +328,69 @@ image footprint. The underlying functionality is proved by the `reproject
 project`_. Please see :ref:reprojection for more details.
 
 
+Filter and Convolution
+----------------------
+
+There are several convolution and filter functions for `numpy.ndarray` across
+the scientific python packages:
+
+- ``scipy.ndimage.filters``, offers a variety of filters.
+- ``astropy.convolution``, offers some filters which also handle ``NaN`` values.
+- ``scikit-image.filters``, offers several filters which can also handle masks
+  but are mostly limited to special data types (mostly unsigned integers).
+
+For convenience one of these is also accessible through the ``ccdproc``
+package namespace which accepts `~ccdproc.CCDData` objects and then also
+returns one:
+
+- `~ccdproc.median_filter`
+
+Median Filter
++++++++++++++
+
+The median filter is especially useful if the data contains sharp noise peaks
+which should be removed rather than propagated:
+
+.. plot::
+    :include-source:
+
+    import ccdproc
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from astropy.modeling.functional_models import Gaussian2D
+    from astropy.utils.misc import NumpyRNGContext
+    from scipy.ndimage import uniform_filter
+
+    # Create some source signal
+    source = Gaussian2D(60, 70, 70, 20, 25)
+    data = source(*np.mgrid[0:250, 0:250])
+
+    # and another one
+    source = Gaussian2D(70, 150, 180, 15, 15)
+    data += source(*np.mgrid[0:250, 0:250])
+
+    # create some random signals
+    with NumpyRNGContext(1234):
+        noise = np.random.exponential(40, (250, 250))
+        # remove low signal
+        noise[noise < 100] = 0
+        data += noise
+
+    # create a CCD object based on the data
+    ccd = ccdproc.CCDData(data, unit='adu')
+
+    # Create some plots
+    fig, (ax1, ax2, ax3) = plt.subplots(1, 3)
+    ax1.set_title('Unprocessed')
+    ax1.imshow(ccd, origin='lower', interpolation='none', cmap=plt.cm.gray)
+    ax2.set_title('Mean filtered')
+    ax2.imshow(uniform_filter(ccd.data, 5), origin='lower', interpolation='none', cmap=plt.cm.gray)
+    ax3.set_title('Median filtered')
+    ax3.imshow(ccdproc.median_filter(ccd, 5), origin='lower', interpolation='none', cmap=plt.cm.gray)
+    plt.tight_layout()
+    plt.show()
+
+
 .. [1] van Dokkum, P; 2001, "Cosmic-Ray Rejection by Laplacian Edge
        Detection". The Publications of the Astronomical Society of the
        Pacific, Volume 113, Issue 789, pp. 1420-1427.


### PR DESCRIPTION
Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [x] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------

This PR is an attempt to add the ability to calculate the shutter correction map for CCDs with non-uniform shutter times (i.e. iris type shutters).  I ended up coding two algorithms.  I began after reading the Surma, P. (1993) "Shutter-free flatfielding for CCD detectors" Astronomy and Astrophysics (ISSN 0004-6361), 278, 654–658 paper.  After implementing this algorithm, I found that the assumption that there was no shutter bias to be inaccurate for some systems.  This means that the exposure time in the header might not be equal to the exposure time of the pixel(s) with the most exposure time in the array (which is the assumption in the paper).  I added a crude fix for that with the `fit_shutter_bias` function.

I later found the Galadi-Enriquez, D., Jordi, C., & Trullols, E. (1995). "Effects of Shutter Timing on CCD Photometry". IAU Symposium No. 167, 167, 327 paper.  I prefer this algorithm as it does not make the assumption about the exposure times in the header.  I've left both algorithms in place in case the Surma 1993 one becomes useful in some cases which I may not have considered.  It does have the benefit of producing an uncertainty map.

The user facing functions are `get_shutter_map` and `apply_shutter_map`.  The `get_shutter_map` function takes as input an `ImageFileCollection` and some information about how to sort those images in to biases and flats.  I thought about adding the ability to input a list of files or a string with the path to files, but I'm not sure if that would offer any additional utility, so I've left it out for now.

I'm looking for some feedback as to whether this algorithm is a good solution to this problem, does anyone have much experience with this calculation?   If anyone can do some comparison testing with other code, that would be great.