### PR TITLE
Remove unnecessary default value for keyword property setter.

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -255,7 +255,7 @@ class ImageFileCollection(object):
             return []
 
     @keywords.setter
-    def keywords(self, keywords=None):
+    def keywords(self, keywords):
         # since keywords are drawn from self.summary, setting
         # summary sets the keywords.
         if keywords is None:


### PR DESCRIPTION
Setters actually don't need a default value because that would only be useful if one accesses the `fset` method of the property instance directly.