### PR TITLE
Fix failures in astropy-dev tests

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -631,7 +631,7 @@ class ImageFileCollection(object):
         # be omitted, hence use ~matches.
         logger.debug('Matches: %s', matches)
         self.summary['file'].mask = ma.nomask
-        self.summary['file'][~matches] = ma.masked
+        self.summary['file'].mask[~matches] = True
 
     def _fits_files_in_directory(self, extensions=None,
                                  compressed=True):

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -10,7 +10,6 @@ from astropy.stats import median_absolute_deviation as mad
 
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.compat import NUMPY_LT_1_9
 from astropy.wcs import WCS
 
 from ..ccddata import CCDData
@@ -335,8 +334,6 @@ def test_combine_limitedmem_fitsimages():
 
 #test combiner convenience function reads fits file and
 # and combine as expected when asked to run in limited memory with scaling
-@pytest.mark.xfail(NUMPY_LT_1_9,
-                   reason="numpy < 1.9 loses precision in np.ma.average")
 def test_combine_limitedmem_scale_fitsimages():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
     ccd = CCDData.read(fitsfile, unit=u.adu)


### PR DESCRIPTION
Closes #496


This fixes the issue in our tests with astropy dev -- the definition of `NUMPY_LT_1_9` was removed recently. It was used only to skip a test in one case that we no longer test against anyway...