### PR TITLE
Using temporary files in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Bug Fixes
 ^^^^^^^^^
 
 - ``test_image_collection.py`` in the test suite no longer produces
- permanent files on disk and cleans up after itself. [#736]
+ permanent files on disk and cleans up after itself. [#738]
 
 2.1.0 (2019-12-24)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Other Changes and Additions
 Bug Fixes
 ^^^^^^^^^
 
+- ``test_image_collection.py`` in the test suite no longer produces
+ permanent files on disk and cleans up after itself. [#736]
 
 2.1.0 (2019-12-24)
 ------------------

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -2,7 +2,7 @@
 
 import os
 from shutil import rmtree
-from tempfile import mkdtemp, TemporaryDirectory
+from tempfile import mkdtemp, TemporaryDirectory, NamedTemporaryFile
 from glob import iglob
 from pathlib import Path
 import logging
@@ -650,8 +650,9 @@ class TestImageFileCollection:
         path_history = os.path.join(triage_setup.test_dir, 'long_history.fit')
         long_history.writeto(path_history)
         ic = ImageFileCollection(triage_setup.test_dir, keywords='*')
-        ic.summary.write('test_table.txt', format='ascii.csv')
-        table_disk = Table.read('test_table.txt', format='ascii.csv')
+        with NamedTemporaryFile() as test_table:
+            ic.summary.write(test_table.name, format='ascii.csv')
+            table_disk = Table.read(test_table.name, format='ascii.csv')
         assert len(table_disk) == len(ic.summary)
 
     @pytest.mark.skipif("os.environ.get('APPVEYOR') or os.sys.platform == 'win32'",

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -634,6 +634,8 @@ class TestImageFileCollection:
         ic = ImageFileCollection(triage_setup.test_dir, keywords='*')
         assert 'col0' not in ic.summary.colnames
 
+    @pytest.mark.skipif("os.environ.get('APPVEYOR') or os.sys.platform == 'win32'",
+                        reason="fails on Windows because of file permissions.")
     def test_header_with_long_history_roundtrips_to_disk(self, triage_setup):
         # I tried combing several history comments into one table entry with
         # '\n'.join(history), which resulted in a table that couldn't


### PR DESCRIPTION
This commit addresses issue [#736], where `test_image_collection.py`
in the test suite generates a `test_table.txt` in the working directory
and does not clean up after itself. This is fixed now by using a
`NamedTemporaryFile` within a context manager, and deletes the file
once the test is completed.

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

-----------------------------------------
