### PR TITLE
Fix a FutureWarning from NumPy regarding non-dtype argument for issubdtype

### DIFF
--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -66,7 +66,7 @@ def test_initialize_from_FITS(ccd_data, tmpdir):
     cd = CCDData.read(filename, unit=u.electron)
     assert cd.shape == (10, 10)
     assert cd.size == 100
-    assert np.issubdtype(cd.data.dtype, np.float)
+    assert np.issubdtype(cd.data.dtype, np.floating)
     for k, v in hdu.header.items():
         assert cd.meta[k] == v
 


### PR DESCRIPTION
I found the warning in a test log against NumPy master: https://travis-ci.org/astropy/ccdproc/jobs/270021313#L787

The correct form is to use `np.floating` as second argument.