### PR TITLE
ccdproc median combine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Other Changes and Additions
 
 Bug Fixes
 ^^^^^^^^^
-- Function ``median_combine`` now works correctly for masked ``CCDData``. [#608]
+- Function ``median_combine`` now correctly calculates the uncertainty for 
+  masked ``CCDData``. [#608]
 
 1.3.0 (2017-11-1)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Other Changes and Additions
 
 Bug Fixes
 ^^^^^^^^^
-
+- Function ``median_combine`` now works correctly for masked ``CCDData``. [#608]
 
 1.3.0 (2017-11-1)
 -----------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -13,8 +13,6 @@ from .core import sigma_func
 from astropy.nddata import StdDevUncertainty
 from astropy import log
 
-import math
-
 __all__ = ['Combiner', 'combine']
 
 
@@ -362,10 +360,7 @@ class Combiner(object):
         # set the uncertainty
         uncertainty = uncertainty_func(self.data_arr, axis=0)
         # Divide uncertainty by the number of pixel (#309)
-        # TODO: This should be np.sqrt(len(self.data_arr) - masked_values) but
-        # median_absolute_deviation ignores the mask... so it
-        # would yield inconsistent results.
-        uncertainty /= math.sqrt(len(self.data_arr) - masked_values)
+        uncertainty /= np.sqrt(len(self.data_arr) - masked_values)
         # Convert uncertainty to plain numpy array (#351)
         # There is no need to care about potential masks because the
         # uncertainty was calculated based on the data so potential masked

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -360,12 +360,12 @@ class Combiner(object):
         mask = (masked_values == len(self.data_arr))
 
         # set the uncertainty
-        uncertainty = uncertainty_func(self.data_arr.data, axis=0)
+        uncertainty = uncertainty_func(self.data_arr, axis=0)
         # Divide uncertainty by the number of pixel (#309)
         # TODO: This should be np.sqrt(len(self.data_arr) - masked_values) but
         # median_absolute_deviation ignores the mask... so it
         # would yield inconsistent results.
-        uncertainty /= math.sqrt(len(self.data_arr))
+        uncertainty /= math.sqrt(len(self.data_arr) - masked_values)
         # Convert uncertainty to plain numpy array (#351)
         # There is no need to care about potential masks because the
         # uncertainty was calculated based on the data so potential masked

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -466,7 +466,26 @@ def test_combiner_uncertainty_average_mask():
     ref_uncertainty = np.ones((10, 10)) * np.std([1, 2, 3])
     # Correction because we combined two images.
     ref_uncertainty /= np.sqrt(3)
-    ref_uncertainty[5, 5] = np.std([2, 3]) / np.sqrt(2)
+    ref_uncertainty[5, 5] = np.std([2, 3]) / np.sqrt(2) 
+    np.testing.assert_array_almost_equal(ccd.uncertainty.array,
+                                         ref_uncertainty)
+
+# test resulting uncertainty is corrected for the number of images (with mask)
+def test_combiner_uncertainty_median_mask():
+    mad_to_sigma = 1.482602218505602
+    mask = np.zeros((10, 10), dtype=np.bool_)
+    mask[5, 5] = True
+    ccd_with_mask = CCDData(np.ones((10, 10)), unit=u.adu, mask=mask)
+    ccd_list = [ccd_with_mask,
+                CCDData(np.ones((10, 10))*2, unit=u.adu),
+                CCDData(np.ones((10, 10))*3, unit=u.adu)]
+    c = Combiner(ccd_list)
+    ccd = c.median_combine()
+    # Just the standard deviation of ccd data.
+    ref_uncertainty = np.ones((10, 10)) * mad_to_sigma * mad([1, 2, 3])
+    # Correction because we combined two images.
+    ref_uncertainty /= np.sqrt(3)  # 0.855980789955
+    ref_uncertainty[5, 5] = mad_to_sigma * mad([2, 3]) / np.sqrt(2) # 0.524179041254
     np.testing.assert_array_almost_equal(ccd.uncertainty.array,
                                          ref_uncertainty)
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -466,7 +466,7 @@ def test_combiner_uncertainty_average_mask():
     ref_uncertainty = np.ones((10, 10)) * np.std([1, 2, 3])
     # Correction because we combined two images.
     ref_uncertainty /= np.sqrt(3)
-    ref_uncertainty[5, 5] = np.std([2, 3]) / np.sqrt(2) 
+    ref_uncertainty[5, 5] = np.std([2, 3]) / np.sqrt(2)
     np.testing.assert_array_almost_equal(ccd.uncertainty.array,
                                          ref_uncertainty)
 


### PR DESCRIPTION
For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

-----------------------------------------

The same code as #608 now gives correct answer:

```
-- median:
[[ 4.5  3.   4.5]] [[ 0.35355339  0.63245553  0.35355339]]
[[ 4.5  3.   4.5]] [[ 0.35355339  0.4472136   0.35355339]]
-- average:
[[ 4.5  3.   4.5]] [[ 0.35355339  0.63245553  0.35355339]]
[[ 4.5  3.   4.5]] [[ 0.35355339  0.4472136   0.35355339]]
----------expected------------------------------
[[ 4.5  3.   4.5]] [[ 0.35355339  0.63245553  0.35355339]]
[[ 4.5  3.   4.5]] [[ 0.35355339  0.4472136   0.35355339]]
[[ 4.5  3.   4.5]] [[ 0.35355339  0.63245553  0.35355339]]
[[ 4.5  3.   4.5]] [[ 0.35355339  0.4472136   0.35355339]]
```

  