### PR TITLE
Make key argument for ImageFileCollection.sort mandatory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Bug Fixes
   ``NotImplementedError`` in case the parameter ``overwrite=True`` or
   ``clobber=True`` is used instead of silently ignoring the parameter.
 
+- The ``sort`` method of ``ImageFileCollection`` now requires an explicitly
+  given ``keys`` argument. [tbd]
+
 
 1.2.0 (2016-12-13)
 ------------------

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -400,7 +400,7 @@ class ImageFileCollection(object):
         self._files = self._get_files()
         self._summary = self._fits_summary(header_keywords=keywords)
 
-    def sort(self, keys=None):
+    def sort(self, keys):
         """Sort the list of files to determine the order of iteration.
 
         Sort the table of files according to one or more keys. This does not
@@ -408,9 +408,8 @@ class ImageFileCollection(object):
 
         Parameters
         ----------
-        keys : str, list of str or None, optional
+        keys : str, list of str
             The key(s) to order the table by.
-            Default is ``None``.
         """
         if len(self._summary) > 0:
             self._summary.sort(keys)

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -751,6 +751,11 @@ class TestImageFileCollection(object):
         for i in range(len(collection.summary)):
             assert(collection.summary['file'][i] == collection.files[i])
 
+    def test_sorting_without_key_fails(self, triage_setup):
+        ic = ImageFileCollection(location=triage_setup.test_dir)
+        with pytest.raises(ValueError):
+            ic.sort(keys=None)
+
     def test_duplicate_keywords(self, triage_setup):
         # Make sure duplicated keywords don't make the imagefilecollection
         # fail.

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -14,6 +14,7 @@ import astropy.io.fits as fits
 import numpy as np
 
 from astropy.tests.helper import catch_warnings
+from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.extern import six
 
@@ -23,6 +24,8 @@ from ..image_collection import ImageFileCollection
 
 _filters = []
 _original_dir = ''
+
+_ASTROPY_LT_1_3 = not minversion("astropy", "1.3")
 
 
 def test_fits_summary(triage_setup):
@@ -751,6 +754,10 @@ class TestImageFileCollection(object):
         for i in range(len(collection.summary)):
             assert(collection.summary['file'][i] == collection.files[i])
 
+    @pytest.mark.skipif(
+        _ASTROPY_LT_1_3,
+        reason="It seems to fail with a TypeError there but because of "
+               "different reasons (something to do with NumPy).")
     def test_sorting_without_key_fails(self, triage_setup):
         ic = ImageFileCollection(location=triage_setup.test_dir)
         with pytest.raises(ValueError):


### PR DESCRIPTION
Just found out by coincidence that `sort` without argument always throws a `ValueError` so it's probably better to make the `keys` argument mandatory.