### PR TITLE
Changed relative imports to absolute imports issue

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,6 +33,7 @@ Alphabetical list of contributors
 * Anthony Horton (@AnthonyHorton)
 * Jennifer Karr (@JenniferKarr)
 * Yücel Kılıç (@yucelkilic)
+* Kelvin Lee (@laserkelvin)
 * James McCormac (@jmccormac01)
 * Stefan Nelson (@stefannelson)
 * Joe Philip Ninan (@indiajoe)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ New Features
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Updated test suite to use absolute, not relative imports [#735]
+
 Bug Fixes
 ^^^^^^^^^
 

--- a/ccdproc/tests/test_bitfield.py
+++ b/ccdproc/tests/test_bitfield.py
@@ -5,7 +5,7 @@ import pytest
 
 from astropy.tests.helper import catch_warnings
 
-from ..core import bitfield_to_boolean_mask
+from ccdproc.core import bitfield_to_boolean_mask
 
 
 def test_bitfield_not_integer():

--- a/ccdproc/tests/test_ccdmask.py
+++ b/ccdproc/tests/test_ccdmask.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import pytest
 
-from ..core import ccdmask
+from ccdproc.core import ccdmask
 from astropy.nddata import CCDData
 
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -16,12 +16,12 @@ from numpy.testing import assert_array_equal
 import pytest
 import skimage
 
-from ..core import (
+from ccdproc.core import (
     ccd_process, cosmicray_median, cosmicray_lacosmic, create_deviation,
     flat_correct, gain_correct, subtract_bias, subtract_dark, subtract_overscan,
     transform_image, trim_image, wcs_project, Keyword)
-from ..core import _blkavg
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.core import _blkavg
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 try:
     from ..core import block_reduce, block_average, block_replicate

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -5,8 +5,8 @@ import numpy as np
 from astropy.nddata import CCDData
 import pytest
 
-from .. import subtract_bias, create_deviation, Keyword
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc import subtract_bias, create_deviation, Keyword
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
 @pytest.mark.parametrize('key', [

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -9,8 +9,8 @@ import pytest
 from astropy.utils.data import get_pkg_data_filename
 from astropy.nddata import CCDData
 
-from ..combiner import Combiner, combine, _calculate_step_sizes
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.combiner import Combiner, combine, _calculate_step_sizes
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
 # test that the Combiner raises error if empty

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -8,9 +8,9 @@ from astropy.utils import NumpyRNGContext
 from astropy.nddata import StdDevUncertainty
 from astropy import units as u
 
-from ..core import (cosmicray_lacosmic, cosmicray_median,
+from ccdproc.core import (cosmicray_lacosmic, cosmicray_median,
                     background_deviation_box, background_deviation_filter)
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
 DATA_SCALE = 5.3

--- a/ccdproc/tests/test_gain.py
+++ b/ccdproc/tests/test_gain.py
@@ -5,8 +5,8 @@ import pytest
 
 import astropy.units as u
 
-from ..core import create_deviation, gain_correct, Keyword
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.core import create_deviation, gain_correct, Keyword
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
 # tests for gain

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -19,7 +19,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from astropy.nddata import CCDData
 
-from ..image_collection import ImageFileCollection
+from ccdproc.image_collection import ImageFileCollection
 
 _filters = []
 _original_dir = ''

--- a/ccdproc/tests/test_keyword.py
+++ b/ccdproc/tests/test_keyword.py
@@ -4,7 +4,7 @@ import pytest
 from astropy import units as u
 from astropy.io import fits
 
-from ..core import Keyword
+from ccdproc.core import Keyword
 
 
 def test_keyword_init():

--- a/ccdproc/tests/test_memory_use.py
+++ b/ccdproc/tests/test_memory_use.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 try:
-    from .run_for_memory_profile import run_memory_profile, generate_fits_files, TMPPATH
+    from ccdproc.tests.run_for_memory_profile import run_memory_profile, generate_fits_files, TMPPATH
 except ImportError:
     memory_profile_present = False
 else:

--- a/ccdproc/tests/test_rebin.py
+++ b/ccdproc/tests/test_rebin.py
@@ -8,8 +8,8 @@ from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from ..core import rebin
-from .pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.core import rebin
+from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
 # test rebinning ndarray

--- a/ccdproc/tests/test_wrapped_external_funcs.py
+++ b/ccdproc/tests/test_wrapped_external_funcs.py
@@ -6,7 +6,7 @@ from astropy.nddata import StdDevUncertainty, CCDData
 
 from scipy import ndimage
 
-from .. import core
+from ccdproc import core
 
 
 def test_medianfilter_correct():


### PR DESCRIPTION
This PR addresses issue [#735] by replacing relative imports in the test suite with absolute ones.
All tests passed with 46 warnings.

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [x] Does this PR ad

-----------------------------------------
