### PR TITLE
Fix failures against numpy dev

### DIFF
--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -53,7 +53,7 @@ class Combiner(object):
         >>> ccddata3 = CCDData(np.ones((4, 4)), unit=u.adu)
         >>> c = Combiner([ccddata1, ccddata2, ccddata3])
         >>> ccdall = c.average_combine()
-        >>> ccdall
+        >>> ccdall  # doctest: +FLOAT_CMP
         CCDData([[ 0.66666667,  0.66666667,  0.66666667,  0.66666667],
                  [ 0.66666667,  0.66666667,  0.66666667,  0.66666667],
                  [ 0.66666667,  0.66666667,  0.66666667,  0.66666667],

--- a/docs/ccdproc/ccddata.rst
+++ b/docs/ccdproc/ccddata.rst
@@ -86,7 +86,7 @@ data (ignoring any mask) is accessed through ``data`` attribute:
                  mask = [False False  True],
            fill_value = 1e+20)
     <BLANKLINE>
-    >>> 2 * np.ones(3) * ccd_masked.data   # ignores the mask
+    >>> 2 * np.ones(3) * ccd_masked.data   # doctest: +FLOAT_CMP
     array([ 2.,  4.,  6.])
 
 You can force conversion to a numpy array with:


### PR DESCRIPTION
Based on https://github.com/astropy/astropy/pull/6090. Let's just hope it's backported and the astropy 2.0.3 is released before NumPy 1.14 is, otherwise the `+FLOAT_CMP` won't do the "correct thing".