### PR TITLE
Remove pytest.ini in favor of setup.cfg

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-markers =
-    data_size(N): set dimension of square data array for ccd_data fixture
-    data_scale(s): set the scale of the normal distribution used to generate data
-    data_mean(m): set the center of the normal distribution used to generate data

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,10 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+markers =
+    data_size(N): set dimension of square data array for ccd_data fixture
+    data_scale(s): set the scale of the normal distribution used to generate data
+    data_mean(m): set the center of the normal distribution used to generate data
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
We currently use `pytest.ini` **and** the pytest section in `setup.cfg`. This PR removes the pytest.ini and puts the stuff in the setup.cfg.

Not sure if that makes sense though.