### PR TITLE
Add Unix-style filename inclusion/exclusion to imagecollection

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -70,6 +70,17 @@ class ImageFileCollection(object):
     """
     def __init__(self, location=None, keywords=None, info_file=None,
                  filenames=None, glob_include=None, glob_exclude=None):
+
+        # Include or exclude files from the collection based on glob pattern
+        # matching - has to go above call to _get_files()
+        if glob_exclude is not None:
+            glob_exclude = str(glob_exclude) # some minimal validation
+        self.glob_exclude = glob_exclude
+
+        if glob_include is not None:
+            glob_include = str(glob_include)
+        self.glob_include = glob_include
+
         self._location = location
         self._filenames = filenames
         self._files = []
@@ -106,16 +117,6 @@ class ImageFileCollection(object):
                                    info_path)
                 else:
                     raise
-
-        # Include or exclude files from the collection based on glob pattern
-        # matching
-        if glob_exclude is not None:
-            glob_exclude = str(glob_exclude) # some minimal validation
-        self.glob_exclude = glob_exclude
-
-        if glob_include is not None:
-            glob_include = str(glob_include)
-        self.glob_include = glob_include
 
         # Used internally to keep track of whether the user asked for all
         # keywords or a specific list. The keywords setter takes care of

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -69,7 +69,7 @@ class ImageFileCollection(object):
         value.
     """
     def __init__(self, location=None, keywords=None, info_file=None,
-                 filenames=None):
+                 filenames=None, glob_include=None, glob_exclude=None):
         self._location = location
         self._filenames = filenames
         self._files = []
@@ -106,6 +106,16 @@ class ImageFileCollection(object):
                                    info_path)
                 else:
                     raise
+
+        # Include or exclude files from the collection based on glob pattern
+        # matching
+        if glob_exclude is not None:
+            glob_exclude = str(glob_exclude) # some minimal validation
+        self.glob_exclude = glob_exclude
+
+        if glob_include is not None:
+            glob_include = str(glob_include)
+        self.glob_include = glob_include
 
         # Used internally to keep track of whether the user asked for all
         # keywords or a specific list. The keywords setter takes care of
@@ -330,7 +340,22 @@ class ImageFileCollection(object):
             else:
                 files = self._filenames
         else:
-            files = self._fits_files_in_directory()
+            _files = self._fits_files_in_directory()
+
+            files = []
+            for fn in _files:
+
+                # logic is backwards because we continue if fnmatch()
+                #   doesn't evaluate
+                if (self.glob_include is not None and
+                    not fnmatch.fnmatch(fn, self.glob_include)):
+                    continue
+
+                if (self.glob_exclude is not None and
+                    fnmatch.fnmatch(fn, self.glob_exclude)):
+                    continue
+
+                files.append(fn)
 
         return files
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -62,6 +62,16 @@ class ImageFileCollection(object):
         The filenames are assumed to be in ``location``.
         Default is ``None``.
 
+    glob_include: str, optional
+        Unix-style filename pattern to select filenames to include in the file
+        collection. Can be used in conjunction with ``glob_exclude`` to
+        easily select subsets of files in the target directory.
+
+    glob_exclude: str, optional
+        Unix-style filename pattern to select filenames to exclude from the
+        file collection. Can be used in conjunction with ``glob_include`` to
+        easily select subsets of files in the target directory.
+
     Raises
     ------
     ValueError

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -700,3 +700,22 @@ class TestImageFileCollection(object):
         # This generated an IOError before the issue was fixed.
         for _ in coll.ccds(ccd_kwargs={'unit': 'adu'}):
             pass
+
+    def test_glob_matching(self, triage_setup):
+        # We'll create two files with strange names to test glob
+        #   includes / excludes
+        one = fits.PrimaryHDU()
+        one.data = np.zeros((100, 100))
+        one.header[''] = 'whatever'
+
+        one.writeto(os.path.join(triage_setup.test_dir, 'SPAM_stuff.fits'))
+        one.writeto(os.path.join(triage_setup.test_dir, 'SPAM_other_stuff.fits'))
+
+        coll = image_collection.ImageFileCollection(triage_setup.test_dir,
+                                                    glob_include='SPAM*')
+        assert len(coll.files) == 2
+
+        coll = image_collection.ImageFileCollection(triage_setup.test_dir,
+                                                    glob_include='SPAM*',
+                                                    glob_exclude='*other*')
+        assert len(coll.files) == 1

--- a/docs/ccdproc/image_management.rst
+++ b/docs/ccdproc/image_management.rst
@@ -14,7 +14,8 @@ a directory that contains FITS images.
 
 The class :class:`~ccdproc.image_collection.ImageFileCollection` is meant to
 make working with a directory of FITS images easier by allowing you select the
-files you act on based on the values of FITS keywords in their headers.
+files you act on based on the values of FITS keywords in their headers or based
+on Unix shell-style filename matching.
 
 It is initialized with the name of a directory containing FITS images and a
 list of FITS keywords you want the
@@ -29,6 +30,13 @@ You can use the wildcard ``*`` in place of a list to indicate you want the
 collection to use all keywords in the headers::
 
     >>> ic_all = ImageFileCollection('.', keywords='*')
+
+You can indicate filename patterns to include or exclude using Unix shell-style
+expressions. For example, to include all filenames that begin with ``1d_`` but
+not ones that include the word ``bad``, you could do::
+
+    >>> ic_all = ImageFileCollection('.', glob_include='1d_*',
+    ...                              glob_exclude='*bad*')
 
 Most of the useful interaction with the image collection is via its
 ``.summary`` property, a :class:`~astropy.table.Table` of the value of each keyword for each


### PR DESCRIPTION
- [ ] Did you add yourself to the "Authors.rst" file?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [x] Did you include tests for the new functionality?
- [x] Does this PR add, rename, move or remove any existing functions or parameters?

I've been using `ccdproc` quite a bit lately for doing spectroscopic data reduction. I've found that I often want to be able to select subsets of my data based on filename pattern matching to test out certain pieces of the reduction pipeline, so I had implemented something like the features in this PR locally on a subclass of `ImageFileCollection`. If you like it, I'll add a changelog entry.