### PR TITLE
ImageFileCollection fails if the fits headers contain the keyword 'FILE'

### DIFF
--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -500,8 +500,6 @@ class ImageFileCollection:
 
         h = fits.getheader(file_name, self.ext)
 
-        assert 'file' not in h
-
         if self.location:
             # We have a location and can reconstruct the path using it
             name_for_file_column = path.basename(file_name)
@@ -509,6 +507,17 @@ class ImageFileCollection:
             # No location, so use whatever path the user passed in
             name_for_file_column = file_name
 
+        # Remove the header 'FILE' keyword if present to avoid adding the value
+        # twice to the summary dictionary.
+        if h.get('file') is not None: 
+            if h.get('file').strip() != name_for_file_column.strip():
+                warnings.warn(
+                    'Header from file "{f}" contains keyword "FILE" with '
+                    'FILE={v}" which will be ignored.'
+                    ''.format(v=h.get('file').strip(), f=file_name),
+                    UserWarning)
+            h.remove('file')
+        
         # Try opening header before this so that file name is only added if
         # file is valid FITS
         try:


### PR DESCRIPTION
There's an assert statement on line 503 in image_collection.py in method _dict_from_fits_header:
assert 'file' not in h
to catch and raise the problem - but no handling is implemented. 
If not caught the 'file' value list in the summary dictionary would get a filename appended twice for each image.
This will cause the generation of the summary_table to fail.

The suggested way to fix this is to remove the header 'FILE' keyword if present.
This should be okay since it will either be the same as the input filename or likely incorrect - I guess?

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
