### PR TITLE
Fix builds on RTD

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -2,4 +2,5 @@ numpy>=1.9
 scipy
 scikit-image
 numpydoc
-astropy>=2.0
+astropy>=3.0
+sphinx-astropy


### PR DESCRIPTION
This adds sphinx-astropy to the ReadTheDocs build requirements. If it fixes the builds, this closes #654 and closes #655 