### PR TITLE
Remove Python2 support by removing __future__ includes and six

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Dropped support for Python 2.x and Astropy 1.x.
+
 - Removed deprecated property ``summary_info`` of ``ImageFileCollection``.
 
 - Improved handling of large flags in the ``bitfield`` module. [#610]

--- a/ccdproc/_astropy_init.py
+++ b/ccdproc/_astropy_init.py
@@ -6,11 +6,7 @@ __all__ = ['__version__', '__githash__', 'test']
 try:
     _ASTROPY_SETUP_
 except NameError:
-    from sys import version_info
-    if version_info[0] >= 3:
-        import builtins
-    else:
-        import __builtin__ as builtins
+    import builtins
     builtins._ASTROPY_SETUP_ = False
 
 try:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -2,14 +2,10 @@
 
 """This module implements the base CCDPROC functions"""
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numbers
 
 import numpy as np
 import math
-from astropy.extern import six
 from astropy.units.quantity import Quantity
 from astropy import units as u
 from astropy.modeling import fitting
@@ -196,7 +192,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         nccd = subtract_overscan(nccd, overscan=oscan,
                                  median=oscan_median,
                                  model=oscan_model)
-    elif isinstance(oscan, six.string_types):
+    elif isinstance(oscan, str):
         nccd = subtract_overscan(nccd, fits_section=oscan,
                                  median=oscan_median,
                                  model=oscan_model)
@@ -206,7 +202,7 @@ def ccd_process(ccd, oscan=None, trim=None, error=False, master_bias=None,
         raise TypeError('oscan is not None, a string, or CCDData object.')
 
     # apply the trim correction
-    if isinstance(trim, six.string_types):
+    if isinstance(trim, str):
         nccd = trim_image(nccd, fits_section=trim)
     elif trim is None:
         pass
@@ -442,7 +438,7 @@ def subtract_overscan(ccd, overscan=None, overscan_axis=1, fits_section=None,
         raise TypeError('overscan is not a CCDData object.')
 
     if (fits_section is not None and
-            not isinstance(fits_section, six.string_types)):
+            not isinstance(fits_section, str)):
         raise TypeError('overscan is not a string.')
 
     if fits_section is not None:
@@ -531,7 +527,7 @@ def trim_image(ccd, fits_section=None):
     ``arr1``, not a copy.
     """
     if (fits_section is not None and
-            not isinstance(fits_section, six.string_types)):
+            not isinstance(fits_section, str)):
         raise TypeError("fits_section must be a string.")
     trimmed = ccd.copy()
     if fits_section:
@@ -1729,8 +1725,8 @@ def ccdmask(ratio, findbadcolumns=False, byblocks=False, ncmed=7, nlmed=7,
     if byblocks:
         nlinesblock = int(math.ceil(nlines / nlsig))
         ncolsblock = int(math.ceil(ncols / ncsig))
-        for i in six.moves.range(nlinesblock):
-            for j in six.moves.range(ncolsblock):
+        for i in range(nlinesblock):
+            for j in range(ncolsblock):
                 l1 = i * nlsig
                 l2 = min((i + 1) * nlsig, nlines)
                 c1 = j * ncsig
@@ -1761,10 +1757,10 @@ def ccdmask(ratio, findbadcolumns=False, byblocks=False, ncmed=7, nlmed=7,
         # Loop through columns and look for short segments (<ngood pixels long)
         # which are unmasked, but are surrounded by masked pixels and mask them
         # under the assumption that the column region is bad.
-        for col in six.moves.range(0, ncols):
-            for line in six.moves.range(0, nlines - ngood - 1):
+        for col in range(0, ncols):
+            for line in range(0, nlines - ngood - 1):
                 if mask[line, col]:
-                    for i in six.moves.range(2, ngood + 2):
+                    for i in range(2, ngood + 2):
                         lend = line + i
                         if (mask[lend, col] and
                                 not np.all(mask[line:lend + 1, col])):
@@ -1888,7 +1884,7 @@ class Keyword(object):
         elif isinstance(value, Quantity):
             self._unit = value.unit
             self._value = value
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, str):
             if self.unit is not None:
                 raise ValueError("keyword with a unit cannot have a "
                                  "string value.")

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (print_function, division, absolute_import,
-                        unicode_literals)
-
 from collections import OrderedDict
 import fnmatch
 from os import listdir, path
@@ -13,7 +10,6 @@ import numpy.ma as ma
 
 from astropy.table import Table, MaskedColumn
 import astropy.io.fits as fits
-from astropy.extern import six
 from astropy.utils import minversion
 
 import warnings
@@ -436,7 +432,7 @@ class ImageFileCollection(object):
         """
         files = []
         if self._filenames:
-            if isinstance(self._filenames, six.string_types):
+            if isinstance(self._filenames, str):
                 files.append(self._filenames)
             else:
                 files = self._filenames
@@ -509,7 +505,7 @@ class ImageFileCollection(object):
                             'history': []}
 
         alreadyencountered = set()
-        for k, v in six.iteritems(h):
+        for k, v in h.items():
             if k == '':
                 continue
 
@@ -538,7 +534,7 @@ class ImageFileCollection(object):
 
             _add_val_to_dict(k, v, summary, n_previous, missing_marker)
 
-        for k, v in six.iteritems(multi_entry_keys):
+        for k, v in multi_entry_keys.items():
             if v:
                 joined = ','.join(v)
                 _add_val_to_dict(k, joined, summary, n_previous,
@@ -672,7 +668,7 @@ class ImageFileCollection(object):
             if value == '*':
                 have_this_value = value_not_missing
             elif value is not None:
-                if isinstance(value, six.string_types):
+                if isinstance(value, str):
                     # need to loop explicitly over array rather than using
                     # where to correctly do string comparison.
                     have_this_value = np.zeros(len(use_info), dtype=bool)

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -1,15 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from functools import wraps
 import inspect
 from itertools import chain
 
 import numpy as np
 
-from astropy.extern import six
 from astropy.nddata import NDData
 from astropy import units as u
 from astropy.io import fits
@@ -104,8 +100,7 @@ def log_to_metadata(func):
             # Logging is not turned off, but user did not provide a value
             # so construct one.
             key = func.__name__
-            all_args = chain(zip(original_positional_args, args),
-                             six.iteritems(kwd))
+            all_args = chain(zip(original_positional_args, args), kwd.items())
             all_args = ["{0}={1}".format(name,
                                          _replace_array_with_placeholder(val))
                         for name, val in all_args]
@@ -113,7 +108,7 @@ def log_to_metadata(func):
             log_val = log_val.replace("\n", "")
             meta_dict = {key: log_val}
 
-        for k, v in six.iteritems(meta_dict):
+        for k, v in meta_dict.items():
             _insert_in_metadata_fits_safe(result, k, v)
         return result
 
@@ -121,7 +116,7 @@ def log_to_metadata(func):
 
 
 def _metadata_to_dict(arg):
-    if isinstance(arg, six.string_types):
+    if isinstance(arg, str):
         # add the key, no value
         return {arg: None}
     elif isinstance(arg, ccdproc.Keyword):

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -1,11 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 
-from astropy.extern import six
 from astropy.nddata import CCDData
 import pytest
 
@@ -48,7 +44,7 @@ def test_log_dict(ccd_data):
     }
     new = create_deviation(ccd_data, readnoise=3 * ccd_data.unit,
                           add_keyword=keys_to_add)
-    for k, v in six.iteritems(keys_to_add):
+    for k, v in keys_to_add.items():
         # Were all dictionary items added?
         assert k in new.meta
         assert k not in ccd_data.meta

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1,13 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (print_function, division, absolute_import,
-                        unicode_literals)
-
 import os
 from shutil import rmtree
 from tempfile import mkdtemp
 from glob import iglob
-import sys
 import logging
 import pytest
 
@@ -17,7 +13,6 @@ import numpy as np
 from astropy.tests.helper import catch_warnings
 from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.extern import six
 
 from astropy.nddata import CCDData
 
@@ -74,9 +69,9 @@ class TestImageFileCollectionRepresentation(object):
             filenames=['no_filter_no_object_light.fit',
                        'no_filter_no_object_bias.fit'])
         ref = ("ImageFileCollection(location={0!r}, "
-               "filenames=[{1}'no_filter_no_object_light.fit', "
-               "{1}'no_filter_no_object_bias.fit'])"
-               .format(triage_setup.test_dir, 'u' if six.PY2 else ''))
+               "filenames=['no_filter_no_object_light.fit', "
+               "'no_filter_no_object_bias.fit'])"
+               .format(triage_setup.test_dir))
         assert repr(ic) == ref
 
     def test_repr_ext(self, triage_setup):
