### PR TITLE
 Port enhancements to bitfield from stsci.tools

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Alphabetical list of contributors
 * Yoonsoo P. Bach (@ysBach)
 * Kyle Barbary (@kbarbary)
 * Javier Blasco (@javierblasco)
+* Mihai Cara (@mcara)
 * Christoph Deil (@cdeil)
 * Carlos Gomez (@carlgogo)
 * Hans Moritz Günther (@hamogu)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Improved handling of large flags in the `bitfield` module. [#610]
+- Improved handling of large flags in the ``bitfield`` module. [#610]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved handling of large flags in the `bitfield` module. [#610]
+
 Bug Fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
This PR enhances the treatment of very high bit flags in such a way that flags like `1<<63` (maximum supported by `uint64` type) now work and flags larger than maximum supported by `numpy.uint64` are ignored and again allow code to work without crashing. See #610 for more details.