### PR TITLE
Fix calculation of `ystep` in `combine`

### DIFF
--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -507,9 +507,19 @@ def _calculate_step_sizes(x_size, y_size, num_chunks):
     # First we try to split only along fast x axis
     xstep = max(1, int(x_size / num_chunks))
 
-    # If more chunks need to be created we split in Y axis for remaining number
-    # of chunks
-    ystep = max(1, int(y_size / (1 + num_chunks - int(x_size / xstep))))
+    # More chunks are needed only if xstep gives us fewer chunks than
+    # requested.
+    x_chunks = int(x_size / xstep)
+
+    if x_chunks >= num_chunks:
+        ystep = y_size
+    else:
+        # The x and y loops are nested, so the number of chunks
+        # is multiplicative, not additive. Calculate the number
+        # of y chunks we need to get at num_chunks.
+        y_chunks = int(num_chunks / x_chunks) + 1
+        ystep = max(1, int(y_size / y_chunks))
+
     return xstep, ystep
 
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -9,7 +9,7 @@ import pytest
 from astropy.utils.data import get_pkg_data_filename
 from astropy.nddata import CCDData
 
-from ..combiner import Combiner, combine
+from ..combiner import Combiner, combine, _calculate_step_sizes
 
 
 #test that the Combiner raises error if empty
@@ -630,3 +630,17 @@ def test_clip_extrema_with_other_rejection():
                 [ 30. , 30. , 47.5, 30., 30.],
                 [ 47.5, 30. , 30. , 30., 30.]]
     np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize('num_chunks, expected',
+                         [(53, (37, 2000)),
+                          (1500, (1, 2000))]
+                         )
+def test_ystep_calculation(num_chunks, expected):
+    # Regression test for
+    # https://github.com/astropy/ccdproc/issues/639
+    # See that issue for the motivation for the choice of
+    # image size and number of chunks in the test below.
+
+    xstep, ystep = _calculate_step_sizes(2000, 2000, num_chunks)
+    assert xstep == expected[0] and ystep == expected[1]

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -632,9 +632,13 @@ def test_clip_extrema_with_other_rejection():
     np.testing.assert_array_equal(result, expected)
 
 
+# The expected values below assume an image that is 2000x2000
 @pytest.mark.parametrize('num_chunks, expected',
                          [(53, (37, 2000)),
-                          (1500, (1, 2000))]
+                          (1500, (1, 2000)),
+                          (2001, (1, 1000)),
+                          (2999, (1, 1000)),
+                          (10000, (1, 333))]
                          )
 def test_ystep_calculation(num_chunks, expected):
     # Regression test for


### PR DESCRIPTION
The first commit here adds a regression test; I haven't pushed the fix yet so I expect it to fail.

I moved calculation of the steps into a function of its own because it made testing much simpler. 