### PR TITLE
add ccdmask to reduction toolbox documentation

### DIFF
--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -361,7 +361,7 @@ pixels have a value of one.   This task follows the same algorithm used in the
 iraf ccdmask task. 
 
      >>> ccd.mask =  ccdmask(ccd, ncmed=7, nlmed=7, ncsig=15, nlsig=15, lsigma=9, 
-     ...                     lsigma=9, hsigma=9, ngood=5)
+     ...                     hsigma=9, ngood=5)
   
 
 Filter and Convolution

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -355,6 +355,14 @@ operations in `ccdproc`.
     # Save the mask as "mask" attribute of the ccd
     ccd.mask = mask
 
+Another method for creating a mask is using the `~ccdproc.ccdmask` task.  This
+task will produced a data aray where good pixels have a value of zero and bad
+pixels have a value of one.   This task follows the same algorithm used in the
+iraf ccdmask task. 
+
+     >>> ccd.mask =  ccdmask(ccd, ncmed=7, nlmed=7, ncsig=15, nlsig=15, lsigma=9, 
+     ...                     lsigma=9, hsigma=9, ngood=5)
+  
 
 Filter and Convolution
 ----------------------

--- a/docs/ccdproc/reduction_toolbox.rst
+++ b/docs/ccdproc/reduction_toolbox.rst
@@ -360,8 +360,8 @@ task will produced a data aray where good pixels have a value of zero and bad
 pixels have a value of one.   This task follows the same algorithm used in the
 iraf ccdmask task. 
 
-     >>> ccd.mask =  ccdmask(ccd, ncmed=7, nlmed=7, ncsig=15, nlsig=15, lsigma=9, 
-     ...                     hsigma=9, ngood=5)
+     >>> ccd.mask =  ccdproc.ccdmask(ccd, ncmed=7, nlmed=7, ncsig=15, nlsig=15,
+     ...                             lsigma=9, hsigma=9, ngood=5)
   
 
 Filter and Convolution


### PR DESCRIPTION
documentation update to include ccdmask in narrative docs.

closes #437  