### PR TITLE
Fix deprecations in tests with astropy development version

### DIFF
--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -46,7 +46,7 @@ except ImportError:
 def test_create_deviation(ccd_data, u_image, u_gain, u_readnoise,
                           expect_success):
     ccd_data.unit = u_image
-    if u_gain:
+    if u_gain is not None:
         gain = 2.0 * u_gain
     else:
         gain = None
@@ -56,7 +56,7 @@ def test_create_deviation(ccd_data, u_image, u_gain, u_readnoise,
         assert ccd_var.uncertainty.array.shape == (10, 10)
         assert ccd_var.uncertainty.array.size == 100
         assert ccd_var.uncertainty.array.dtype == np.dtype(float)
-        if gain:
+        if gain is not None:
             expected_var = np.sqrt(2 * ccd_data.data + 5 ** 2) / 2
         else:
             expected_var = np.sqrt(ccd_data.data + 5 ** 2)


### PR DESCRIPTION
https://github.com/astropy/astropy/pull/6590 caused two deprecation warnings in our test suite but not related to actual code, just inside the test.

The reason is that composite-units like `u.electron / u.adu` create Quantities and casting them to `bool` currently raises a deprecation but it will be an Error in the future.