### PR TITLE
changed unit setter 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- removed ability to set ccdata.unit to None [#451]
+
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -232,10 +232,7 @@ class CCDData(NDDataArray):
 
     @unit.setter
     def unit(self, value):
-        if value is not None:
-            self._unit = u.Unit(value)
-        else:
-            self._unit = None
+        self._unit = u.Unit(value)
 
     @property
     def shape(self):

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -37,10 +37,8 @@ if _ASTROPY_LT_1_2:
                     # to get the object the reference points to.
                     if isinstance(obj._parent_nddata, weakref.ref):
                         return obj._parent_nddata()
-                    else:
-                        log.info("parent_nddata should be a weakref to an "
-                                 "NDData object.")
-                        return obj._parent_nddata
+                    log.info("parent_nddata should be a weakref to an "
+                             "NDData object.")
                     return obj._parent_nddata
             except AttributeError:
                 raise MissingDataAssociationException(message)

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -7,7 +7,7 @@ import numpy as np
 from astropy.io import fits
 
 from astropy.tests.helper import pytest
-from astropy.nddata import StdDevUncertainty
+from astropy.nddata import StdDevUncertainty, MissingDataAssociationException
 from astropy import units as u
 from astropy.extern import six
 from astropy import log
@@ -384,6 +384,61 @@ def test_arithmetic_overload_fails(ccd_data):
         ccd_data.subtract("five")
 
 
+def test_arithmetic_no_wcs_compare():
+    ccd = CCDData(np.ones((10, 10)), unit='')
+    assert ccd.add(ccd, compare_wcs=None).wcs is None
+    assert ccd.subtract(ccd, compare_wcs=None).wcs is None
+    assert ccd.multiply(ccd, compare_wcs=None).wcs is None
+    assert ccd.divide(ccd, compare_wcs=None).wcs is None
+
+
+@pytest.mark.skipif('not ASTROPY_GT_1_2')
+def test_arithmetic_with_wcs_compare():
+    def return_diff_smaller_3(first, second):
+        return abs(first - second) <= 3
+
+    ccd1 = CCDData(np.ones((10, 10)), unit='', wcs=2)
+    ccd2 = CCDData(np.ones((10, 10)), unit='', wcs=5)
+    assert ccd1.add(ccd2, compare_wcs=return_diff_smaller_3).wcs == 2
+    assert ccd1.subtract(ccd2, compare_wcs=return_diff_smaller_3).wcs == 2
+    assert ccd1.multiply(ccd2, compare_wcs=return_diff_smaller_3).wcs == 2
+    assert ccd1.divide(ccd2, compare_wcs=return_diff_smaller_3).wcs == 2
+
+
+@pytest.mark.skipif('not ASTROPY_GT_1_2')
+def test_arithmetic_with_wcs_compare_fail():
+    def return_diff_smaller_1(first, second):
+        return abs(first - second) <= 1
+
+    ccd1 = CCDData(np.ones((10, 10)), unit='', wcs=2)
+    ccd2 = CCDData(np.ones((10, 10)), unit='', wcs=5)
+    with pytest.raises(ValueError):
+        ccd1.add(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ValueError):
+        ccd1.subtract(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ValueError):
+        ccd1.multiply(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ValueError):
+        ccd1.divide(ccd2, compare_wcs=return_diff_smaller_1).wcs
+
+
+@pytest.mark.skipif('ASTROPY_GT_1_2')
+def test_arithmetic_with_wcs_compare_fail_astropy_version():
+    def return_diff_smaller_1(first, second):
+        return abs(first - second) <= 1
+
+    ccd1 = CCDData(np.ones((10, 10)), unit='', wcs=2)
+    ccd2 = CCDData(np.ones((10, 10)), unit='', wcs=5)
+    with pytest.raises(ImportError):
+        ccd1.add(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ImportError):
+        ccd1.subtract(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ImportError):
+        ccd1.multiply(ccd2, compare_wcs=return_diff_smaller_1).wcs
+    with pytest.raises(ImportError):
+        ccd1.divide(ccd2, compare_wcs=return_diff_smaller_1).wcs
+
+
 def test_arithmetic_overload_ccddata_operand(ccd_data):
     ccd_data.uncertainty = StdDevUncertainty(np.ones_like(ccd_data))
     operand = ccd_data.copy()
@@ -725,3 +780,19 @@ def test_recognized_fits_formats_for_read_write(ccd_data, tmpdir):
         ccd_data.write(path.strpath)
         from_disk = CCDData.read(path.strpath)
         assert (ccd_data.data == from_disk.data).all()
+
+
+def test_stddevuncertainty_compat_descriptor_no_parent():
+    with pytest.raises(MissingDataAssociationException):
+        StdDevUncertainty(np.ones((10, 10))).parent_nddata
+
+
+def test_stddevuncertainty_compat_descriptor_no_weakref():
+    # TODO: Remove this test if astropy 1.0 isn't supported anymore
+    # This test might create a Memoryleak on purpose, so the last lines after
+    # the assert are IMPORTANT cleanup.
+    ccd = CCDData(np.ones((10, 10)), unit='')
+    uncert = StdDevUncertainty(np.ones((10, 10)))
+    uncert._parent_nddata = ccd
+    assert uncert.parent_nddata is ccd
+    uncert._parent_nddata = None


### PR DESCRIPTION
Removing the ability to set the unit of `CCDData` to None.    This is to make it consistent with the behavior when initiating `CCDData`.  