### PR TITLE
Change in image_collection.py to support for .fz files

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -732,7 +732,7 @@ class ImageFileCollection(object):
 
         # The common compressed fits image .fz not supported.
         if compressed:
-            for comp in ['.gz', '.bz2', '.Z', '.zip']:
+            for comp in ['.gz', '.bz2', '.Z', '.zip', '.fz']:
                 with_comp = [extension + comp for extension in full_extensions]
                 full_extensions.extend(with_comp)
 


### PR DESCRIPTION
This PR is a change for the support of fpack files, and fixes #643 . That issue has all the descriptions for this little change in `image_collection.py`

- [yes] Does the commit message include a "Fixes #643 " (replace "issue_number").
- [] Does this PR add, rename, move or remove any existing functions or parameters?
---------------------------------------


