### PR TITLE
Use absolute of data in gain tests so the sqrt does not warn

### DIFF
--- a/ccdproc/tests/test_gain.py
+++ b/ccdproc/tests/test_gain.py
@@ -3,12 +3,12 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from numpy.testing import assert_array_equal
+import numpy as np
 import pytest
-from astropy.units.quantity import Quantity
+
 import astropy.units as u
 
-from ..core import *
+from ..core import create_deviation, gain_correct, Keyword
 
 
 # tests for gain
@@ -19,6 +19,9 @@ from ..core import *
                          Keyword('gainval', unit=u.electron / u.adu)])
 @pytest.mark.data_unit(u.adu)
 def test_linear_gain_correct(ccd_data, gain):
+    # The data values should be positive, so the poisson noise calculation
+    # works without throwing warnings
+    ccd_data.data = np.absolute(ccd_data.data)
     ccd_data = create_deviation(ccd_data, readnoise=1.0 * u.adu)
     ccd_data.meta['gainval'] = 3.0
     orig_data = ccd_data.data
@@ -30,11 +33,11 @@ def test_linear_gain_correct(ccd_data, gain):
     except AttributeError:
         gain_value = gain
 
-    assert_array_equal(ccd.data, gain_value * orig_data)
-    assert_array_equal(ccd.uncertainty.array,
-                       gain_value * ccd_data.uncertainty.array)
+    np.testing.assert_array_equal(ccd.data, gain_value * orig_data)
+    np.testing.assert_array_equal(ccd.uncertainty.array,
+                                  gain_value * ccd_data.uncertainty.array)
 
-    if isinstance(gain, Quantity):
+    if isinstance(gain, u.Quantity):
         assert ccd.unit == ccd_data.unit * gain.unit
     else:
         assert ccd.unit == ccd_data.unit
@@ -43,12 +46,16 @@ def test_linear_gain_correct(ccd_data, gain):
 # test gain with gain_unit
 @pytest.mark.data_unit(u.adu)
 def test_linear_gain_unit_keyword(ccd_data):
+    # The data values should be positive, so the poisson noise calculation
+    # works without throwing warnings
+    ccd_data.data = np.absolute(ccd_data.data)
+
     ccd_data = create_deviation(ccd_data, readnoise=1.0 * u.adu)
     orig_data = ccd_data.data
     gain = 3.0
     gain_unit = u.electron / u.adu
     ccd = gain_correct(ccd_data, gain, gain_unit=gain_unit)
-    assert_array_equal(ccd.data, gain * orig_data)
-    assert_array_equal(ccd.uncertainty.array,
-                       gain * ccd_data.uncertainty.array)
+    np.testing.assert_array_equal(ccd.data, gain * orig_data)
+    np.testing.assert_array_equal(ccd.uncertainty.array,
+                                  gain * ccd_data.uncertainty.array)
     assert ccd.unit == ccd_data.unit * gain_unit


### PR DESCRIPTION
Currently the tests raise warnings because several values are negative.