### PR TITLE
Fixes #90. Add auto_logging configuration parameter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Other Changes and Additions
 
 - Improved the performance of several ``ImageFileCollection`` methods. [#599]
 
+- Added auto_logging configuration paramenter [#90]
+
 Bug Fixes
 ^^^^^^^^^
 - Function ``median_combine`` now correctly calculates the uncertainty for 

--- a/ccdproc.cfg
+++ b/ccdproc.cfg
@@ -1,0 +1,5 @@
+[ccdproc]
+# auto_logging = True
+# Whether to automatically log operations to metadata
+# If set to False, there is no need to specify add_keyword=False
+# when calling processing operations

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -17,3 +17,20 @@ if not _ASTROPY_SETUP_:
     from .ccddata import *
     from .combiner import *
     from .image_collection import *
+
+from astropy import config as _config
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astropy.ccdproc`.
+    """
+
+    auto_logging = _config.ConfigItem(
+        True,
+        'Whether to automatically log operations to metadata'
+        'If set to False, there is no need to specify add_keyword=False'
+        'when calling processing operations.'
+    )
+
+
+conf = Conf()

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -98,15 +98,18 @@ def log_to_metadata(func):
             meta_dict = _metadata_to_dict(log_result)
         else:
             # Logging is not turned off, but user did not provide a value
-            # so construct one.
-            key = func.__name__
-            all_args = chain(zip(original_positional_args, args), kwd.items())
-            all_args = ["{0}={1}".format(name,
-                                         _replace_array_with_placeholder(val))
-                        for name, val in all_args]
-            log_val = ", ".join(all_args)
-            log_val = log_val.replace("\n", "")
-            meta_dict = {key: log_val}
+            # so construct one unless the config parameter auto_logging is set to False
+            if ccdproc.conf.auto_logging is True:
+                key = func.__name__
+                all_args = chain(zip(original_positional_args, args), kwd.items())
+                all_args = ["{0}={1}".format(name,
+                                            _replace_array_with_placeholder(val))
+                            for name, val in all_args]
+                log_val = ", ".join(all_args)
+                log_val = log_val.replace("\n", "")
+                meta_dict = {key: log_val}
+            else:
+                meta_dict = {}
 
         for k, v in meta_dict.items():
             _insert_in_metadata_fits_safe(result, k, v)


### PR DESCRIPTION


If auto_logging is set to False and no add_keyword is specified,
ccdproc will not automatically create  and add a keyword to the
metadata

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ yes] Did you add an entry to the "Changes.rst" file?
- [ no] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [yes ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ no] Did you include tests for the new functionality?
- [ yes] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------


All tests passed:
running test
running build
running build_py
============================= test session starts ==============================
platform darwin -- Python 3.6.3, pytest-3.2.1, py-1.4.34, pluggy-0.4.0

Running tests with ccdproc version 2.0.dev1355.
Running tests in lib.macosx-10.7-x86_64-3.6/ccdproc docs.

Date: 2018-05-03T16:03:50

Platform: Darwin-17.5.0-x86_64-i386-64bit

Executable: /Users/lrizzi/anaconda/bin/python

Full Python Version: 
3.6.3 |Anaconda custom (64-bit)| (default, Nov  8 2017, 18:10:31) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]

encodings: sys: utf-8, locale: US-ASCII, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.13.3
Scipy: 1.0.0
Matplotlib: 2.1.0
Pandas: 0.21.0
Astropy: 2.0.2
astroscrappy: 1.0.5
reproject: 0.3.2
Using Astropy options: remote_data: none.

rootdir: /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy, inifile: setup.cfg
collected 288 items

ccdproc/combiner.py .
ccdproc/core.py ....ss...
ccdproc/extern/bitfield.py ..
ccdproc/tests/test_bitfield.py ............
ccdproc/tests/test_ccdmask.py ...
ccdproc/tests/test_ccdproc.py ....................................................................
ccdproc/tests/test_ccdproc_logging.py .......
ccdproc/tests/test_combiner.py ..............................................
ccdproc/tests/test_cosmicray.py ...............
ccdproc/tests/test_gain.py .....
ccdproc/tests/test_image_collection.py .....................................................................
ccdproc/tests/test_keyword.py ..........
ccdproc/tests/test_rebin.py ........
ccdproc/tests/test_wrapped_external_funcs.py ...
ccdproc/utils/slices.py .
ccdproc/utils/tests/test_slices.py ..................
../docs/authors_for_sphinx.rst .
../docs/changelog.rst .
../docs/index.rst .
../docs/license.rst .
../docs/ccdproc/ccddata.rst .
../docs/ccdproc/image_combination.rst .
../docs/ccdproc/image_management.rst .
../docs/ccdproc/index.rst .
../docs/ccdproc/install.rst .
../docs/ccdproc/reduction_examples.rst .
../docs/ccdproc/reduction_toolbox.rst .

=============================== warnings summary ===============================
None
  [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.

lib.macosx-10.7-x86_64-3.6/ccdproc/tests/test_ccdproc.py::test_cosmicray_median_does_not_change_input
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:1560: RuntimeWarning: divide by zero encountered in true_divide
    rarr = (data - marr) / error_image
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:1560: RuntimeWarning: invalid value encountered in true_divide
    rarr = (data - marr) / error_image
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:1563: RuntimeWarning: invalid value encountered in greater
    crarr = (rarr > thresh)

lib.macosx-10.7-x86_64-3.6/ccdproc/tests/test_ccdproc.py::test_flat_correct_does_not_change_input
  /Users/lrizzi/anaconda/lib/python3.6/site-packages/astropy/units/quantity.py:641: RuntimeWarning: invalid value encountered in true_divide
    *arrays, **kwargs)

lib.macosx-10.7-x86_64-3.6/ccdproc/tests/test_ccdproc.py::test_transform_image_does_not_change_input
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:836: RuntimeWarning: invalid value encountered in sqrt
    nccd.data = transform_func(nccd.data, **kwargs)

lib.macosx-10.7-x86_64-3.6/ccdproc/tests/test_ccdproc.py::test_wcs_project_onto_shifted_wcs
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:916: RuntimeWarning: invalid value encountered in greater
    reprojected_mask = reprojected_mask > 1e-8

lib.macosx-10.7-x86_64-3.6/ccdproc/tests/test_ccdproc.py::test_wcs_project_onto_scale_wcs
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/core.py:916: RuntimeWarning: invalid value encountered in greater
    reprojected_mask = reprojected_mask > 1e-8

docs/ccdproc/image_combination.rst
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/combiner.py:167: UserWarning: Warning: converting a masked element to nan.
    self._scaling = np.array(self._scaling)
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/combiner.py:167: UserWarning: Warning: converting a masked element to nan.
    self._scaling = np.array(self._scaling)
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/combiner.py:167: UserWarning: Warning: converting a masked element to nan.
    self._scaling = np.array(self._scaling)

docs/ccdproc/image_management.rst
  /private/var/folders/mw/ywl_w2k12bq4ddknw62xnf5m0000gq/T/ccdproc-test-gwbqogdy/lib.macosx-10.7-x86_64-3.6/ccdproc/image_collection.py:113: AstropyUserWarning: no FITS files in the collection.
    AstropyUserWarning)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
============= 286 passed, 2 skipped, 12 warnings in 14.29 seconds ==============




