### PR TITLE
Remove replace_ argument for files_filtered again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,9 +28,6 @@ New Features
 
 - Added ``sum`` option in method for ``combime``. [#500, #508]
 
-- Add ``replace_`` argument for the ``files_filtered`` and generator methods of
-  ``ImageFileCollection`` to allow filtering for whitespace seperated keys. [#539]
-
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -143,11 +143,7 @@ class TestImageFileCollection(object):
                                   'hdr_with_whitespace.fits'))
 
         ic = ImageFileCollection(location=triage_setup.test_dir)
-        filtered = ic.files_filtered(a_b=2, replace_='_')
-        assert len(filtered) == 1
-        assert 'hdr_with_whitespace.fits' in filtered
-
-        # The same can be achieved by unpacking a dict yourself
+        # Using a dictionary and unpacking it should work
         filtered = ic.files_filtered(**{'a b': 2})
         assert len(filtered) == 1
         assert 'hdr_with_whitespace.fits' in filtered


### PR DESCRIPTION
The `replace_` argument was basically a good idea but as #559 and #557 show whitespaces are not the only problematic character. ``-`` is quite frequently used and sometimes even ``.``. Other invalid characters for keyword arguments are quite rare.

However it might be better to just document the workaround (passing in an unpacked dictionary) than actually inventing a functionality that tries to cover these cases in an easy to use way.

If we make `replace_` a dictionary for characters to translate that will be very awkward to use (because you could end up inventing different placeholders for different characters) and when you're passing in a dictionary already one might as well pass in the dictionary containing the key-value pairs.

Note that `replace_` hasn't been released yet so this doesn't need a deprecation.