### PR TITLE
Use CCDData from astropy.nddata if astropy version >= 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,13 @@ Other Changes and Additions
 - deprecated ``summary_info`` property of ``ImageFileCollection`` now raises
   a deprecation warning. [#486]
 
+- Logging will include the abbreviation even if the ``meta`` attribute of
+  the processed ``CCDData`` isn't a ``fits.Header``. [#528]
+
+- The ``CCDData`` class and the functions ``fits_ccddata_reader`` and
+  ``fits_ccddata_writer`` will be imported from ``astropy.nddata`` if
+  astropy >= 2.0 is installed (instead of the one defined in ``ccdproc``). [#528]
+
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Other Changes and Additions
   ``fits_ccddata_writer`` will be imported from ``astropy.nddata`` if
   astropy >= 2.0 is installed (instead of the one defined in ``ccdproc``). [#528]
 
+- Building the documentation requires astropy >= 2.0. [#528]
+
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -20,6 +20,7 @@ from astropy.wcs import WCS
 
 _ASTROPY_LT_1_2 = not minversion("astropy", "1.2")
 _ASTROPY_LT_1_3 = not minversion("astropy", "1.3")
+_ASTROPY_GT_2_0 = minversion("astropy", "2.0")
 
 # FIXME: Remove the content of the following "if" as soon as astropy 1.1 isn't
 # supported anymore. This is just a temporary workaround to fix the memory leak
@@ -795,3 +796,8 @@ try:
     CCDData.write.__doc__ = fits_ccddata_writer.__doc__
 except AttributeError:
     CCDData.write.__func__.__doc__ = fits_ccddata_writer.__doc__
+
+# CCDData moved to astropy core so we just import them from there (overwriting)
+# the classes defined here.
+if _ASTROPY_GT_2_0:
+    from astropy.nddata import fits_ccddata_reader, fits_ccddata_writer, CCDData

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -20,7 +20,7 @@ class Combiner(object):
     """
     A class for combining CCDData objects.
 
-    The Combiner class is used to combine together `~ccdproc.CCDData` objects
+    The Combiner class is used to combine together `~astropy.nddata.CCDData` objects
     including the method for combining the data, rejecting outlying data,
     and weighting used for combining frames.
 
@@ -37,13 +37,13 @@ class Combiner(object):
     Raises
     ------
     TypeError
-        If the ``ccd_list`` are not `~ccdproc.CCDData` objects, have different
+        If the ``ccd_list`` are not `~astropy.nddata.CCDData` objects, have different
         units, or are different shapes.
 
     Examples
     --------
     The following is an example of combining together different
-    `~ccdproc.CCDData` objects::
+    `~astropy.nddata.CCDData` objects::
 
         >>> import numpy as np
         >>> import astropy.units as u
@@ -116,7 +116,7 @@ class Combiner(object):
     @property
     def weights(self):
         """
-        Weights used when combining the `~ccdproc.CCDData` objects.
+        Weights used when combining the `~astropy.nddata.CCDData` objects.
 
         Parameters
         ----------
@@ -311,7 +311,7 @@ class Combiner(object):
         """
         Median combine a set of arrays.
 
-        A `~ccdproc.CCDData` object is returned with the data property set to
+        A `~astropy.nddata.CCDData` object is returned with the data property set to
         the median of the arrays. If the data was masked or any data have been
         rejected, those pixels will not be included in the median. A mask will
         be returned, and if a pixel has been rejected in all images, it will be
@@ -335,7 +335,7 @@ class Combiner(object):
 
         Returns
         -------
-        combined_image: `~ccdproc.CCDData`
+        combined_image: `~astropy.nddata.CCDData`
             CCDData object based on the combined input of CCDData objects.
 
         Warnings
@@ -387,7 +387,7 @@ class Combiner(object):
         """
         Average combine together a set of arrays.
 
-        A `~ccdproc.CCDData` object is returned with the data property
+        A `~astropy.nddata.CCDData` object is returned with the data property
         set to the average of the arrays. If the data was masked or any
         data have been rejected, those pixels will not be included in the
         average. A mask will be returned, and if a pixel has been
@@ -410,7 +410,7 @@ class Combiner(object):
 
         Returns
         -------
-        combined_image: `~ccdproc.CCDData`
+        combined_image: `~astropy.nddata.CCDData`
             CCDData object based on the combined input of CCDData objects.
         """
         if scale_to is not None:
@@ -452,7 +452,7 @@ class Combiner(object):
         """
         Sum combine together a set of arrays.
 
-        A `~ccdproc.CCDData` object is returned with the data property
+        A `~astropy.nddata.CCDData` object is returned with the data property
         set to the sum of the arrays. If the data was masked or any
         data have been rejected, those pixels will not be included in the
         sum. A mask will be returned, and if a pixel has been
@@ -478,7 +478,7 @@ class Combiner(object):
 
         Returns
         -------
-        combined_image: `~ccdproc.CCDData`
+        combined_image: `~astropy.nddata.CCDData`
             CCDData object based on the combined input of CCDData objects.
         """
         if scale_to is not None:
@@ -530,7 +530,7 @@ def combine(img_list, output_file=None,
     Parameters
     -----------
     img_list : `numpy.ndarray`, list or str
-        A list of fits filenames or `~ccdproc.CCDData` objects that will be
+        A list of fits filenames or `~astropy.nddata.CCDData` objects that will be
         combined together. Or a string of fits filenames separated by comma
         ",".
 
@@ -620,11 +620,11 @@ def combine(img_list, output_file=None,
         sum combine, otherwise use the function provided.
         Default is ``None``.
 
-    ccdkwargs : Other keyword arguments for `ccdproc.fits_ccddata_reader`.
+    ccdkwargs : Other keyword arguments for `astropy.nddata.fits_ccddata_reader`.
 
     Returns
     -------
-    combined_image : `~ccdproc.CCDData`
+    combined_image : `~astropy.nddata.CCDData`
         CCDData object based on the combined input of CCDData objects.
     """
     if not isinstance(img_list, list):

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -71,14 +71,14 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
     * subtraction of a dark frame (:func:`subtract_dark`)
     * correction of flat field (:func:`flat_correct`)
 
-    The task returns a processed `~ccdproc.CCDData` object.
+    The task returns a processed `~astropy.nddata.CCDData` object.
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Frame to be reduced.
 
-    oscan : `~ccdproc.ccddata.CCDData`, str or None, optional
+    oscan : `~astropy.nddata.CCDData`, str or None, optional
         For no overscan correction, set to None. Otherwise provide a region
         of ccd from which the overscan is extracted, using the FITS
         conventions for index order and index start, or a
@@ -95,19 +95,19 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         If True, create an uncertainty array for ccd.
         Default is ``False``.
 
-    master_bias : `~ccdproc.CCDData` or None, optional
+    master_bias : `~astropy.nddata.CCDData` or None, optional
         A master bias frame to be subtracted from ccd. The unit of the
         master bias frame should match the unit of the image **after
         gain correction** if ``gain_corrected`` is True.
         Default is ``None``.
 
-    dark_frame : `~ccdproc.CCDData` or None, optional
+    dark_frame : `~astropy.nddata.CCDData` or None, optional
         A dark frame to be subtracted from the ccd. The unit of the
         master dark frame should match the unit of the image **after
         gain correction** if ``gain_corrected`` is True.
         Default is ``None``.
 
-    master_flat : `~ccdproc.CCDData` or None, optional
+    master_flat : `~astropy.nddata.CCDData` or None, optional
         A master flat frame to be divided into ccd. The unit of the
         master flat frame should match the unit of the image **after
         gain correction** if ``gain_corrected`` is True.
@@ -171,7 +171,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
 
     Returns
     -------
-    occd : `~ccdproc.CCDData`
+    occd : `~astropy.nddata.CCDData`
         Reduded ccd.
 
     Examples
@@ -282,7 +282,7 @@ def create_deviation(ccd_data, gain=None, readnoise=None):
 
     Parameters
     ----------
-    ccd_data : `~ccdproc.CCDData`
+    ccd_data : `~astropy.nddata.CCDData`
         Data whose deviation will be calculated.
 
     gain : `~astropy.units.Quantity` or None, optional
@@ -306,7 +306,7 @@ def create_deviation(ccd_data, gain=None, readnoise=None):
 
     Returns
     -------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         CCDData object with uncertainty created; uncertainty is in the same
         units as the data in the parameter ``ccd_data``.
 
@@ -347,10 +347,10 @@ def subtract_overscan(ccd, overscan=None, overscan_axis=1, fits_section=None,
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Data to have overscan frame corrected.
 
-    overscan : `~ccdproc.CCDData` or None, optional
+    overscan : `~astropy.nddata.CCDData` or None, optional
         Slice from ``ccd`` that contains the overscan. Must provide either
         this argument or ``fits_section``, but not both.
         Default is ``None``.
@@ -390,7 +390,7 @@ def subtract_overscan(ccd, overscan=None, overscan_axis=1, fits_section=None,
 
     Returns
     -------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         CCDData object with overscan subtracted.
 
     Notes
@@ -484,7 +484,7 @@ def trim_image(ccd, fits_section=None):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         CCD image to be trimmed, sliced if desired.
 
     fits_section : str or None, optional
@@ -496,7 +496,7 @@ def trim_image(ccd, fits_section=None):
 
     Returns
     -------
-    trimmed_ccd : `~ccdproc.CCDData`
+    trimmed_ccd : `~astropy.nddata.CCDData`
         Trimmed image.
 
     Examples
@@ -547,17 +547,17 @@ def subtract_bias(ccd, master):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Image from which bias will be subtracted.
 
-    master : `~ccdproc.CCDData`
+    master : `~astropy.nddata.CCDData`
         Master image to be subtracted from ``ccd``.
 
     {log}
 
     Returns
     -------
-    result : `~ccdproc.CCDData`
+    result : `~astropy.nddata.CCDData`
         CCDData object with bias subtracted.
     """
 
@@ -584,10 +584,10 @@ def subtract_dark(ccd, master, dark_exposure=None, data_exposure=None,
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Image from which dark will be subtracted.
 
-    master : `~ccdproc.CCDData`
+    master : `~astropy.nddata.CCDData`
         Dark image.
 
     dark_exposure : `~astropy.units.Quantity` or None, optional
@@ -617,7 +617,7 @@ def subtract_dark(ccd, master, dark_exposure=None, data_exposure=None,
 
     Returns
     -------
-    result : `~ccdproc.CCDData`
+    result : `~astropy.nddata.CCDData`
         Dark-subtracted image.
     """
     if not (isinstance(ccd, CCDData) and isinstance(master, CCDData)):
@@ -686,7 +686,7 @@ def gain_correct(ccd, gain, gain_unit=None):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
       Data to have gain corrected.
 
     gain : `~astropy.units.Quantity` or `~ccdproc.Keyword`
@@ -701,7 +701,7 @@ def gain_correct(ccd, gain, gain_unit=None):
 
     Returns
     -------
-    result : `~ccdproc.CCDData`
+    result : `~astropy.nddata.CCDData`
       CCDData object with gain corrected.
     """
     if isinstance(gain, Keyword):
@@ -724,10 +724,10 @@ def flat_correct(ccd, flat, min_value=None):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Data to be transformed.
 
-    flat : `~ccdproc.CCDData`
+    flat : `~astropy.nddata.CCDData`
         Flatfield to apply to the data.
 
     min_value : float or None, optional
@@ -740,7 +740,7 @@ def flat_correct(ccd, flat, min_value=None):
 
     Returns
     -------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         CCDData object with flat corrected.
     """
     # Use the min_value to replace any values in the flat
@@ -770,7 +770,7 @@ def transform_image(ccd, transform_func, **kwargs):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Data to be flatfield corrected.
 
     transform_func : callable
@@ -783,7 +783,7 @@ def transform_image(ccd, transform_func, **kwargs):
 
     Returns
     -------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         A transformed CCDData object.
 
     Notes
@@ -849,7 +849,7 @@ def wcs_project(ccd, target_wcs, target_shape=None, order='bilinear'):
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         Data to be projected.
 
     target_wcs : `~astropy.wcs.WCS` object
@@ -874,7 +874,7 @@ def wcs_project(ccd, target_wcs, target_shape=None, order='bilinear'):
 
     Returns
     -------
-    ccd : `~ccdproc.CCDData`
+    ccd : `~astropy.nddata.CCDData`
         A transformed CCDData object.
     """
     from reproject import reproject_interp
@@ -930,7 +930,7 @@ def sigma_func(arr, axis=None):
 
     Parameters
     ----------
-    arr : `~ccdproc.CCDData` or `numpy.ndarray`
+    arr : `~astropy.nddata.CCDData` or `numpy.ndarray`
         Array whose deviation is to be calculated.
 
     axis : int, tuple of ints or None, optional
@@ -1072,7 +1072,7 @@ def rebin(ccd, newshape):
 
     Parameters
     ----------
-    data : `~ccdproc.CCDData` or `numpy.ndarray`
+    data : `~astropy.nddata.CCDData` or `numpy.ndarray`
         Data to rebin.
 
     newshape : tuple
@@ -1080,7 +1080,7 @@ def rebin(ccd, newshape):
 
     Returns
     -------
-    output : `~ccdproc.CCDData` or `numpy.ndarray`
+    output : `~astropy.nddata.CCDData` or `numpy.ndarray`
         An array with the new shape. It will have the same type as the input
         object.
 
@@ -1088,7 +1088,7 @@ def rebin(ccd, newshape):
     ------
     TypeError
         A type error is raised if data is not an `numpy.ndarray` or
-        `~ccdproc.CCDData`.
+        `~astropy.nddata.CCDData`.
 
     ValueError
         A value error is raised if the dimension of the new shape is not equal
@@ -1244,8 +1244,8 @@ def _blkavg(data, newshape):
 def median_filter(data, *args, **kwargs):
     """See `scipy.ndimage.median_filter` for arguments.
 
-    If the ``data`` is a `~ccdproc.CCDData` object the result will be another
-    `~ccdproc.CCDData` object with the median filtered data as ``data`` and
+    If the ``data`` is a `~astropy.nddata.CCDData` object the result will be another
+    `~astropy.nddata.CCDData` object with the median filtered data as ``data`` and
     copied ``unit`` and ``meta``.
     """
     if isinstance(data, CCDData):
@@ -1272,7 +1272,7 @@ def cosmicray_lacosmic(ccd, sigclip=4.5, sigfrac=0.3,
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData` or `numpy.ndarray`
+    ccd : `~astropy.nddata.CCDData` or `numpy.ndarray`
         Data to have cosmic ray cleaned.
 
     sigclip : float, optional
@@ -1373,9 +1373,9 @@ def cosmicray_lacosmic(ccd, sigclip=4.5, sigfrac=0.3,
 
     Returns
     -------
-    nccd : `~ccdproc.CCDData` or `numpy.ndarray`
+    nccd : `~astropy.nddata.CCDData` or `numpy.ndarray`
         An object of the same type as ccd is returned. If it is a
-        `~ccdproc.CCDData`, the mask attribute will also be updated with
+        `~astropy.nddata.CCDData`, the mask attribute will also be updated with
         areas identified with cosmic rays masked.
 
     crmask : `numpy.ndarray`
@@ -1404,7 +1404,7 @@ def cosmicray_lacosmic(ccd, sigclip=4.5, sigfrac=0.3,
        with the bad pixels replaced by the local median from a box of 11
        pixels; and it would return a mask indicating the bad pixels.
 
-    2) Given an `~ccdproc.CCDData` object with an uncertainty frame, the syntax
+    2) Given an `~astropy.nddata.CCDData` object with an uncertainty frame, the syntax
        for running cosmicrar_lacosmic would be:
 
        >>> newccd = cosmicray_lacosmic(ccd, sigclip=5)   # doctest: +SKIP
@@ -1461,7 +1461,7 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0,
 
     Parameters
     ----------
-    ccd : `~ccdproc.CCDData`, `numpy.ndarray` or `numpy.ma.MaskedArray`
+    ccd : `~astropy.nddata.CCDData`, `numpy.ndarray` or `numpy.ma.MaskedArray`
         Data to have cosmic ray cleaned.
 
     thresh : float, optional
@@ -1493,9 +1493,9 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0,
 
     Returns
     -------
-    nccd : `~ccdproc.CCDData` or `numpy.ndarray`
+    nccd : `~astropy.nddata.CCDData` or `numpy.ndarray`
         An object of the same type as ccd is returned. If it is a
-        `~ccdproc.CCDData`, the mask attribute will also be updated with
+        `~astropy.nddata.CCDData`, the mask attribute will also be updated with
         areas identified with cosmic rays masked.
 
     nccd : `numpy.ndarray`
@@ -1516,7 +1516,7 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0,
        with the bad pixels replaced by the local median from a box of 11
        pixels; and it would return a mask indicating the bad pixels.
 
-    2) Given an `~ccdproc.CCDData` object with an uncertainty frame, the syntax
+    2) Given an `~astropy.nddata.CCDData` object with an uncertainty frame, the syntax
        for running cosmicray_median would be:
 
        >>> newccd = cosmicray_median(ccd, thresh=5, mbox=11,
@@ -1598,7 +1598,7 @@ def ccdmask(ratio, findbadcolumns=False, byblocks=False, ncmed=7, nlmed=7,
 
     Parameters
     ----------
-    ratio : `~ccdproc.CCDData`
+    ratio : `~astropy.nddata.CCDData`
         Data to used to form mask.  Typically this is the ratio of two flat
         field images.
 
@@ -1781,7 +1781,7 @@ def bitfield_to_boolean_mask(bitfield, ignore_bits=0, flip_bits=None):
     -------
     mask : `numpy.ndarray` of boolean dtype
         The bitfield converted to a boolean mask that can be used for
-        `numpy.ma.MaskedArray` or `~ccdproc.CCDData`.
+        `numpy.ma.MaskedArray` or `~astropy.nddata.CCDData`.
 
     Examples
     --------

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -772,11 +772,11 @@ class ImageFileCollection(object):
             Default is ``False``.
 
         ccd_kwargs : dict, optional
-            Dict with parameters for `~ccdproc.fits_ccddata_reader`.
+            Dict with parameters for `~astropy.nddata.fits_ccddata_reader`.
             For instance, the key ``'unit'`` can be used to specify the unit
             of the data. If ``'unit'`` is not given then ``'adu'`` is used as
             the default unit.
-            See `~ccdproc.fits_ccddata_reader` for a complete list of
+            See `~astropy.nddata.fits_ccddata_reader` for a complete list of
             parameters that can be passed through ``ccd_kwargs``.
 
         kwd :
@@ -897,4 +897,4 @@ class ImageFileCollection(object):
     def ccds(self, ccd_kwargs=None, **kwd):
         return self._generator('ccd', ccd_kwargs=ccd_kwargs, **kwd)
     ccds.__doc__ = _generator.__doc__.format(
-        name='CCDData', default_scaling='True', return_type='ccdproc.CCDData')
+        name='CCDData', default_scaling='True', return_type='astropy.nddata.CCDData')

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -20,6 +20,7 @@ from .. import subtract_dark
 
 
 ASTROPY_GT_1_2 = minversion("astropy", "1.2")
+ASTROPY_GT_2_0 = minversion("astropy", "2.0")
 
 
 def test_ccddata_empty():
@@ -645,7 +646,13 @@ def test_wcs_attribute(ccd_data, tmpdir):
     # Converting CCDData object with wcs to an hdu shouldn't
     # create duplicate wcs-related entries in the header.
     ccd_new_hdu = ccd_new.to_hdu()[0]
-    assert len(ccd_new_hdu.header) == original_header_length
+    if not ASTROPY_GT_2_0:
+        # from astropy 2.0 on the CCDData has been moved to the astropy core
+        # package and the WCS attributes are removed from the meta when the
+        # data is read the WCS related attributes are removed.
+        # In that case the length of the read header will differ from the
+        # header in the HDU after `to_hdu` is called.
+        assert len(ccd_new_hdu.header) == original_header_length
 
     # Making a CCDData with WCS (but not WCS in the header) should lead to
     # WCS information in the header when it is converted to an HDU.
@@ -704,20 +711,23 @@ def test_wcs_sip_handling():
     """
     data_file = get_pkg_data_filename('data/sip-wcs.fit')
 
-    def check_wcs_ctypes(header):
+    def check_wcs_ctypes_header(header):
         expected_wcs_ctypes = {
             'CTYPE1': 'RA---TAN-SIP',
             'CTYPE2': 'DEC--TAN-SIP'
         }
-
         return [header[k] == v for k, v in expected_wcs_ctypes.items()]
 
+    def check_wcs_ctypes_wcs(wcs):
+        expected = ['RA---TAN-SIP', 'DEC--TAN-SIP']
+        return [act == ref for act, ref in zip(wcs.wcs.ctype, expected)]
+
     ccd_original = CCDData.read(data_file)
-    good_ctype = check_wcs_ctypes(ccd_original.meta)
+    good_ctype = check_wcs_ctypes_wcs(ccd_original.wcs)
     assert all(good_ctype)
 
     ccd_new = ccd_original.to_hdu()
-    good_ctype = check_wcs_ctypes(ccd_new[0].header)
+    good_ctype = check_wcs_ctypes_header(ccd_new[0].header)
     assert all(good_ctype)
 
     # Try converting to header with wcs_relax=False and
@@ -725,7 +735,7 @@ def test_wcs_sip_handling():
     # the -SIP
 
     ccd_no_relax = ccd_original.to_hdu(wcs_relax=False)
-    good_ctype = check_wcs_ctypes(ccd_no_relax[0].header)
+    good_ctype = check_wcs_ctypes_header(ccd_no_relax[0].header)
     if ASTROPY_GT_1_2:
         # This behavior was introduced in astropy 1.2.
         assert not any(good_ctype)

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -75,8 +75,12 @@ def test_implicit_logging(ccd_data):
     bias = CCDData(np.zeros_like(ccd_data.data), unit="adu")
     result = subtract_bias(ccd_data, bias)
     assert "subtract_bias" in result.header
-    assert result.header['subtract_bias'] == "ccd=<CCDData>, master=<CCDData>"
+    assert result.header['subtract_bias'] == (
+        'subbias', 'Shortened name for ccdproc command')
+    assert result.header['subbias'] == "ccd=<CCDData>, master=<CCDData>"
 
     result = create_deviation(ccd_data, readnoise=3 * ccd_data.unit)
+    assert result.header['create_deviation'] == (
+        'creatvar', 'Shortened name for ccdproc command')
     assert ("readnoise="+str(3 * ccd_data.unit) in
-            result.header['create_deviation'])
+            result.header['creatvar'])

--- a/docs/ccdproc/ccddata.rst
+++ b/docs/ccdproc/ccddata.rst
@@ -9,10 +9,10 @@ Getting started
 Getting data in
 +++++++++++++++
 
-The tools in `ccdproc` accept only `~ccdproc.CCDData` objects, a
+The tools in `ccdproc` accept only `~astropy.nddata.CCDData` objects, a
 subclass of `~astropy.nddata.NDData`.
 
-Creating a `~ccdproc.ccddata.CCDData` object from any array-like data is easy:
+Creating a `~astropy.nddata.CCDData` object from any array-like data is easy:
 
     >>> import numpy as np
     >>> import ccdproc
@@ -32,13 +32,13 @@ above) or from unit objects:
     >>> ccd_electron = ccdproc.CCDData([1, 2, 3], unit="electron")
 
 If you prefer *not* to use the unit functionality then use the special unit
-``u.dimensionless_unscaled`` when you create your `~ccdproc.ccddata.CCDData`
+``u.dimensionless_unscaled`` when you create your `~astropy.nddata.CCDData`
 images:
 
     >>> ccd_unitless = ccdproc.CCDData(np.zeros((10, 10)),
     ...                                unit=u.dimensionless_unscaled)
 
-A `~ccdproc.ccddata.CCDData` object can also be initialized from a FITS file:
+A `~astropy.nddata.CCDData` object can also be initialized from a FITS file:
 
     >>> ccd = ccdproc.CCDData.read('my_file.fits', unit="adu")  # doctest: +SKIP
 
@@ -76,8 +76,8 @@ dictionary is.
 Getting data out
 ++++++++++++++++
 
-A `~ccdproc.CCDData` object behaves like a numpy array (masked if the
-`~ccdproc.CCDData` mask is set) in expressions, and the underlying
+A `~astropy.nddata.CCDData` object behaves like a numpy array (masked if the
+`~astropy.nddata.CCDData` mask is set) in expressions, and the underlying
 data (ignoring any mask) is accessed through ``data`` attribute:
 
     >>> ccd_masked = ccdproc.CCDData([1, 2, 3], unit="adu", mask=[0, 0, 1])
@@ -99,7 +99,7 @@ You can force conversion to a numpy array with:
            fill_value = 999999)
     <BLANKLINE>
 
-A method for converting a `~ccdproc.ccddata.CCDData` object to a FITS HDU list
+A method for converting a `~astropy.nddata.CCDData` object to a FITS HDU list
 is also available. It converts the metadata to a FITS header:
 
     >>> hdulist = ccd_masked.to_hdu()
@@ -111,7 +111,7 @@ You can also write directly to a FITS file:
 Masks and flags
 +++++++++++++++
 
-Although not required when a `~ccdproc.ccddata.CCDData` image is created you
+Although not required when a `~astropy.nddata.CCDData` image is created you
 can also specify a mask and/or flags.
 
 A mask is a boolean array the same size as the data in which a value of
@@ -125,17 +125,17 @@ shape of the data. For more details on setting flags see
 WCS
 +++
 
-The  ``wcs`` attribute of `~ccdproc.ccddata.CCDData` object can be set two ways.
+The  ``wcs`` attribute of `~astropy.nddata.CCDData` object can be set two ways.
 
-+ If the `~ccdproc.ccddata.CCDData` object is created from a FITS file that has
++ If the `~astropy.nddata.CCDData` object is created from a FITS file that has
   WCS keywords in the header, the ``wcs`` attribute is set to a
   `astropy.wcs.WCS` object using the information in the FITS header.
 
-+ The WCS can also be provided when the `~ccdproc.ccddata.CCDData` object is
++ The WCS can also be provided when the `~astropy.nddata.CCDData` object is
   constructed with the ``wcs`` argument.
 
 Either way, the ``wcs`` attribute is kept up to date if the
-`~ccdproc.ccddata.CCDData` image is trimmed.
+`~astropy.nddata.CCDData` image is trimmed.
 
 Uncertainty
 -----------
@@ -163,7 +163,7 @@ or by providing a `~numpy.ndarray` with the same shape as the data:
 
 In this case the uncertainty is assumed to be
 `~astropy.nddata.StdDevUncertainty`. Using `~astropy.nddata.StdDevUncertainty`
-is required to enable error propagation in `~ccdproc.ccddata.CCDData`
+is required to enable error propagation in `~astropy.nddata.CCDData`
 
 If you want access to the underlying uncertainty use its ``.array`` attribute:
 
@@ -174,14 +174,14 @@ Arithmetic with images
 ----------------------
 
 Methods are provided to perform arithmetic operations with a
-`~ccdproc.ccddata.CCDData` image and a number, an astropy
+`~astropy.nddata.CCDData` image and a number, an astropy
 `~astropy.units.Quantity` (a number with units) or another
-`~ccdproc.ccddata.CCDData` image.
+`~astropy.nddata.CCDData` image.
 
 Using these methods propagates errors correctly (if the errors are
 uncorrelated), take care of any necessary unit conversions, and apply masks
 appropriately. Note that the metadata of the result is *not* set if the operation
-is between two `~ccdproc.ccddata.CCDData` objects.
+is between two `~astropy.nddata.CCDData` objects.
 
     >>> result = ccd.multiply(0.2 * u.adu)
     >>> uncertainty_ratio = result.uncertainty.array[0, 0]/ccd.uncertainty.array[0, 0]
@@ -202,4 +202,4 @@ The arithmetic operators ``*``, ``/``, ``+`` and ``-`` are *not* overridden.
 
 .. note::
    If two images have different WCS values, the wcs on the first
-   `~ccdproc.ccddata.CCDData` object will be used for the resultant object.
+   `~astropy.nddata.CCDData` object will be used for the resultant object.

--- a/docs/ccdproc/index.rst
+++ b/docs/ccdproc/index.rst
@@ -9,7 +9,7 @@ Introduction
 
 The `ccdproc` package provides:
 
-+ An image class, `~ccdproc.CCDData`, that includes an uncertainty for the
++ An image class, `~astropy.nddata.CCDData`, that includes an uncertainty for the
   data, units and methods for performing arithmetic with images including the
   propagation of uncertainties.
 + A set of functions performing common CCD data reduction steps (e.g. dark
@@ -35,7 +35,7 @@ a FITS file:
     >>> image_1 = ccdproc.CCDData(np.ones((10, 10)), unit="adu")
 
 An example of reading from a FITS file is
-``image_2 = ccdproc.CCDData.read('my_image.fits', unit="electron")`` (the
+``image_2 = astropy.nddata.CCDData.read('my_image.fits', unit="electron")`` (the
 ``electron`` unit is defined as part of ``ccdproc``).
 
 The metadata of a ``CCDData`` object may be any dictionary-like object, including a FITS header. When a ``CCDData`` object is initialized from FITS file its metadata is a FITS header.
@@ -46,7 +46,7 @@ attribute:
     >>> sub_image = image_1[:, 1:-3]  # a CCDData object
     >>> sub_data =  image_1.data[:, 1:-3]  # a numpy array
 
-See the documentation for `~ccdproc.CCDData` for a complete list of attributes.
+See the documentation for `~astropy.nddata.CCDData` for a complete list of attributes.
 
 Most operations are performed by functions in `ccdproc`:
 
@@ -125,6 +125,9 @@ Using `ccdproc`
     reduction_examples.rst
 
 .. automodapi:: ccdproc
+   :skip: CCDData
+   :skip: fits_ccddata_writer
+   :skip: fits_ccddata_reader
 
 .. automodapi:: ccdproc.utils.slices
 

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -332,7 +332,7 @@ Data Quality Flags (Bitfields and bitmasks)
 -------------------------------------------
 
 Some FITS files contain data quality flags or bitfield extension, while these
-are currently not supported as part of `~ccdproc.CCDData` these can be loaded
+are currently not supported as part of `~astropy.nddata.CCDData` these can be loaded
 manually using `~astropy.io.fits` and converted to regular (`numpy`-like) masks
 (with `~ccdproc.bitfield_to_boolean_mask`) that are supported by many
 operations in `ccdproc`.
@@ -368,7 +368,7 @@ the scientific python packages:
   but are mostly limited to special data types (mostly unsigned integers).
 
 For convenience one of these is also accessible through the ``ccdproc``
-package namespace which accepts `~ccdproc.CCDData` objects and then also
+package namespace which accepts `~astropy.nddata.CCDData` objects and then also
 returns one:
 
 - `~ccdproc.median_filter`


### PR DESCRIPTION
Fixes #510  (and maybe #232)

I tried to make minimal changes but a few tests had to be rewritten and the logging system now works a bit differently.

I included some comments about the need for the change but if some change seems "weird" please mention it so I can include a comment why that's needed.