### PR TITLE
Fix RessourceWarnings due to open files in ImageFileCollection._generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ New Features
 
 - Added ``sum`` option in method for ``combime``. [#500, #508]
 
+- Add ``_replace_with_whitespace`` argument for the ``files_filtered`` and
+  generator methods of ``ImageFileCollection`` to allow filtering for whitespace
+  seperated keys. [#539]
+
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,10 @@ Bug Fixes
 
 - Suppress errors during WCS creation in CCDData.read(). [#552]
 
+- The generator methods in ``ImageFileCollection`` now don't leave open file
+  handles in case the iterator wasn't advanced or an exception was raised
+  either inside the method itself or during the loop. [#545]
+
 
 1.2.0 (2016-12-13)
 ------------------

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -883,10 +883,8 @@ class ImageFileCollection(object):
             elif return_type == 'data':
                 return_thing = fits.getdata(full_path, self.ext, **add_kwargs)
             elif return_type == 'ccd':
-                with fits.open(full_path, **add_kwargs) as hdulist:
-                    ext_index = hdulist.index_of(self.ext)
                 return_thing = fits_ccddata_reader(
-                    full_path, hdu=ext_index, **ccd_kwargs)
+                    full_path, hdu=self.ext, **ccd_kwargs)
             elif return_type == 'hdu':
                 with fits.open(full_path, **add_kwargs) as hdulist:
                     ext_index = hdulist.index_of(self.ext)

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -876,29 +876,32 @@ class ImageFileCollection(object):
         ccd_kwargs = ccd_kwargs or {}
 
         for full_path in self._paths():
-            no_scale = do_not_scale_image_data
-            hdulist = fits.open(full_path,
-                                do_not_scale_image_data=no_scale)
+            add_kwargs = {'do_not_scale_image_data': do_not_scale_image_data}
+
+            if return_type == 'header':
+                return_thing = fits.getheader(full_path, self.ext)
+            elif return_type == 'data':
+                return_thing = fits.getdata(full_path, self.ext, **add_kwargs)
+            elif return_type == 'ccd':
+                with fits.open(full_path, **add_kwargs) as hdulist:
+                    ext_index = hdulist.index_of(self.ext)
+                return_thing = fits_ccddata_reader(
+                    full_path, hdu=ext_index, **ccd_kwargs)
+            elif return_type == 'hdu':
+                with fits.open(full_path, **add_kwargs) as hdulist:
+                    ext_index = hdulist.index_of(self.ext)
+                    # Need to copy the HDU to prevent lazy loading problems
+                    # and "IO operations on closed file" errors
+                    return_thing = hdulist[ext_index].copy()
+            else:
+                raise ValueError('no generator for {}'.format(return_type))
 
             file_name = path.basename(full_path)
 
-            ext_index = hdulist.index_of(self.ext)
-
-            return_options = {
-                    'header': lambda: hdulist[ext_index].header,
-                    'hdu': lambda: hdulist[ext_index],
-                    'data': lambda: hdulist[ext_index].data,
-                    'ccd': lambda: fits_ccddata_reader(full_path,
-                                                       hdu=ext_index,
-                                                       **ccd_kwargs)
-                    }
-            try:
-                if return_fname:
-                    yield return_options[return_type](), file_name
-                else:
-                    yield return_options[return_type]()
-            except KeyError:
-                raise ValueError('no generator for {}'.format(return_type))
+            if return_fname:
+                yield return_thing, file_name
+            else:
+                yield return_thing
 
             if save_location:
                 destination_dir = save_location
@@ -921,13 +924,23 @@ class ImageFileCollection(object):
                     nuke_existing = {'overwrite': True}
             else:
                 nuke_existing = {}
-            if (new_path != full_path) or nuke_existing:
-                try:
-                    hdulist.writeto(new_path, **nuke_existing)
-                except IOError:
-                    logger.error('error writing file %s', new_path)
-                    raise
-            hdulist.close()
+            if return_type == 'ccd':
+                pass
+            elif (new_path != full_path) or nuke_existing:
+                with fits.open(full_path, **add_kwargs) as hdulist:
+                    ext_index = hdulist.index_of(self.ext)
+                    if return_type == 'hdu':
+                        hdulist[ext_index] = return_thing
+                    elif return_type == 'data':
+                        hdulist[ext_index].data = return_thing
+                    elif return_type == 'header':
+                        hdulist[ext_index].header = return_thing
+
+                    try:
+                        hdulist.writeto(new_path, **nuke_existing)
+                    except IOError:
+                        logger.error('error writing file %s', new_path)
+                        raise
 
         # reset mask
         for col in self.summary.columns:

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -358,30 +358,78 @@ class ImageFileCollection(object):
         else:
             return list(self.summary[keyword])
 
+    def _preprocess_kwargs_for_filtering(self, kwargs):
+        """Method to find out if the kwargs dictionary that will be used to
+        find matching files should be preprocessed.
+
+        Currently this includes checking if any character should be replaced
+        by a whitespace.
+        """
+        char_to_replace = kwargs.pop('_replace_with_whitespace', None)
+        if char_to_replace is not None:
+            kwargs = {key.replace(char_to_replace, ' '): value
+                      for key, value in six.iteritems(kwargs)}
+            # It should be impossible to pass in strings so this doesn't have
+            # a check for non-string keys. The only functions that call this
+            # method only accept it as `**kwargs` so these have to be strings or
+            # it would raise "TypeError: func_name() keywords must be strings".
+        return kwargs
+
     def files_filtered(self, **kwd):
         """Determine files whose keywords have listed values.
 
-        ``**kwd`` is list of keywords and values the files must have.
+        Parameters
+        ----------
+        include_path : bool, keyword-only
+            If the keyword ``include_path=True`` is set, the returned list
+            contains not just the filename, but the full path to each file.
+            Default is ``False``.
 
-        If the keyword ``include_path=True`` is set, the returned list
-        contains not just the filename, but the full path to each file.
+        _replace_with_whitespace : str, optional, keyword-only
+            If this parameter is given it should be a string of length 1 that
+            indicates which character is replaced by a whitespace. This affects
+            all keys passed in as ``**kwd``.
 
-        The value '*' represents any value.
-        A missing keyword is indicated by value ''.
+            .. versionadded:: 1.3
 
-        Example::
+        **kwd :
+            ``**kwd`` is dict of keywords and values the files must have.
+            The value '*' represents any value.
+            A missing keyword is indicated by value ''.
+
+        Returns
+        -------
+        filenames : list
+            The files that satisfy the keyword-value restrictions specified by
+            the ``**kwd``.
+
+        Examples
+        --------
+        Some examples for filtering::
 
             >>> keys = ['imagetyp','filter']
             >>> collection = ImageFileCollection('test/data', keywords=keys)
             >>> collection.files_filtered(imagetyp='LIGHT', filter='R')
             >>> collection.files_filtered(imagetyp='*', filter='')
 
-        NOTE: Value comparison is case *insensitive* for strings.
+        In case there is a keyword with whitespaces you can use::
+
+            >>> collection.files_filtered(image_typ='LIGHT',
+            ...                           _replace_with_whitespace='_')
+
+        This will look for the ``image typ`` keyword (the underscore was
+        replaced by a whitespace). This could be useful in case the header
+        contains keys like ``ESO TPL ID`` (or similar).
+
+        Notes
+        -----
+        Value comparison is case *insensitive* for strings.
         """
         # force a copy by explicitly converting to a list
         current_file_mask = list(self.summary['file'].mask)
 
         include_path = kwd.pop('include_path', False)
+        kwd = self._preprocess_kwargs_for_filtering(kwd)
 
         self._find_keywords_by_values(**kwd)
         filtered_files = self.summary['file'].compressed()
@@ -791,9 +839,16 @@ class ImageFileCollection(object):
             See `~astropy.nddata.fits_ccddata_reader` for a complete list of
             parameters that can be passed through ``ccd_kwargs``.
 
-        kwd :
+        _replace_with_whitespace : str, optional, keyword-only
+            If this parameter is given it should be a string of length 1 that
+            indicates which character is replaced by a whitespace. This affects
+            all keys passed in as ``**kwd``.
+
+            .. versionadded:: 1.3
+
+        **kwd :
             Any additional keywords are used to filter the items returned; see
-            Examples for details.
+            `files_filtered` examples for details.
 
         Returns
         -------
@@ -815,6 +870,7 @@ class ImageFileCollection(object):
             current_mask[col] = self.summary[col].mask
 
         if kwd:
+            kwd = self._preprocess_kwargs_for_filtering(kwd)
             self._find_keywords_by_values(**kwd)
 
         ccd_kwargs = ccd_kwargs or {}

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -17,6 +17,7 @@ from astropy.tests.helper import catch_warnings
 from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.extern import six
+from astropy.extern.six.moves import zip
 
 from ccdproc import CCDData
 

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -135,6 +135,27 @@ class TestImageFileCollection(object):
         assert ('flying monkeys' not in img_collection.keywords)
         assert len(img_collection.values('imagetyp', unique=True)) == 2
 
+    def test_filter_files_whitespace_keys(self, triage_setup):
+        hdr = fits.Header([('HIERARCH a b', 2)])
+        hdul = fits.HDUList([fits.PrimaryHDU(np.ones((10, 10)), header=hdr)])
+        hdul.writeto(os.path.join(triage_setup.test_dir,
+                                  'hdr_with_whitespace.fits'))
+
+        ic = ImageFileCollection(location=triage_setup.test_dir)
+        filtered = ic.files_filtered(a_b=2, _replace_with_whitespace='_')
+        assert len(filtered) == 1
+        assert 'hdr_with_whitespace.fits' in filtered
+
+        # The same can be achieved by unpacking a dict yourself
+        filtered = ic.files_filtered(**{'a b': 2})
+        assert len(filtered) == 1
+        assert 'hdr_with_whitespace.fits' in filtered
+
+        # Also check it's working with generators:
+        for _, filename in ic.data(a_b=2, _replace_with_whitespace='_',
+                                   return_fname=True):
+            assert filename == 'hdr_with_whitespace.fits'
+
     def test_filtered_files_have_proper_path(self, triage_setup):
         ic = ImageFileCollection(location=triage_setup.test_dir, keywords='*')
         # Get a subset of the files.


### PR DESCRIPTION
These `ResourceWarnings` were because files were still open and the reason is that the `_generator` opens a file, then yields the contents but only closes the file **if** the next element is requested. That works fine for loops but actually doesn't close the file when the generator isn't advanced.

So this approach opens the file to extract the relevant data, then closes it before yielding the "object" and if overwriting or a save-location was specified opens the file again to write the stuff into the file.

It's still fragile because not advancing the iterator may cause the file not to be written but that was also the case before. However like this it won't leave files open.