### PR TITLE
Relax the array equality check in the gain tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ matrix:
           env: ASTROPY_VERSION=2
                SETUP_CMD='test --coverage'
 
-        # Try older numpy, python versions
-        - python: 3.4
-          env: NUMPY_VERSION=1.12
-
         - python: 3.5
           env: NUMPY_VERSION=1.13
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,13 @@ matrix:
 
         # Try older numpy, python versions
         - python: 3.4
-          env: NUMPY_VERSION=1.11
-
-        - python: 3.5
           env: NUMPY_VERSION=1.12
 
-        - python: 3.6
+        - python: 3.5
           env: NUMPY_VERSION=1.13
+
+        - python: 3.6
+          env: NUMPY_VERSION=1.14
 
         # Try numpy pre-release version. This runs only when a pre-release
         # is available on pypi.

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -28,11 +28,11 @@ DEFAULT_DATA_SCALE = 1.0
 
 
 def value_from_markers(key, request):
-    try:
-        val = request.keywords[key].args[0]
-    except KeyError:
-        val = DEFAULTS[key]
-    return val
+    m = request.node.get_closest_marker(key)
+    if m is not None:
+        return m.args[0]
+    else:
+        return DEFAULTS[key]
 
 
 @pytest.fixture

--- a/ccdproc/tests/test_gain.py
+++ b/ccdproc/tests/test_gain.py
@@ -30,9 +30,9 @@ def test_linear_gain_correct(ccd_data, gain):
     except AttributeError:
         gain_value = gain
 
-    np.testing.assert_array_equal(ccd.data, gain_value * orig_data)
-    np.testing.assert_array_equal(ccd.uncertainty.array,
-                                  gain_value * ccd_data.uncertainty.array)
+    np.testing.assert_array_almost_equal_nulp(ccd.data, gain_value * orig_data)
+    np.testing.assert_array_almost_equal_nulp(
+        ccd.uncertainty.array, gain_value * ccd_data.uncertainty.array)
 
     if isinstance(gain, u.Quantity):
         assert ccd.unit == ccd_data.unit * gain.unit
@@ -52,7 +52,7 @@ def test_linear_gain_unit_keyword(ccd_data):
     gain = 3.0
     gain_unit = u.electron / u.adu
     ccd = gain_correct(ccd_data, gain, gain_unit=gain_unit)
-    np.testing.assert_array_equal(ccd.data, gain * orig_data)
-    np.testing.assert_array_equal(ccd.uncertainty.array,
-                                  gain * ccd_data.uncertainty.array)
+    np.testing.assert_array_almost_equal_nulp(ccd.data, gain * orig_data)
+    np.testing.assert_array_almost_equal_nulp(
+        ccd.uncertainty.array, gain * ccd_data.uncertainty.array)
     assert ccd.unit == ccd_data.unit * gain_unit


### PR DESCRIPTION
This fixes #647 (some test failures against astropy dev and the 3.1 release candidate)