### PR TITLE
Replace unicode quotation marks in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ github_project = astropy/ccdproc
 # E224 - tab after operator
 # E225 - missing whitespace around operator
 # E241 - multiple whitespace after ','
-# E242 - tab after ‘,’
+# E242 - tab after ','
 # E251 - unexpected spaces around keyword / parameter equals
 # E271 - multiple spaces after keyword
 # E272 - multiple spaces before keyword


### PR DESCRIPTION
Fixes #590 

Not sure if this is a general problem but it's not really necessary to use unicodes there so we might as well remove it.