### PR TITLE
Ignore .vscode and .eggs folder in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,11 @@ docs/_build
 # Pycharm editor project files
 .idea
 
+# VSCode editor files
+.vscode
+
 # Packages/installer info
+.eggs
 *.egg
 *.egg-info
 dist
@@ -59,4 +63,3 @@ nosetests.xml
 
 # Mr Developer
 .mr.developer.cfg
-


### PR DESCRIPTION
No idea where the `.eggs` folder is coming from but it's probably not necessary to include it in the repo