### PR TITLE
Mark tests that require remote data

### DIFF
--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -321,6 +321,7 @@ def test_combiner_mask_sum():
 
 
 # test combiner convenience function reads fits file and combine as expected
+@pytest.mark.remote_data
 def test_combine_average_fitsimages():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
     ccd = CCDData.read(fitsfile, unit=u.adu)
@@ -335,6 +336,7 @@ def test_combine_average_fitsimages():
     np.testing.assert_array_almost_equal(avgccd.data, ccd_by_combiner.data)
 
 
+@pytest.mark.remote_data
 def test_combine_numpyndarray():
     """ Test of numpy ndarray implementation: #493
 
@@ -374,6 +376,7 @@ def test_combiner_result_dtype():
 
 
 # test combiner convenience function works with list of ccddata objects
+@pytest.mark.remote_data
 def test_combine_average_ccddata():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
     ccd = CCDData.read(fitsfile, unit=u.adu)
@@ -388,6 +391,7 @@ def test_combine_average_ccddata():
 
 # test combiner convenience function reads fits file and
 # and combine as expected when asked to run in limited memory
+@pytest.mark.remote_data
 def test_combine_limitedmem_fitsimages():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
     ccd = CCDData.read(fitsfile, unit=u.adu)
@@ -404,6 +408,7 @@ def test_combine_limitedmem_fitsimages():
 
 # test combiner convenience function reads fits file and
 # and combine as expected when asked to run in limited memory with scaling
+@pytest.mark.remote_data
 def test_combine_limitedmem_scale_fitsimages():
     fitsfile = get_pkg_data_filename('data/a8280271.fits')
     ccd = CCDData.read(fitsfile, unit=u.adu)

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -789,6 +789,7 @@ class TestImageFileCollection:
         with pytest.raises(AttributeError):
             coll.glob_include = '*stuff*'
 
+    @pytest.mark.remote_data
     def test_that_test_files_have_expected_properties(self, triage_setup):
         expected_name = \
             get_pkg_data_filename('data/expected_ifc_file_properties.csv')
@@ -812,6 +813,7 @@ class TestImageFileCollection:
         for column in expected.colnames:
             assert np.all(actual[column] == expected[column])
 
+    @pytest.mark.remote_data
     def test_image_collection_with_no_location(self, triage_setup):
         # Test for a feature requested in
         #


### PR DESCRIPTION
Some tests now use data that are not available locally but need to be retrieved from the data server. This requires remote access, and so the tests should be marked as such.


- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
