### PR TITLE
Astropy > 2.0 for rtd pip-requirements

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -2,4 +2,4 @@ numpy>=1.9
 scipy
 scikit-image
 numpydoc
-astropy>=1.0
+astropy>=2.0


### PR DESCRIPTION
I missed that in my earlier PR.