### PR TITLE
Remove wcs-related header-items when reading CCDData from file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,9 @@ Other Changes and Additions
 
 - Building the documentation requires astropy >= 2.0. [#528]
 
+- When reading a ``CCDData`` from a file the WCS-related keywords are removed
+  from the header. [#568]
+
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/ccddata.py
+++ b/ccdproc/ccddata.py
@@ -605,6 +605,54 @@ class CCDData(NDDataArray):
             self.meta[key] = value
 
 
+# This needs to be importable by the tests...
+_KEEP_THESE_KEYWORDS_IN_HEADER = [
+    'JD-OBS',
+    'MJD-OBS',
+    'DATE-OBS'
+]
+
+
+def _generate_wcs_and_update_header(hdr):
+    """
+    Generate a WCS object from a header and remove the WCS-specific
+    keywords from the header.
+    Parameters
+    ----------
+    hdr : astropy.io.fits.header or other dict-like
+    Returns
+    -------
+    new_header, wcs
+    """
+
+    # Try constructing a WCS object.
+    try:
+        wcs = WCS(hdr)
+    except Exception as exc:
+        # Normally WCS only raises Warnings and doesn't fail but in rare
+        # cases (malformed header) it could fail...
+        log.info('An exception happened while extracting WCS informations from '
+                 'the Header.\n{}: {}'.format(type(exc).__name__, str(exc)))
+        return hdr, None
+    # Test for success by checking to see if the wcs ctype has a non-empty
+    # value, return None for wcs if ctype is empty.
+    if not wcs.wcs.ctype[0]:
+        return hdr, None
+
+    new_hdr = hdr.copy()
+    # If the keywords below are in the header they are also added to WCS.
+    # It seems like they should *not* be removed from the header, though.
+
+    wcs_header = wcs.to_header(relax=True)
+    for k in wcs_header:
+        if k not in _KEEP_THESE_KEYWORDS_IN_HEADER:
+            try:
+                new_hdr.remove(k)
+            except KeyError:
+                pass
+    return new_hdr, wcs
+
+
 def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         hdu_mask='MASK', hdu_flags=None, **kwd):
     """
@@ -706,17 +754,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                                                              fits_unit_string))
 
         use_unit = unit or fits_unit_string
-        # Try constructing a WCS object.
-        try:
-            wcs = WCS(hdr)
-        except Exception:
-            # Normally WCS only raises Warnings and doesn't fail but in rare
-            # cases (malformed header) it could fail...
-            wcs = None
-        else:
-            # Test for success by checking to see if the wcs ctype has a non-empty
-            # value.
-            wcs = wcs if wcs.wcs.ctype[0] else None
+        hdr, wcs = _generate_wcs_and_update_header(hdr)
         ccd_data = CCDData(hdus[hdu].data, meta=hdr, unit=use_unit,
                            mask=mask, uncertainty=uncertainty, wcs=wcs)
 

--- a/ccdproc/tests/test_ccddata.py
+++ b/ccdproc/tests/test_ccddata.py
@@ -73,6 +73,32 @@ def test_initialize_from_FITS(ccd_data, tmpdir):
         assert cd.meta[k] == v
 
 
+def test_reader_removes_wcs_related_keywords(tmpdir):
+    arr = np.arange(100).reshape(10, 10)
+    # Create a WCS programatically (straight from the astropy WCS documentation)
+    w = WCS(naxis=2)
+    w.wcs.crpix = [-234.75, 8.3393]
+    w.wcs.cdelt = np.array([-0.066667, 0.066667])
+    w.wcs.crval = [0, -90]
+    w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
+    w.wcs.set_pv([(2, 1, 45.0)])
+    # Write the image including WCS to file
+    ccd = CCDData(arr, unit='adu', wcs=w)
+    filename = tmpdir.join('afile.fits').strpath
+    ccd.write(filename)
+
+    # Check that the header and the meta of the CCDData are not equal
+    ccd_fromfile = CCDData.read(filename)
+    read_header = ccd_fromfile.meta
+    ref_header = fits.getheader(filename)
+    ref_wcs = ccd_fromfile.wcs.to_header()
+    for key in read_header:
+        # Make sure no new keys were accidentally added
+        assert key in ref_header
+    for key in ref_header:
+        assert key in read_header or key in ref_wcs
+
+
 def test_initialize_from_fits_with_unit_in_header(tmpdir):
     fake_img = np.random.random(size=(100, 100))
     hdu = fits.PrimaryHDU(fake_img)
@@ -650,17 +676,6 @@ def test_wcs_attribute(ccd_data, tmpdir):
     assert ccd_new.wcs is not None
     # WCS attribute should be equal to wcs above.
     assert ccd_new.wcs.wcs == wcs.wcs
-
-    # Converting CCDData object with wcs to an hdu shouldn't
-    # create duplicate wcs-related entries in the header.
-    ccd_new_hdu = ccd_new.to_hdu()[0]
-    if not ASTROPY_GT_2_0:
-        # from astropy 2.0 on the CCDData has been moved to the astropy core
-        # package and the WCS attributes are removed from the meta when the
-        # data is read the WCS related attributes are removed.
-        # In that case the length of the read header will differ from the
-        # header in the HDU after `to_hdu` is called.
-        assert len(ccd_new_hdu.header) == original_header_length
 
     # Making a CCDData with WCS (but not WCS in the header) should lead to
     # WCS information in the header when it is converted to an HDU.


### PR DESCRIPTION
This is so we have the same behavior as astropy 2.0

The test is different and I'm not sure it's completely correct.