### PR TITLE
Wrong parameter name in docstring

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -734,7 +734,7 @@ class ImageFileCollection(object):
 
         Parameters
         ----------
-        extension : list of str or None, optional
+        extensions : list of str or None, optional
             List of filename extensions that are FITS files. Default is
             ``['fit', 'fits', 'fts']``.
             Default is ``None``.


### PR DESCRIPTION
The parameter name is `extensions` not `extension`. 