### PR TITLE
Copy meta in block_x functions

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -1148,7 +1148,7 @@ def block_reduce(ccd, block_size, func=np.sum):
     if isinstance(ccd, CCDData):
         # unit and meta "should" be unaffected by the change of shape and can
         # be copied. However wcs, mask, uncertainty should not be copied!
-        data = CCDData(data, unit=ccd.unit, meta=ccd.meta)
+        data = CCDData(data, unit=ccd.unit, meta=ccd.meta.copy())
     return data
 
 
@@ -1158,7 +1158,7 @@ def block_average(ccd, block_size):
     data = nddata_utils.block_reduce(ccd, block_size, np.mean)
     # Like in block_reduce:
     if isinstance(ccd, CCDData):
-        data = CCDData(data, unit=ccd.unit, meta=ccd.meta)
+        data = CCDData(data, unit=ccd.unit, meta=ccd.meta.copy())
     return data
 
 
@@ -1167,7 +1167,7 @@ def block_replicate(ccd, block_size, conserve_sum=True):
     data = nddata_utils.block_replicate(ccd, block_size, conserve_sum)
     # Like in block_reduce:
     if isinstance(ccd, CCDData):
-        data = CCDData(data, unit=ccd.unit, meta=ccd.meta)
+        data = CCDData(data, unit=ccd.unit, meta=ccd.meta.copy())
     return data
 
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -638,6 +638,10 @@ def test_block_reduce():
     assert ccd_summed.wcs is None
     assert ccd_summed.uncertainty is None
 
+    # Make sure meta is copied
+    ccd_summed.meta['testkw2'] = 10
+    assert 'testkw2' not in ccd.meta
+
 
 @pytest.mark.skipif(not HAS_BLOCK_X_FUNCS, reason="needs astropy >= 1.1.x")
 def test_block_average():
@@ -658,6 +662,10 @@ def test_block_average():
     assert ccd_avgd.wcs is None
     assert ccd_avgd.uncertainty is None
 
+    # Make sure meta is copied
+    ccd_avgd.meta['testkw2'] = 10
+    assert 'testkw2' not in ccd.meta
+
 
 @pytest.mark.skipif(not HAS_BLOCK_X_FUNCS, reason="needs astropy >= 1.1.x")
 def test_block_replicate():
@@ -676,6 +684,10 @@ def test_block_replicate():
     assert ccd_repl.mask is None
     assert ccd_repl.wcs is None
     assert ccd_repl.uncertainty is None
+
+    # Make sure meta is copied
+    ccd_repl.meta['testkw2'] = 10
+    assert 'testkw2' not in ccd.meta
 
 
 #test blockaveraging ndarray


### PR DESCRIPTION
For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file? - not needed because they were not released yet
- [x] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number"). - no issue posted.
- [ ] Does this PR add, rename, move or remove any existing functions or parameters? - no!

-----------------------------------------

When comparing the results to the support_nddata decorator I noticed that these functions did not copy the `meta` property. This PR fixes this and includes a regression test.