### PR TITLE
Using minversion for version checks and include some new 1.3 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
         # compiled during setup which takes some time.
         - python: 3.5
           env: ASTROPY_VERSION=development NUMPY_VERSION=dev
+               SETUP_CMD='test --coverage'
 
         # Do coverage tests for both latest Python versions
         - python: 3.5

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -15,16 +15,14 @@ from astropy.nddata import (NDDataArray, StdDevUncertainty, NDUncertainty,
 from astropy.io import fits, registry
 from astropy import units as u
 from astropy import log
+from astropy.utils import minversion
 from astropy.wcs import WCS
+
+_ASTROPY_LT_1_2 = not minversion("astropy", "1.2")
 
 # FIXME: Remove the content of the following "if" as soon as astropy 1.1 isn't
 # supported anymore. This is just a temporary workaround to fix the memory leak
 # described in https://github.com/astropy/astropy/issues/4825
-import astropy
-from distutils.version import LooseVersion
-
-_ASTROPY_LT_1_2 = LooseVersion(astropy.__version__) < LooseVersion('1.2')
-
 if _ASTROPY_LT_1_2:
 
     class ParentNDDataDescriptor(object):


### PR DESCRIPTION
This PR changes manual `LooseVersion` checks in `CCDData` with `astropy.utils.minversion` (more convenience) and adds two new 1.3 features:

- `astropy.io.fits.is_fits` was changed to also accept `fts` so we don't need the custom function anymore
- `astropy.io.registry` can now delay documentation updates when registering reader/writer for the registry. This may reduce the import time _slightly_.