### PR TITLE
Use full path in ccd generator (replaces #422)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,6 @@ Other Changes and Additions
 - ``combine`` now accepts a ``dtype`` argument which is passed to
   ``Combiner.__init__``. [#391, #392]
 
-
 Bug Fixes
 ^^^^^^^^^
 
@@ -45,6 +44,8 @@ Bug Fixes
 - Fixed ``combine`` with ``CCDData`` objects using ``StdDevUncertainty`` as
   uncertainty. [#416, #424]
 
+- ``ccd`` generator from ``ImageFileCollection`` now uses the full path to the
+  file when calling ``fits_ccddata_reader``. [#421 #422]
 
 1.1.0 (2016-08-01)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Other Changes and Additions
 - ``combine`` now accepts a ``dtype`` argument which is passed to
   ``Combiner.__init__``. [#391, #392]
 
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -697,7 +697,7 @@ class ImageFileCollection(object):
                     'header': lambda: hdulist[0].header,
                     'hdu': lambda: hdulist[0],
                     'data': lambda: hdulist[0].data,
-                    'ccd': lambda: fits_ccddata_reader(file_name, **ccd_kwargs)
+                    'ccd': lambda: fits_ccddata_reader(full_path, **ccd_kwargs)
                     }
             try:
                 yield (return_options[return_type]()  # pragma: no branch

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -657,3 +657,23 @@ class TestImageFileCollection(object):
             assert((str(hdu.header), fname) in all_elements)
         for i in range(len(collection.summary)):
             assert(collection.summary['file'][i] == collection.files[i])
+
+    def test_ccds_generator_in_different_directory(self, triage_setup, tmpdir):
+        """
+        Regression test for https://github.com/astropy/ccdproc/issues/421 in
+        which the ccds generator fails if the current working directory is
+        not the location of the ImageFileCollection.
+        """
+
+        coll = image_collection.ImageFileCollection(triage_setup.test_dir)
+
+        # The temporary directory below should be different that the collection
+        # location.
+        os.chdir(tmpdir.strpath)
+
+        # Let's make sure it is.
+        assert not os.path.samefile(os.getcwd(), coll.location)
+
+        # This generated an IOError before the issue was fixed.
+        for _ in coll.ccds(ccd_kwargs={'unit': 'adu'}):
+            pass


### PR DESCRIPTION
This is another rebase of #422 and contains the changes originally in (and discussed at) that PR.