### PR TITLE
Remove several properties already present in NDDataArray

### DIFF
--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -235,18 +235,6 @@ class CCDData(NDDataArray):
         self._unit = u.Unit(value)
 
     @property
-    def shape(self):
-        return self.data.shape
-
-    @property
-    def size(self):
-        return self.data.size
-
-    @property
-    def dtype(self):
-        return self.data.dtype
-
-    @property
     def header(self):
         return self._meta
 

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -32,6 +32,11 @@ def test_ccddata_must_have_unit():
         CCDData(np.zeros([100, 100]))
 
 
+def test_ccddata_unit_cannot_be_set_to_none(ccd_data):
+    with pytest.raises(TypeError):
+        ccd_data.unit = None
+
+
 def test_ccddata_meta_header_conflict():
     with pytest.raises(ValueError) as exc:
         CCDData([1, 2, 3], unit='', meta={1: 1}, header={2: 2})


### PR DESCRIPTION
This PR removes several properties that are already defined in `NDDataArray`. The only one that differed in any way from `NDDataArray` is `unit`. It's setter in `NDDataArray` is at https://github.com/astropy/astropy/blob/master/astropy/nddata/compat.py#L146

I'm going to hold off on opening the PR to astropy until this is merged.