### PR TITLE
Use build_docs instead of the deprecated build_sphinx in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 
         # Check for sphinx doc build warnings
         - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
+          env: SETUP_CMD='build_docs -w'
 
         # Check compatibility with the current astropy LTS release
         - python: 2.7


### PR DESCRIPTION
While looking into a failure with the sphinx build I noticed that we use the deprecated `build_sphinx` command there: https://travis-ci.org/astropy/ccdproc/jobs/255026568#L621