### PR TITLE
Handle duplicated header-keywords in ImageFileCollection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Other Changes and Additions
 Bug Fixes
 ^^^^^^^^^
 
+- ``ImageFileCollection`` now handles Headers with duplicated keywords
+  (other than ``COMMENT`` and ``HISTORY``) by ignoring all but the first. [#467]
+
 
 1.2.0 (2016-12-13)
 ------------------

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -386,7 +386,7 @@ class ImageFileCollection(object):
             k = k.lower()
 
             if k in ['comment', 'history']:
-                multi_entry_keys[k.lower()].append(str(v))
+                multi_entry_keys[k].append(str(v))
                 # Accumulate these in a separate dictionary until the
                 # end to avoid adding multiple entries to summary.
                 continue

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -349,7 +349,6 @@ class ImageFileCollection(object):
         from collections import OrderedDict
 
         def _add_val_to_dict(key, value, tbl_dict, n_previous, missing_marker):
-            key = key.lower()
             try:
                 tbl_dict[key].append(value)
             except KeyError:
@@ -379,19 +378,35 @@ class ImageFileCollection(object):
         multi_entry_keys = {'comment': [],
                             'history': []}
 
+        alreadyencountered = set()
         for k, v in six.iteritems(h):
             if k == '':
                 continue
 
-            if k.lower() in ['comment', 'history']:
+            k = k.lower()
+
+            if k in ['comment', 'history']:
                 multi_entry_keys[k.lower()].append(str(v))
                 # Accumulate these in a separate dictionary until the
                 # end to avoid adding multiple entries to summary.
                 continue
+            elif k in alreadyencountered:
+                # The "normal" multi-entries HISTORY, COMMENT and BLANK are
+                # already processed so any further duplication is probably
+                # a mistake. It would lead to problems in ImageFileCollection
+                # to add it as well, so simply ignore those.
+                warnings.warn(
+                    'Header from file "{f}" contains multiple entries for {k},'
+                    ' the pair "{k}={v}" will be ignored.'
+                    ''.format(k=k, v=v, f=file_name),
+                    UserWarning)
+                continue
             else:
-                val = v
+                # Add the key to the already encountered keys so we don't add
+                # it more than once.
+                alreadyencountered.add(k)
 
-            _add_val_to_dict(k, val, summary, n_previous, missing_marker)
+            _add_val_to_dict(k, v, summary, n_previous, missing_marker)
 
         for k, v in six.iteritems(multi_entry_keys):
             if v:

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -657,6 +657,20 @@ class TestImageFileCollection(object):
         for i in range(len(collection.summary)):
             assert(collection.summary['file'][i] == collection.files[i])
 
+    def test_duplicate_keywords(self, triage_setup):
+        # Make sure duplicated keywords don't make the imagefilecollection
+        # fail.
+        hdu = fits.PrimaryHDU()
+        hdu.data = np.zeros((5, 5))
+        hdu.header['stupid'] = 'fun'
+        hdu.header.append(('stupid', 'nofun'))
+
+        hdu.writeto(os.path.join(triage_setup.test_dir, 'duplicated.fits'))
+
+        ic = image_collection.ImageFileCollection(triage_setup.test_dir,
+                                                  keywords='*')
+        assert 'stupid' in ic.summary.colnames
+
     def test_ccds_generator_in_different_directory(self, triage_setup, tmpdir):
         """
         Regression test for https://github.com/astropy/ccdproc/issues/421 in

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -670,6 +670,8 @@ class TestImageFileCollection(object):
         ic = image_collection.ImageFileCollection(triage_setup.test_dir,
                                                   keywords='*')
         assert 'stupid' in ic.summary.colnames
+        assert 'fun' in ic.summary['stupid']
+        assert 'nofun' not in ic.summary['stupid']
 
     def test_ccds_generator_in_different_directory(self, triage_setup, tmpdir):
         """


### PR DESCRIPTION
Checklist:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you add a regression test?
- [x] Fixes #464 and Closes #465 
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

This implements option 3 from https://github.com/astropy/ccdproc/issues/464#issuecomment-285733207:

> Ignore these duplicate entries with a warning.

I haven't implemented a check if these entries are equal but the warning includes a message about the file and the ignored keyword value pair. Is that enough information?

@janga1997 I hope you don't mind that I made another pull request. I started reviewing #465 but that did not fix the bug and introduced a lot of new bugs.