### PR TITLE
MNT: Set max-line-length for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,3 +78,6 @@ select = E101,E111,E112,E113,E221,E222,E223,E224,E225,E241,E242,E251,E271,E272,E
 exclude = _astropy_init.py,version.py
 
 [entry_points]
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.