### PR TITLE
Remove astropy 1.0 and 1.3 and Python 2 from testing. Added test for Numpy 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
             - dvipng
 
 python:
-    - 2.7
     - 3.4
     - 3.5
     - 3.6
@@ -42,43 +41,33 @@ matrix:
         # Try Astropy/NumPy development versions. This requires them to be
         # compiled during setup which takes some time.
         - python: 3.6
-          env: ASTROPY_VERSION=development NUMPY_VERSION=dev
+          env: ASTROPY_VERSION=development
+               NUMPY_VERSION=dev
                SETUP_CMD='test --coverage'
+
+        # Check for sphinx doc build warnings
+        - python: 3.6
+          env: SETUP_CMD='build_docs -w'
 
         # Do coverage tests for both latest Python versions
         - python: 3.6
-          env: SETUP_CMD='test --coverage'
-
-        - python: 2.7
-          env: SETUP_CMD='test --coverage'
-
-        # Check for sphinx doc build warnings
-        - python: 2.7
-          env: SETUP_CMD='build_docs -w'
+          env: ASTROPY_VERSION=3
+               SETUP_CMD='test --coverage'
 
         # Check compatibility with the current astropy LTS release
-        - python: 2.7
-          env: ASTROPY_VERSION=LTS
-               SETUP_CMD='test --coverage'
-
-        # Check compatibility with the pre-LTS astropys
         - python: 3.6
-          env: ASTROPY_VERSION=1.3 PYTEST_VERSION=3.1
-               SETUP_CMD='test --coverage'
-
-        - python: 3.6
-          env: ASTROPY_VERSION=1.0 PYTEST_VERSION=2.7
+          env: ASTROPY_VERSION=2
                SETUP_CMD='test --coverage'
 
         # Try older numpy, python versions
         - python: 3.4
-          env: NUMPY_VERSION=1.10
-
-        - python: 3.5
           env: NUMPY_VERSION=1.11
 
-        - python: 3.6
+        - python: 3.5
           env: NUMPY_VERSION=1.12
+
+        - python: 3.6
+          env: NUMPY_VERSION=1.13
 
         # Try numpy pre-release version. This runs only when a pre-release
         # is available on pypi.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,6 @@ environment:
       ASTROPY_USE_SYSTEM_PYTEST: 1
 
   matrix:
-
-      - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "stable"
-        NUMPY_VERSION: "stable"
-
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"


### PR DESCRIPTION
Removes the following from CI:

- Python 2,7
- Astropy 1.x

And adds:

- NumPy 1.13 (which was untested since 1.14 has been released),

Given that Python 3.7 will be out soon we could also think about dropping Python 3.4.

Closes #511 and closes #613 and closes #615 