### PR TITLE
Remove conda-forge channel from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
       CONDA_DEPENDENCIES: "scipy astroscrappy reproject scikit-image"
       PIP_DEPENDENCIES: ""
-      CONDA_CHANNELS: "astropy conda-forge"
+      CONDA_CHANNELS: "astropy"
 
   matrix:
 


### PR DESCRIPTION
With the 1.3.1 astropy release the AppVeyor test should pass for 3.6 and numpy 1.12

Fixes #472 