### PR TITLE
remove deprecated summary_info propery of ImageFileCollection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Other Changes and Additions
 
 - removed ability to set ccdata.unit to None [#451]
 
+- deprecated ``summary_info`` property of ``ImageFileCollection`` now raises
+  a deprecation warning. [#486]
+
 
 Bug Fixes
 ^^^^^^^^^


### PR DESCRIPTION
- [x] Did you add an entry to the "Changes.rst" file?
- [x] Does this PR add, rename, move or remove any existing functions or parameters?

The attribute is marked as deprecated in the docstring and it was since the `ImageFileCollection` was implemented in #217 . I had to change quite a lot to actually remove it.