### PR TITLE
fix unneeded compatibility import

### DIFF
--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import gzip
 from tempfile import mkdtemp
 import os
 from shutil import rmtree
@@ -13,7 +14,6 @@ from astropy import units as u
 from astropy.utils import NumpyRNGContext
 from astropy.io import fits
 
-from astropy.utils.compat import gzip
 
 from ..ccddata import CCDData
 


### PR DESCRIPTION
This fixes a failure with astropy dev because we still imported the (now removed: https://github.com/astropy/astropy/pull/6164) `astropy.utils.compat.gzip` module.