### PR TITLE
add error in subtract_dark for array differences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Bug Fixes
 
 - Function ``combine`` avoids keeping files open unnecessarily. [#629, #630]
 
+- Raise ``ValueError`` error in ``subtract_dark`` for when the errors have
+  different shapes [#674, #677]
+
 1.3.0 (2017-11-1)
 -----------------
 

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -617,6 +617,10 @@ def subtract_dark(ccd, master, dark_exposure=None, data_exposure=None,
     result : `~astropy.nddata.CCDData`
         Dark-subtracted image.
     """
+    if ccd.shape != master.shape:
+        err_str = "operands could not be subtracted with shapes {} {}".format(ccd.shape, master.shape)
+        raise ValueError(err_str)
+
     if not (isinstance(ccd, CCDData) and isinstance(master, CCDData)):
         raise TypeError("ccd and master must both be CCDData objects.")
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -401,6 +401,12 @@ def test_subtract_dark_fails(ccd_data):
                       exposure_unit=u.second)
     assert "uncalibrated image" in str(e.value)
 
+    # fail when the arrays are not the same size
+    with pytest.raises(ValueError):
+        small_master = CCDData(ccd_data)
+        small_master.data = np.zeros((1, 1))
+        subtract_dark(ccd_data, small_master)
+
 
 def test_unit_mismatch_behaves_as_expected(ccd_data):
     """


### PR DESCRIPTION
Fixes #674 by adding a check that the arrays have to be the same size. 