### PR TITLE
Update block_reduce and block_replicate imports

### DIFF
--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -14,7 +14,7 @@ from astropy.units.quantity import Quantity
 from astropy import units as u
 from astropy.modeling import fitting
 from astropy import stats
-from astropy.nddata import utils as nddata_utils
+from astropy import nddata
 from astropy.nddata import StdDevUncertainty, CCDData
 from astropy.wcs.utils import proj_plane_pixel_area
 from astropy.utils import deprecated
@@ -1199,7 +1199,7 @@ def rebin(ccd, newshape):
 
 def block_reduce(ccd, block_size, func=np.sum):
     """Thin wrapper around `astropy.nddata.block_reduce`."""
-    data = nddata_utils.block_reduce(ccd, block_size, func)
+    data = nddata.block_reduce(ccd, block_size, func)
     if isinstance(ccd, CCDData):
         # unit and meta "should" be unaffected by the change of shape and can
         # be copied. However wcs, mask, uncertainty should not be copied!
@@ -1210,7 +1210,7 @@ def block_reduce(ccd, block_size, func=np.sum):
 def block_average(ccd, block_size):
     """Like `block_reduce` but with predefined ``func=np.mean``.
     """
-    data = nddata_utils.block_reduce(ccd, block_size, np.mean)
+    data = nddata.block_reduce(ccd, block_size, np.mean)
     # Like in block_reduce:
     if isinstance(ccd, CCDData):
         data = CCDData(data, unit=ccd.unit, meta=ccd.meta.copy())
@@ -1219,7 +1219,7 @@ def block_average(ccd, block_size):
 
 def block_replicate(ccd, block_size, conserve_sum=True):
     """Thin wrapper around `astropy.nddata.block_replicate`."""
-    data = nddata_utils.block_replicate(ccd, block_size, conserve_sum)
+    data = nddata.block_replicate(ccd, block_size, conserve_sum)
     # Like in block_reduce:
     if isinstance(ccd, CCDData):
         data = CCDData(data, unit=ccd.unit, meta=ccd.meta.copy())
@@ -1228,8 +1228,8 @@ def block_replicate(ccd, block_size, conserve_sum=True):
 
 try:
     # Append original docstring to docstrings of these functions
-    block_reduce.__doc__ += nddata_utils.block_reduce.__doc__
-    block_replicate.__doc__ += nddata_utils.block_replicate.__doc__
+    block_reduce.__doc__ += nddata.block_reduce.__doc__
+    block_replicate.__doc__ += nddata.block_replicate.__doc__
     __all__ += ['block_average', 'block_reduce', 'block_replicate']
 except AttributeError:
     # Astropy 1.0 has no block_reduce, block_average


### PR DESCRIPTION
In astropy 4.1, these functions moved from the `nddata.utils` to the `nddata.blocks` module (https://github.com/astropy/astropy/pull/10214).  Importing from `nddata.utils` will still work, but will raise a deprecation warning.
