### PR TITLE
Only check for HDUs if they are not None (fits reader)

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -615,18 +615,18 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     with fits.open(filename, **kwd) as hdus:
         hdr = hdus[hdu].header
 
-        if hdu_uncertainty in hdus:
+        if hdu_uncertainty is not None and hdu_uncertainty in hdus:
             uncertainty = StdDevUncertainty(hdus[hdu_uncertainty].data)
         else:
             uncertainty = None
 
-        if hdu_mask in hdus:
+        if hdu_mask is not None and hdu_mask in hdus:
             # Mask is saved as uint but we want it to be boolean.
             mask = hdus[hdu_mask].data.astype(np.bool_)
         else:
             mask = None
 
-        if hdu_flags in hdus:
+        if hdu_flags is not None and hdu_flags in hdus:
             raise NotImplementedError('loading flags is currently not '
                                       'supported.')
 


### PR DESCRIPTION
I've added no regression test (because `hdu_flags=None` is the default and therefore already checked in several tests) and I added no changelog entry because it shouldn't change any behaviour.

The reason this fails is because `None in HDUList` is not allowed anymore in `astropy.io.fits` but `hdu_mask`, `hdu_uncertainty` and `hdu_flags` are allowed to be `None`.

I reported the issue upstream: https://github.com/astropy/astropy/issues/5583 but I think we should change it even if it's not fixed upstream.