### PR TITLE
Added compression formats supported by astropy

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Alphabetical list of contributors
 * Yoonsoo P. Bach (@ysBach)
 * Kyle Barbary (@kbarbary)
 * Javier Blasco (@javierblasco)
+* Julio C. N. Campagnolo (@juliotux)
 * Mihai Cara (@mcara)
 * Christoph Deil (@cdeil)
 * Carlos Gomez (@carlgogo)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,11 @@ Other Changes and Additions
 
 - Added auto_logging configuration paramenter [#622, #90]
 
+- Added support for .bz2, .Z and .zip file formats in ``ImageFileCollection``.
+
 Bug Fixes
 ^^^^^^^^^
-- Function ``median_combine`` now correctly calculates the uncertainty for 
+- Function ``median_combine`` now correctly calculates the uncertainty for
   masked ``CCDData``. [#608]
 
 1.3.0 (2017-11-1)

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -731,8 +731,9 @@ class ImageFileCollection(object):
         full_extensions = extensions or list(_recognized_fits_file_extensions)
 
         if compressed:
-            with_gz = [extension + '.gz' for extension in full_extensions]
-            full_extensions.extend(with_gz)
+            for comp in ['gz', 'bz2', 'Z', '.zip']:
+                with_comp = [extension + comp for extension in full_extensions]
+                full_extensions.extend(with_comp)
 
         all_files = listdir(self.location)
         files = []

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -730,8 +730,9 @@ class ImageFileCollection(object):
 
         full_extensions = extensions or list(_recognized_fits_file_extensions)
 
+        # The common compressed fits image .fz not supported.
         if compressed:
-            for comp in ['gz', 'bz2', 'Z', '.zip']:
+            for comp in ['.gz', '.bz2', '.Z', '.zip']:
                 with_comp = [extension + comp for extension in full_extensions]
                 full_extensions.extend(with_comp)
 


### PR DESCRIPTION
Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
Astropy supports more formats of compressed images that are not included in the original version, commonly used by several observatories.