### PR TITLE
Rewrite pytest fixture for generating ImageFileCollection test directory

### DIFF
--- a/ccdproc/tests/data/expected_ifc_file_properties.csv
+++ b/ccdproc/tests/data/expected_ifc_file_properties.csv
@@ -1,0 +1,7 @@
+file,simple,bitpix,naxis,naxis1,extend,bscale,bzero,imagetyp,filter,exptime
+filter_no_object_light.fit,True,16,1,100,True,1,32768,LIGHT,R,1.0
+filter_object_light.fit,True,16,1,100,True,1,32768,LIGHT,R,1.0
+filter_object_light.fit.gz,True,16,1,100,True,1,32768,LIGHT,R,1.0
+no_filter_no_object_bias.fit,True,16,1,100,True,1,32768,BIAS,,0.0
+no_filter_no_object_light.fit,True,16,1,100,True,1,32768,LIGHT,,1.0
+test.fits.fz,True,16,1,100,True,1,32768,LIGHT,R,15.0

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -66,94 +66,102 @@ def ccd_data(request):
     return ccd
 
 
-@pytest.fixture
-def triage_setup(request):
-    n_test = {'files': 0, 'need_object': 0,
-              'need_filter': 0, 'bias': 0,
-              'compressed': 0, 'light': 0,
-              'need_pointing': 0}
-
-    test_dir = ''
-
-    for key in n_test.keys():
-        n_test[key] = 0
-
-    test_dir = mkdtemp()
-    original_dir = os.getcwd()
-    os.chdir(test_dir)
+def _make_file_for_testing(file_name='', **kwd):
     img = np.uint16(np.arange(100))
 
-    no_filter_no_object = fits.PrimaryHDU(img)
-    no_filter_no_object.header['imagetyp'] = 'light'.upper()
-    no_filter_no_object.writeto('no_filter_no_object_light.fit')
-    n_test['files'] += 1
-    n_test['need_object'] += 1
-    n_test['need_filter'] += 1
-    n_test['light'] += 1
-    n_test['need_pointing'] += 1
+    hdu = fits.PrimaryHDU(img)
 
-    no_filter_no_object.header['imagetyp'] = 'bias'.upper()
-    no_filter_no_object.writeto('no_filter_no_object_bias.fit')
-    n_test['files'] += 1
-    n_test['bias'] += 1
+    for k, v in kwd.items():
+        hdu.header[k] = v
 
-    filter_no_object = fits.PrimaryHDU(img)
-    filter_no_object.header['imagetyp'] = 'light'.upper()
-    filter_no_object.header['filter'] = 'R'
-    filter_no_object.writeto('filter_no_object_light.fit')
-    n_test['files'] += 1
-    n_test['need_object'] += 1
-    n_test['light'] += 1
-    n_test['need_pointing'] += 1
+    hdu.writeto(file_name)
 
-    filter_no_object.header['imagetyp'] = 'bias'.upper()
-    filter_no_object.writeto('filter_no_object_bias.fit')
-    n_test['files'] += 1
-    n_test['bias'] += 1
 
-    filter_object = fits.PrimaryHDU(img)
-    filter_object.header['imagetyp'] = 'light'.upper()
-    filter_object.header['filter'] = 'R'
-    filter_object.header['OBJCTRA'] = '00:00:00'
-    filter_object.header['OBJCTDEC'] = '00:00:00'
-    filter_object.writeto('filter_object_light.fit')
-    n_test['files'] += 1
-    n_test['light'] += 1
-    n_test['need_object'] += 1
+@pytest.fixture
+def triage_setup(request):
+    """
+    Set up directory with these contents:
+
+    One file with imagetyp BIAS. It has an the keyword EXPTIME in
+    the header, but no others beyond IMAGETYP and the bare minimum
+    created with the FITS file.
+
+    File name(s)
+    ------------
+
+    no_filter_no_object_bias.fit
+
+    Five (5) files with imagetyp LIGHT, including two compressed
+    files.
+
+    + One file for each compression type, currently .gz and .fz.
+    + ALL of the files will have the keyword EXPTIME
+      in the header.
+    + Only ONE of them will have the value EXPTIME=15.0.
+    + All of the files EXCEPT ONE will have the keyword
+      FILTER with the value 'R'.
+    + NONE of the files have the keyword OBJECT
+
+    File names
+    ----------
+
+    test.fits.fz
+    filter_no_object_light.fit
+    filter_object_light.fit.gz
+    filter_object_light.fit
+    no_filter_no_object_light.fit    <---- this one has no filter
+    """
+    n_test = {
+        'files': 6,
+        'missing_filter_value': 1,
+        'bias': 1,
+        'compressed': 2,
+        'light': 5
+    }
+
+    test_dir = mkdtemp()
+
+    # Directory is reset on teardown.
+    original_dir = os.getcwd()
+    os.chdir(test_dir)
+
+    _make_file_for_testing(file_name='no_filter_no_object_bias.fit',
+                           imagetyp='BIAS',
+                           exptime=0.0)
+
+    _make_file_for_testing(file_name='no_filter_no_object_light.fit',
+                           imagetyp='LIGHT',
+                           exptime=1.0)
+
+    _make_file_for_testing(file_name='filter_no_object_light.fit',
+                           imagetyp='LIGHT',
+                           exptime=1.0,
+                           filter='R')
+
+    _make_file_for_testing(file_name='filter_object_light.fit',
+                           imagetyp='LIGHT',
+                           exptime=1.0,
+                           filter='R')
+
     with open('filter_object_light.fit', 'rb') as f_in:
         with gzip.open('filter_object_light.fit.gz', 'wb') as f_out:
             f_out.write(f_in.read())
