### PR TITLE
Include a numpy 1.12 test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,11 @@ matrix:
         - python: 3.4
           env: NUMPY_VERSION=1.10
 
-        # Try older numpy, python versions
         - python: 3.5
           env: NUMPY_VERSION=1.11
+
+        - python: 3.6
+          env: NUMPY_VERSION=1.12
 
         # Try numpy pre-release version. This runs only when a pre-release
         # is available on pypi.


### PR DESCRIPTION
NumPy 1.13 has been released for a few weeks so don't test against NumPy 1.12. 

In case we want to drop NumPy 1.10 support (or at least don't test against it) it could also be shuffled:

- Python 3.4 + NumPy 1.11 (previously NumPy 1.10)
- Python 3.5 + NumPy 1.12 (previously NumPy 1.11)