### PR TITLE
PEP 8 changes and minor change in logger

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -10,8 +10,8 @@ from collections import OrderedDict
 
 import numpy as np
 
-from astropy.nddata import NDDataArray
-from astropy.nddata.nduncertainty import StdDevUncertainty, NDUncertainty, MissingDataAssociationException
+from astropy.nddata import (NDDataArray, StdDevUncertainty, NDUncertainty,
+                            MissingDataAssociationException)
 from astropy.io import fits, registry
 from astropy import units as u
 from astropy import log

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -272,7 +272,8 @@ class ImageFileCollection(object):
         filtered_files = self.summary_info['file'].compressed()
         self.summary_info['file'].mask = current_file_mask
         if include_path:
-            filtered_files = [path.join(self._location, f) for f in filtered_files]
+            filtered_files = [path.join(self._location, f)
+                              for f in filtered_files]
         return filtered_files
 
     def refresh(self):
@@ -744,28 +745,25 @@ class ImageFileCollection(object):
         return self._generator('header',
                                do_not_scale_image_data=do_not_scale_image_data,
                                **kwd)
-    headers.__doc__ = _generator.__doc__.format(name='header',
-                                                default_scaling='True',
-                                                return_type='astropy.io.fits.Header')
+    headers.__doc__ = _generator.__doc__.format(
+        name='header', default_scaling='True',
+        return_type='astropy.io.fits.Header')
 
     def hdus(self, do_not_scale_image_data=False, **kwd):
         return self._generator('hdu',
                                do_not_scale_image_data=do_not_scale_image_data,
                                **kwd)
-    hdus.__doc__ = _generator.__doc__.format(name='HDU',
-                                             default_scaling='False',
-                                             return_type='astropy.io.fits.HDU')
+    hdus.__doc__ = _generator.__doc__.format(
+        name='HDU', default_scaling='False', return_type='astropy.io.fits.HDU')
 
     def data(self, do_not_scale_image_data=False, **kwd):
         return self._generator('data',
                                do_not_scale_image_data=do_not_scale_image_data,
                                **kwd)
-    data.__doc__ = _generator.__doc__.format(name='image',
-                                             default_scaling='False',
-                                             return_type='numpy.ndarray')
+    data.__doc__ = _generator.__doc__.format(
+        name='image', default_scaling='False', return_type='numpy.ndarray')
 
     def ccds(self, ccd_kwargs=None, **kwd):
         return self._generator('ccd', ccd_kwargs=ccd_kwargs, **kwd)
-    ccds.__doc__ = _generator.__doc__.format(name='CCDData',
-                                             default_scaling='True',
-                                             return_type='ccdproc.CCDData')
+    ccds.__doc__ = _generator.__doc__.format(
+        name='CCDData', default_scaling='True', return_type='ccdproc.CCDData')

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from functools import wraps
 import inspect
+from itertools import chain
 
 import numpy as np
 
@@ -77,14 +78,12 @@ def log_to_metadata(func):
             # Logging is not turned off, but user did not provide a value
             # so construct one.
             key = func.__name__
-            pos_args = ["{0}={1}".format(arg_name,
-                                         _replace_array_with_placeholder(arg_value))
-                        for arg_name, arg_value
-                        in zip(original_positional_args, args)]
-            kwd_args = ["{0}={1}".format(k, _replace_array_with_placeholder(v))
-                        for k, v in six.iteritems(kwd)]
-            pos_args.extend(kwd_args)
-            log_val = ", ".join(pos_args)
+            all_args = chain(zip(original_positional_args, args),
+                             six.iteritems(kwd))
+            all_args = ["{0}={1}".format(name,
+                                         _replace_array_with_placeholder(val))
+                        for name, val in all_args]
+            log_val = ", ".join(all_args)
             log_val = log_val.replace("\n", "")
             meta_dict = {key: log_val}
 


### PR DESCRIPTION
This PR mostly fixes static PEP8 linting warnings for lines that are too long.

I also changed the "Notes" section from the combiner to an "Examples" section (because it, well, just contained an example) and moved parts of the "Combiner.clip_extrema" documentation into a "Notes" section.

In `log_to_metadata` I combined handling positional and keyword arguments into one iteration instead of doing both seperatly and combining them later, functionality is the same just without the repetition.