### PR TITLE
Unify scale handling in the combine methods and avoid multiplying by 1 if none is given

### DIFF
--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -302,6 +302,13 @@ class Combiner(object):
             mask = (self.data_arr - baseline > high_thresh * dev)
             self.data_arr.mask[mask] = True
 
+    def _get_scaled_data(self, scale_arg):
+        if scale_arg is not None:
+            return self.data_arr * scale_arg
+        if self.scaling is not None:
+            return self.data_arr * self.scaling
+        return self.data_arr
+
     # set up the combining algorithms
     def median_combine(self, median_func=ma.median, scale_to=None,
                        uncertainty_func=sigma_func):
@@ -340,15 +347,8 @@ class Combiner(object):
         The uncertainty currently calculated using the median absolute
         deviation does not account for rejected pixels.
         """
-        if scale_to is not None:
-            scalings = scale_to
-        elif self.scaling is not None:
-            scalings = self.scaling
-        else:
-            scalings = 1.0
-
         # set the data
-        data = median_func(scalings * self.data_arr, axis=0)
+        data = median_func(self._get_scaled_data(scale_to), axis=0)
 
         # set the mask
         masked_values = self.data_arr.mask.sum(axis=0)
@@ -407,15 +407,8 @@ class Combiner(object):
         combined_image: `~astropy.nddata.CCDData`
             CCDData object based on the combined input of CCDData objects.
         """
-        if scale_to is not None:
-            scalings = scale_to
-        elif self.scaling is not None:
-            scalings = self.scaling
-        else:
-            scalings = 1.0
-
         # set up the data
-        data, wei = scale_func(scalings * self.data_arr,
+        data, wei = scale_func(self._get_scaled_data(scale_to),
                                axis=0, weights=self.weights,
                                returned=True)
 
@@ -475,15 +468,8 @@ class Combiner(object):
         combined_image: `~astropy.nddata.CCDData`
             CCDData object based on the combined input of CCDData objects.
         """
-        if scale_to is not None:
-            scalings = scale_to
-        elif self.scaling is not None:
-            scalings = self.scaling
-        else:
-            scalings = 1.0
-
         # set up the data
-        data = sum_func(scalings * self.data_arr, axis=0)
+        data = sum_func(self._get_scaled_data(scale_to), axis=0)
 
         # set up the mask
         masked_values = self.data_arr.mask.sum(axis=0)


### PR DESCRIPTION
This unifys the `scale` handling in the `*combine` methods by putting it in a separate method. It also simply returns the `data_arr` in case there is no scaling. This has a potentially huge advantage because in the common case that there is no scaling it doesn't do a copy. That copy could be several GB big (because it's a copy of the stacked ccds and the mask) so avoiding it when possible at least saves a bit of memory.

However I noticed that we don't use the scale for the uncertainty calculation, that probably warrants an own issue (or pull request). I tried to keep it to a simple refactor for this PR.