@@ -90,9 +85,9 @@ class TestImageFileCollectionRepresentation(object):
             filenames=['mef.fits'],
             ext=1)
         ref = ("ImageFileCollection(location={0!r}, "
-               "filenames=[{1}'mef.fits'], "
+               "filenames=['mef.fits'], "
                "ext=1)"
-               .format(triage_setup.test_dir, 'u' if six.PY2 else ''))
+               .format(triage_setup.test_dir))
         assert repr(ic) == ref
 
     def test_repr_info(self, triage_setup):
@@ -823,9 +818,6 @@ class TestImageFileCollection(object):
         assert 'fun' in ic.summary['stupid']
         assert 'nofun' not in ic.summary['stupid']
 
-    @pytest.mark.skipif(
-        "sys.platform.startswith('win') and six.PY2",
-        reason="os.path.samefile isn't available on windows (python < 3.2).")
     def test_ccds_generator_in_different_directory(self, triage_setup, tmpdir):
         """
         Regression test for https://github.com/astropy/ccdproc/issues/421 in

--- a/ccdproc/tests/test_keyword.py
+++ b/ccdproc/tests/test_keyword.py
@@ -1,9 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-from astropy.extern import six
 import pytest
 from astropy import units as u
 from astropy.io import fits
@@ -55,7 +51,7 @@ def test_value_setting(value, unit, expected):
             key = Keyword(name, unit=unit, value=value)
     else:
         key = Keyword(name, unit=unit, value=value)
-        if isinstance(expected, six.string_types):
+        if isinstance(expected, str):
             assert key.value == expected
         else:
             assert key.value == numerical_value * key.unit


### PR DESCRIPTION
After we dropped the tests for Python 2 this removes the most obvious compatibility places.