### PR TITLE
Make "header_keywords" argument for "_fits_summary" method mandatory

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -549,15 +549,15 @@ class ImageFileCollection(object):
                 except KeyError:
                     pass
 
-    def _fits_summary(self, header_keywords=None):
+    def _fits_summary(self, header_keywords):
         """
         Generate a summary table of keywords from FITS headers.
 
         Parameters
         ----------
-        header_keywords : list of str, '*' or None, optional
-            Keywords whose value should be extracted from FITS headers.
-            Default value is ``None``.
+        header_keywords : list of str or '*'
+            Keywords whose value should be extracted from FITS headers or '*'
+            to extract all.
         """
 
         if not self.files:


### PR DESCRIPTION
Almost immediately the argument will be passed to `list` which would throw a `TypeError` because `None` isn't iterable.

Given that it's a private method I didn't add a test and changelog.