### PR TITLE
Add filtering by regex matching in ImageFileCollection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New Features
 - Allow identification of FITS files in ``ImageFileCollection`` based on content
   of the files instead of file name extension. [#620, #680]
 
+- Add option to use regular expression matching when filtering items in
+  ``ImageFileCollection``. [#480, #595, #681]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ New Features
   of the files instead of file name extension. [#620, #680]
 
 - Add option to use regular expression matching when filtering items in
-  ``ImageFileCollection``. [#480, #595, #681]
+  ``ImageFileCollection``. [#480, #595, #682]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1018,3 +1018,55 @@ class TestImageFileCollection(object):
         ic = ImageFileCollection(triage_setup.test_dir)
         assert ic.summary is None
         assert ic.keywords == []
+
+    def test_regex_match_for_search(self, triage_setup):
+        # Test regex matching in searches
+
+        ic = ImageFileCollection(triage_setup.test_dir)
+
+        files = ic.files_filtered(regex_match=True, imagetyp='b.*s')
+        assert len(files) == triage_setup.n_test['bias']
+
+        # This should return all of the files in the test set
+        all_files = ic.files_filtered(regex_match=True, imagetyp='bias|light')
+        assert len(all_files) == triage_setup.n_test['files']
+
+        # Add a column with more interesting content and see whether we
+        # match that.
+        ic.summary['match_me'] = [
+            'hello',
+            'goodbye',
+            'bye',
+            'byte',
+            'good bye hello',
+            'dog'
+        ]
+
+        hello_anywhere = ic.files_filtered(regex_match=True,
+                                           match_me='hello')
+        assert len(hello_anywhere) == 2
+
+        hello_start = ic.files_filtered(regex_match=True,
+                                        match_me='^hello')
+        assert len(hello_start) == 1
+
+        # Is it really a case-insensitive match?
+        hello_start = ic.files_filtered(regex_match=True,
+                                        match_me='^HeLlo')
+        assert len(hello_start) == 1
+
+        any_bye = ic.files_filtered(regex_match=True,
+                                    match_me='by.*e')
+        assert len(any_bye) == 4
+
+    def test_generator_with_regex(self, triage_setup):
+        ic = ImageFileCollection(triage_setup.test_dir)
+
+        n_light = 0
+
+        for h in ic.headers(regex_match=True, imagetyp='li.*t'):
+            assert h['imagetyp'].lower() == 'light'
+            n_light += 1
+
+        assert n_light == triage_setup.n_test['light']
+

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1069,4 +1069,3 @@ class TestImageFileCollection(object):
             n_light += 1
 
         assert n_light == triage_setup.n_test['light']
-

--- a/docs/ccdproc/image_management.rst
+++ b/docs/ccdproc/image_management.rst
@@ -83,8 +83,26 @@ seconds, there is a convenience method ``.files_filtered``::
 The optional arguments to ``files_filtered`` are used to filter the list of
 files.
 
+Python regular expression patterns can also be used as the value if the
+``regex_match`` flag is set. For example, to find all of the images whose
+object is in the Kelt exoplanet survey, you might do::
+
+    >>> my_files = ic1.files_filtered(regex_match=True, object='kelt.*')
+
+To get all of the images that have image type ``BIAS`` or ``LIGHT`` you
+can also use a regular expression pattern::
+
+    >>> my_files = ic1.files_filtered(regex_match=True,
+    ...                               imagetyp='bias|light')
+
+Note that regular expression is different, and much more flexible than,
+file name matching (or "globbing") at the command line. The
+`Python documentation on the re module <https://docs.python.org/3.7/library/re.html#module-re>`_
+is useful for learning about regular expressions.
+
 Sorting files
 -------------
+
 Sometimes it is useful to bring the files into a specific order, e.g. if you
 make a plot for each object you probably want all images of the same object
 next to each other. To do this, the images in a collection can be sorted with


### PR DESCRIPTION
This closes a couple of issues by allowing regular expression patterns as the values in `files_filtered` and `headers`, `hdus`, etc. 

For example, #480  asked for the ability to select objects that are either "flat" or "dome". This could now be done with:

```python
image_coll = ImageFileCollection('rawdir')
fl = image_coll.hdus(return_fname=True, regex_match=True, object='FLAT|dome’)
```

The regex searches are case insensitive to match the behavior of the existing behavior.

This addresses part of #595 (the wildcards in the values part). 