### PR TITLE
Remove numpy dev test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,14 @@ matrix:
                ASTROPY_VERSION=stable
                NUMPY_VERSION=stable
 
-        # Try Astropy/NumPy development versions. This requires them to be
+        # Try Astropy development versions. This requires them to be
         # compiled during setup which takes some time.
+        # Building against numpy dev was removed because it was causing
+        # failures due to numpy dev/astropy dev conflicts unresolvable
+        # in ccdproc.
         - env: PYTHON_VERSION=3.7
                ASTROPY_VERSION=development
-               NUMPY_VERSION=dev
+               NUMPY_VERSION=stable
                SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings


### PR DESCRIPTION
This PR is motivated by the failures in our tests like https://travis-ci.org/astropy/ccdproc/jobs/566628367, which is caused by an issue in astropy core that needs to be resolved with numpy dev (https://github.com/astropy/astropy/pull/9075). In this case our tests never even run because importing astropy fails.

Given that most of our internals depend on astropy, not numpy, I think it makes some sense to make this a permanent switch, but will open an issue in a moment so that we can consider it furtherr.