### PR TITLE
show tutorials on the main documentation page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,12 @@ The documentation for this package is here:
   :maxdepth: 2
 
   ccdproc/install.rst
+
+.. toctree::
+  :maxdepth: 3
+
   ccdproc/index.rst
+
 .. toctree::
   :maxdepth: 1
 


### PR DESCRIPTION
This shows one more nesting of the docs-tree on the main documentation page.

I think this makes it much easier to access the relevant "tutorials":

![unbenannt](https://cloud.githubusercontent.com/assets/14200878/20930970/c039abf0-bbcf-11e6-87e5-62de1d68f87f.jpg)

Currently it's: http://ccdproc.readthedocs.io/en/latest/#documentation