### PR TITLE
Fix CI problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,15 @@ matrix:
                MAIN_CMD='pycodestyle ccdproc --count  --show-source --show-pep8'
                SETUP_CMD=''
 
+    allow_failures:
+        # Currently fails because of an issue in astropy, once it's fixed
+        # https://github.com/astropy/astropy/issues/9664 this test should not be
+        # allowed to fail
+        - env: PYTHON_VERSION=3.7
+               ASTROPY_VERSION=development
+               NUMPY_VERSION=stable
+               SETUP_CMD='test --coverage'
+
 install:
 
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,15 +61,15 @@ matrix:
                SETUP_CMD='test --coverage'
 
         # Check compatibility with the current astropy LTS release
-        - python: 3.6
-          env: ASTROPY_VERSION=2
+        - env: ASTROPY_VERSION=2
                PYTEST_VERSION=3.6
+               PYTHON_VERSION=3.6
 
-        - python: 3.5
-          env: NUMPY_VERSION=1.13
+        - env: NUMPY_VERSION=1.14
+               PYTHON_VERSION=3.5
 
-        - python: 3.6
-          env: NUMPY_VERSION=1.14
+        - env: NUMPY_VERSION=1.15
+               PYTHON_VERSION=3.6
 
         # Try numpy pre-release version. This runs only when a pre-release
         # is available on pypi.

--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -6,13 +6,30 @@
 
 import os
 
-from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
-                                           TESTED_VERSIONS)
+try:
+    # When the pytest_astropy_header package is installed
+    from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                               TESTED_VERSIONS)
 
-def pytest_configure(config):
-    config.option.astropy_header = True
+    def pytest_configure(config):
+        config.option.astropy_header = True
+except ImportError:
+    # TODO: Remove this when astropy 2.x and 3.x support is dropped.
+    # Probably an old pytest-astropy package where the pytest_astropy_header
+    # is not a dependency.
+    try:
+        from astropy.tests.plugins.display import (pytest_report_header,
+                                                   PYTEST_HEADER_MODULES,
+                                                   TESTED_VERSIONS)
+    except ImportError:
+        # TODO: Remove this when astropy 2.x support is dropped.
+        # If that also did not work we're probably using astropy 2.0
+        from astropy.tests.pytest_plugins import (pytest_report_header,
+                                                  PYTEST_HEADER_MODULES,
+                                                  TESTED_VERSIONS)
 
 try:
+    # TODO: Remove this when astropy 2.x support is dropped.
     # This is the way to get plugins in astropy 2.x
     from astropy.tests.pytest_plugins import *
 except ImportError:

--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -6,15 +6,11 @@
 
 import os
 
-try:
-    from astropy.tests.plugins.display import (pytest_report_header,
-                                               PYTEST_HEADER_MODULES,
-                                               TESTED_VERSIONS)
-except ImportError:
-    # When using astropy 2.0
-    from astropy.tests.pytest_plugins import (pytest_report_header,
-                                              PYTEST_HEADER_MODULES,
-                                              TESTED_VERSIONS)
+from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                           TESTED_VERSIONS)
+
+def pytest_configure(config):
+    config.option.astropy_header = True
 
 try:
     # This is the way to get plugins in astropy 2.x

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -659,8 +659,8 @@ def test_transform_image(mask_data, uncertainty):
 def test_block_reduce():
     ccd = CCDData(np.ones((4, 4)), unit='adu', meta={'testkw': 1},
                   mask=np.zeros((4, 4), dtype=bool),
-                  uncertainty=StdDevUncertainty(np.ones((4, 4))),
-                  wcs=np.zeros((4, 4)))
+                  uncertainty=StdDevUncertainty(np.ones((4, 4)))
+                  )
     with catch_warnings(AstropyUserWarning) as w:
         ccd_summed = block_reduce(ccd, (2, 2))
     assert len(w) == 1
@@ -673,7 +673,6 @@ def test_block_reduce():
     # work on these attributes correctly those tests need to be updated!
     assert ccd_summed.meta == {'testkw': 1}
     assert ccd_summed.mask is None
-    assert ccd_summed.wcs is None
     assert ccd_summed.uncertainty is None
 
     # Make sure meta is copied
@@ -689,8 +688,7 @@ def test_block_reduce():
 def test_block_average():
     ccd = CCDData(np.ones((4, 4)), unit='adu', meta={'testkw': 1},
                   mask=np.zeros((4, 4), dtype=bool),
-                  uncertainty=StdDevUncertainty(np.ones((4, 4))),
-                  wcs=np.zeros((4, 4)))
+                  uncertainty=StdDevUncertainty(np.ones((4, 4))))
     ccd.data[::2, ::2] = 2
     with catch_warnings(AstropyUserWarning) as w:
         ccd_avgd = block_average(ccd, (2, 2))
@@ -717,8 +715,7 @@ def test_block_average():
 def test_block_replicate():
     ccd = CCDData(np.ones((4, 4)), unit='adu', meta={'testkw': 1},
                   mask=np.zeros((4, 4), dtype=bool),
-                  uncertainty=StdDevUncertainty(np.ones((4, 4))),
-                  wcs=np.zeros((4, 4)))
+                  uncertainty=StdDevUncertainty(np.ones((4, 4))))
     with catch_warnings(AstropyUserWarning) as w:
         ccd_repl = block_replicate(ccd, (2, 2))
     assert len(w) == 1

--- a/ccdproc/tests/test_wrapped_external_funcs.py
+++ b/ccdproc/tests/test_wrapped_external_funcs.py
@@ -43,7 +43,6 @@ def test_medianfilter_unusued():
     ccd = CCDData(np.ones((3, 3)), unit='adu',
                   mask=np.ones((3, 3)),
                   uncertainty=StdDevUncertainty(np.ones((3, 3))),
-                  wcs=np.ones((3, 3)),
                   flags=np.ones((3, 3)))
     result = core.median_filter(ccd, 3)
     assert isinstance(result, CCDData)


### PR DESCRIPTION
It seems like we shouldn't use `python:` but instead use the `PYTHON_VERSION` variable.

I also incremented the NumPy versions (no particular reason except that we were missing NumPy 1.15 and I think that would be more appropriate than NumPy 1.13).

Closes #706 

Ref: #707