### PR TITLE
Fixed typo in license section

### DIFF
--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,8 +1,8 @@
 .. _license:
 
-********
-Licenses
-********
+*******
+License
+*******
 
 Ccdproc License
 ===============


### PR DESCRIPTION
Fixed typo in license section of RTD.

Ignored all the questions placed on this area because I thought they didn't apply to this case.