-    n_test['files'] += 1
-    n_test['compressed'] += 1
-    n_test['light'] += 1
-    n_test['need_object'] += 1
 
-    filter_object.header['RA'] = filter_object.header['OBJCTRA']
-    filter_object.header['Dec'] = filter_object.header['OBJCTDEC']
-    filter_object.writeto('filter_object_RA_keyword_light.fit')
-    n_test['files'] += 1
-    n_test['light'] += 1
-    n_test['need_object'] += 1
+    # filter_object.writeto('filter_object_RA_keyword_light.fit')
 
-    fzfile = fits.PrimaryHDU(img)
-    fzfile.header['EXPTIME'] = 15.0
-    fzfile.header['imagetyp'] = 'light'.upper()
-    fzfile.header['filter'] = 'R'
-    fzfile.writeto('test.fits.fz')
-    n_test['files'] += 1
-    n_test['compressed'] += 1
-    n_test['light'] += 1
-    n_test['need_object'] += 1
+    _make_file_for_testing(file_name='test.fits.fz',
+                           imagetyp='LIGHT',
+                           exptime=15.0,
+                           filter='R')
 
     def teardown():
-        for key in n_test.keys():
-            n_test[key] = 0
+        os.chdir(original_dir)
         try:
             rmtree(test_dir)
         except OSError:
             # If we cannot clean up just keep going.
             pass
-        os.chdir(original_dir)
+
     request.addfinalizer(teardown)
 
     class Result(object):

--- a/ccdproc/tests/setup_package.py
+++ b/ccdproc/tests/setup_package.py
@@ -3,4 +3,5 @@ def get_package_data():
     return {
         _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc',
                                             'data/a8280271.fits',
-                                            'data/sip-wcs.fit']}
+                                            'data/sip-wcs.fit',
+                                            'data/expected_ifc_file_properties.csv']}

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -8,9 +8,11 @@ import logging
 import pytest
 
 import astropy.io.fits as fits
+from astropy.table import Table
 import numpy as np
 
 from astropy.tests.helper import catch_warnings
+from astropy.utils.data import get_pkg_data_filename
 from astropy.utils import minversion
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -159,7 +161,7 @@ class TestImageFileCollection(object):
         fn = 'test.fits.fz'
         ic = ImageFileCollection(location=triage_setup.test_dir, filenames=fn)
         # Get a subset of files with a specific header value
-        filtered = ic.files_filtered(EXPTIME=15.0)
+        filtered = ic.files_filtered(exptime=15.0)
         assert len(filtered) == 1
 
     def test_filtered_files_have_proper_path(self, triage_setup):
@@ -332,7 +334,7 @@ class TestImageFileCollection(object):
             assert header['filter'].lower() == 'r'
             cnt += 1
         assert cnt == (triage_setup.n_test['light'] -
-                       triage_setup.n_test['need_filter'])
+                       triage_setup.n_test['missing_filter_value'])
 
     def test_headers_with_filter_wildcard(self, triage_setup):
         collection = ImageFileCollection(location=triage_setup.test_dir,
@@ -392,7 +394,7 @@ class TestImageFileCollection(object):
         some_files_should_match = collection.files_filtered(object=None,
                                                             imagetyp='light')
         assert(len(some_files_should_match) ==
-               triage_setup.n_test['need_object'])
+               triage_setup.n_test['light'])
 
     def test_filter_does_not_not_permanently_change_file_mask(self,
                                                               triage_setup):

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -882,3 +882,26 @@ class TestImageFileCollection(object):
             coll.glob_exclude = '*stuff*'
         with pytest.raises(AttributeError):
             coll.glob_include = '*stuff*'
+
+    def test_that_test_files_have_expected_properties(self, triage_setup):
+        expected_name = \
+            get_pkg_data_filename('data/expected_ifc_file_properties.csv')
+        expected = Table.read(expected_name)
+
+        # Make the comparison more reliable by sorting
+        expected.sort('file')
+        ic = ImageFileCollection(triage_setup.test_dir)
+        actual = ic.summary
+        # Write the actual IFC summary out to disk to turn bool into strings of
+        # "True" and "False", and any other non-essential differences between
+        # the tables.
+        tmp_file = 'actual.csv'
+        actual.write(tmp_file)
+        actual = Table.read(tmp_file)
+
+        # Make the comparison more reliable by sorting
+        actual.sort('file')
+        assert len(ic.summary) == len(expected)
+
+        for column in expected.colnames:
+            assert np.all(actual[column] == expected[column])


### PR DESCRIPTION
This PR makes the set up of the `ImageFileCollection` tests clearer, and I think helps resolve #468 by vastly limiting the number of cases in which there are missing entries in the summary table.