### PR TITLE
Catch the warnings message in duplicated keyword test

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -565,8 +565,8 @@ class ImageFileCollection(object):
                 # a mistake. It would lead to problems in ImageFileCollection
                 # to add it as well, so simply ignore those.
                 warnings.warn(
-                    'Header from file "{f}" contains multiple entries for {k},'
-                    ' the pair "{k}={v}" will be ignored.'
+                    'Header from file "{f}" contains multiple entries for '
+                    '"{k}", the pair "{k}={v}" will be ignored.'
                     ''.format(k=k, v=v, f=file_name),
                     UserWarning)
                 continue

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -794,7 +794,11 @@ class TestImageFileCollection(object):
 
         hdu.writeto(os.path.join(triage_setup.test_dir, 'duplicated.fits'))
 
-        ic = ImageFileCollection(triage_setup.test_dir, keywords='*')
+        with catch_warnings(UserWarning) as w:
+            ic = ImageFileCollection(triage_setup.test_dir, keywords='*')
+        assert len(w) == 1
+        assert 'stupid' in str(w[0].message)
+
         assert 'stupid' in ic.summary.colnames
         assert 'fun' in ic.summary['stupid']
         assert 'nofun' not in ic.summary['stupid']


### PR DESCRIPTION
And it adds quotations around the keyword name in the warnings message