### PR TITLE
Raise an exception instead of silently ignoring overwrite in ccd generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,10 @@ Bug Fixes
 - ``ImageFileCollection`` now handles Headers with duplicated keywords
   (other than ``COMMENT`` and ``HISTORY``) by ignoring all but the first. [#467]
 
+- The ``ccd`` method of ``ImageFileCollection`` will raise an
+  ``NotImplementedError`` in case the parameter ``overwrite=True`` or
+  ``clobber=True`` is used instead of silently ignoring the parameter.
+
 
 1.2.0 (2016-12-13)
 ------------------

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -895,6 +895,9 @@ class ImageFileCollection(object):
         name='image', default_scaling='False', return_type='numpy.ndarray')
 
     def ccds(self, ccd_kwargs=None, **kwd):
+        if kwd.get('clobber') or kwd.get('overwrite'):
+            raise NotImplementedError(
+                "overwrite=True (or clobber=True) is not supported for CCDs.")
         return self._generator('ccd', ccd_kwargs=ccd_kwargs, **kwd)
     ccds.__doc__ = _generator.__doc__.format(
         name='CCDData', default_scaling='True', return_type='ccdproc.CCDData')

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -789,6 +789,21 @@ class TestImageFileCollection(object):
         for _ in coll.ccds(ccd_kwargs={'unit': 'adu'}):
             pass
 
+    def test_ccds_generator_does_not_support_overwrite(self, triage_setup):
+        """
+        CCDData objects have several attributes that make it hard to
+        reliably support overwriting. For example in what extension should
+        mask, uncertainty be written?
+        Also CCDData doesn't explicitly support in-place operations so it's to
+        easy to create a new CCDData object inadvertantly and all modifications
+        might be lost.
+        """
+        ic = ImageFileCollection(triage_setup.test_dir)
+        with pytest.raises(NotImplementedError):
+            ic.ccds(overwrite=True)
+        with pytest.raises(NotImplementedError):
+            ic.ccds(clobber=True)
+
     def test_glob_matching(self, triage_setup):
         # We'll create two files with strange names to test glob
         #   includes / excludes


### PR DESCRIPTION
It might make sense to think how one could use ``overwrite=True`` with the `ccds` generator in `ImageFileCollection` but given that there could be multiple extensions involved (which the generator doesn't know about) and because `CCDData` doesn't support many in-place operations that won't be straight-forward. So I'm not sure if #453 can be closed afterwards.

However currently the parameter is silently ignored without warning or exception which this PR fixes by raising a `NotImplementedError`.