### PR TITLE
added warning to transform_image that it does not apply to WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Other Changes and Additions
 
 - Added support for .bz2, .Z and .zip file formats in ``ImageFileCollection``.
 
+- Added warning that ``transform_image`` does not apply the transformation to the WCS [#684]
+
+
 Bug Fixes
 ^^^^^^^^^
 - Function ``median_combine`` now correctly calculates the uncertainty for

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -2,10 +2,13 @@
 
 """This module implements the base CCDPROC functions"""
 
+import math
 import numbers
+import logging
 
 import numpy as np
-import math
+from scipy import ndimage
+
 from astropy.units.quantity import Quantity
 from astropy import units as u
 from astropy.modeling import fitting
@@ -16,11 +19,11 @@ from astropy.wcs.utils import proj_plane_pixel_area
 from astropy.utils import deprecated
 import astropy  # To get the version.
 
-from scipy import ndimage
-
 from .utils.slices import slice_from_string
 from .log_meta import log_to_metadata
 from .extern.bitfield import bitfield_to_boolean_mask as _bitfield_to_boolean_mask
+
+logger = logging.getLogger(__name__)
 
 __all__ = ['background_deviation_box', 'background_deviation_filter',
            'ccd_process', 'cosmicray_median', 'cosmicray_lacosmic',
@@ -852,6 +855,10 @@ def transform_image(ccd, transform_func, **kwargs):
     if nccd.mask is not None:
         mask = transform_func(nccd.mask, **kwargs)
         nccd.mask = mask > 0
+
+    if nccd.wcs is not None:
+        warn = 'WCS information may be incorrect as no transformation was applied to it'
+        logging.warning(warn)
 
     return nccd
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -580,7 +580,7 @@ def test_catch_transform_wcs_warning(ccd_data):
         return 10 * arr
 
     with catch_warnings() as w:
-         tran = transform_image(ccd_data, tran)
+        tran = transform_image(ccd_data, tran)
 
 
 @pytest.mark.parametrize('mask_data, uncertainty', [

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -573,6 +573,15 @@ def test_transform_isfunc(ccd_data):
     with pytest.raises(TypeError):
         transform_image(ccd_data, 1)
 
+#test warning is issue if WCS information is available
+def test_catch_transform_wcs_warning(ccd_data):
+
+    def tran(arr):
+        return 10 * arr
+
+    with catch_warnings() as w:
+         tran = transform_image(ccd_data, tran)
+
 
 @pytest.mark.parametrize('mask_data, uncertainty', [
                          (False, False),


### PR DESCRIPTION
This adds a warning to `transform_images` that if a WCS is present, the transform is not applied to that WCS.   