### PR TITLE
gain_corrected in ccd_process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,9 +13,8 @@ New Features
 - Add ``bitfield_to_boolean_mask`` function to convert a ``bitfield`` to a
   boolean mask (following the numpy conventions). [#460]
 
-- Added ``gain_corrected`` option in ccd_process so that 
-  calibration files do not need to previously been gain
-  corrected [#491]
+- Added ``gain_corrected`` option in ccd_process so that calibration 
+  files do not need to previously been gain corrected [#491]
 
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New Features
 - Added ``glob_include`` and ``glob_exclude`` parameter to
   ``ImageFileCollection`` [#484]
 
+- Added ``gain_corrected`` option in ccd_process so that 
+  calibration files do not need to previously been gain
+  corrected 
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -166,7 +166,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         Default is ``False``.
 
     gain_corrected : bool, optional
-        If True, the ``master_bias``, ``master_flat``, and ``dark_frame`` 
+        If True, the ``master_bias``, ``master_flat``, and ``dark_frame``
         have already been gain corrected.  Default is ``True``.
 
     Returns

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -165,7 +165,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         Default is ``False``.
 
     gain_corrected : bool, optional
-        If True, the calibration frames have already been gain. 
+        If True, the calibration frames have already been gain corrected.
         Default is ``True``.
 
     Returns

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -98,19 +98,19 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
     master_bias : `~ccdproc.CCDData` or None, optional
         A master bias frame to be subtracted from ccd. The unit of the
         master bias frame should match the unit of the image **after
-        gain correction**.
+        gain correction** if ``gain_corrected`` is True.
         Default is ``None``.
 
     dark_frame : `~ccdproc.CCDData` or None, optional
         A dark frame to be subtracted from the ccd. The unit of the
         master dark frame should match the unit of the image **after
-        gain correction**.
+        gain correction** if ``gain_corrected`` is True.
         Default is ``None``.
 
     master_flat : `~ccdproc.CCDData` or None, optional
         A master flat frame to be divided into ccd. The unit of the
         master flat frame should match the unit of the image **after
-        gain correction**.
+        gain correction** if ``gain_corrected`` is True.
         Default is ``None``.
 
     bad_pixel_mask : `numpy.ndarray` or None, optional
@@ -166,8 +166,8 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         Default is ``False``.
 
     gain_corrected : bool, optional
-        If True, the calibration frames have already been gain corrected.
-        Default is ``True``.
+        If True, the ``master_bias``, ``master_flat``, and ``dark_frame`` 
+        have already been gain corrected.  Default is ``True``.
 
     Returns
     -------
@@ -231,7 +231,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
     if not (gain is None or isinstance(gain, Quantity)):
         raise TypeError('gain is not None or astropy.units.Quantity.')
 
-    if isinstance(gain, Quantity) and gain_corrected:
+    if gain is not None and gain_corrected:
         nccd = gain_correct(nccd, gain)
 
     # subtracting the master bias
@@ -266,7 +266,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
             'master_flat is not None or a CCDData object.')
 
     # apply the gain correction only at the end if gain_corrected is False
-    if isinstance(gain, Quantity) and gain_corrected is False:
+    if gain is not None and not gain_corrected:
         nccd = gain_correct(nccd, gain)
 
     return nccd

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -915,3 +915,39 @@ def test_ccd_process():
     assert(occd.unit == u.electron)
     # Make sure the original keyword is still present. Regression test for #401
     assert occd.meta['testkw'] == 100
+
+def test_ccd_process_gain_corrected():
+    # test the through ccd_process
+    ccd_data = CCDData(10.0 * np.ones((100, 100)), unit=u.adu)
+    ccd_data.data[:, -10:] = 2
+    ccd_data.meta['testkw'] = 100
+
+    mask = np.zeros((100, 90))
+
+    masterbias = CCDData(4.0 * np.ones((100, 90)), unit=u.adu)
+    masterbias.uncertainty = StdDevUncertainty(np.zeros((100, 90)))
+
+    dark_frame = CCDData(0.0 * np.ones((100, 90)), unit=u.adu)
+    dark_frame.uncertainty = StdDevUncertainty(np.zeros((100, 90)))
+
+    masterflat = CCDData(5.0 * np.ones((100, 90)), unit=u.adu)
+    masterflat.uncertainty = StdDevUncertainty(np.zeros((100, 90)))
+
+    occd = ccd_process(ccd_data, oscan=ccd_data[:, -10:], trim='[1:90,1:100]',
+                       error=True, master_bias=masterbias,
+                       master_flat=masterflat, dark_frame=dark_frame,
+                       bad_pixel_mask=mask, gain=0.5 * u.electron/u.adu,
+                       readnoise=5**0.5 * u.electron, oscan_median=True,
+                       dark_scale=False, dark_exposure=1.*u.s,
+                       data_exposure=1.*u.s, gain_corrected=False)
+
+    # final results should be (10 - 2) / 2.0 - 2 = 2
+    # error should be (4 + 5)**0.5 / 0.5  = 3.0
+
+    np.testing.assert_array_equal(2.0 * np.ones((100, 90)), occd.data)
+    np.testing.assert_almost_equal(3.0 * np.ones((100, 90)),
+                                  occd.uncertainty.array)
+    np.testing.assert_array_equal(mask, occd.mask)
+    assert(occd.unit == u.electron)
+    # Make sure the original keyword is still present. Regression test for #401
+    assert occd.meta['testkw'] == 100

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -917,7 +917,7 @@ def test_ccd_process():
     assert occd.meta['testkw'] == 100
 
 def test_ccd_process_gain_corrected():
-    # test the through ccd_process
+    # test the through ccd_process with gain_corrected as False
     ccd_data = CCDData(10.0 * np.ones((100, 100)), unit=u.adu)
     ccd_data.data[:, -10:] = 2
     ccd_data.meta['testkw'] = 100


### PR DESCRIPTION
This Fixes #490 and adds the option to include ``gain_corrected``.  If set to False, the calibrations files will be assumed to be un-gained corrected and the gain correction will only occur after those corrections are applied to the gain correction



For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [x] Did you include tests for the new functionality?
- [x] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
Default value for ``gain_corrected`` is True, which is inline with backward compatibility