### PR TITLE
Add memory_profiler as a test requirement [#730]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ env:
         - CONDA_CHANNELS='astropy'
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
+        # List runtime dependencies for the package that are available as conda
+        # packages here.
+        - CONDA_DEPENDENCIES='memory-profiler'
+
     matrix:
         - SETUP_CMD='egg_info'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
         # List runtime dependencies for the package that are available as conda
         # packages here.
-        - CONDA_DEPENDENCIES='memory-profiler'
+        - CONDA_DEPENDENCIES='memory_profiler'
 
     matrix:
         - SETUP_CMD='egg_info'

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,6 +46,7 @@ Alphabetical list of contributors
 * Connor Stotts (@stottsco)
 * Ole Streicher (@olebole)
 * JVSN Reddy (@janga1997)
+* Jenna Ryon (@jryon)
 * Brigitta Sipocz (@bsipocz)
 * Erik Tollerud (@eteq)
 * Simon Torres (@simontorres)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- Add memory_profiler as a test requirement [#730]
+- Add memory_profiler as a test requirement [#739]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ New Features
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Add memory_profiler as a test requirement [#730]
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/tests/run_with_file_number_limit.py
+++ b/ccdproc/tests/run_with_file_number_limit.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
 from tempfile import TemporaryDirectory
 from pathlib import Path
-import resource
 import mmap
 import sys
 import gc
@@ -170,6 +169,9 @@ def run_with_limit(n, kind='fits', size=None, overhead=6,
         **entire python process** which will almost certainly lead to nasty
         side effects.
     """
+    # Keep the resource import here so that it is skipped on windows
+    import resource
+
     # Do a little input validation
     if n <= 0:
         raise ValueError("Argument 'n' must be a positive integer")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 
 [tool:pytest]
-addopts = --doctest-ignore-import-errors
 minversion = 2.2
 testpaths = "ccdproc" "docs"
 norecursedirs = build docs/_build
@@ -27,8 +26,8 @@ zip_safe = False
 setup_requires = setuptools_scm
 install_requires = numpy>=1.16
                    astropy>=2.0
-                   scipy 
-                   astroscrappy>=1.0.5 
+                   scipy
+                   astroscrappy>=1.0.5
                    reproject>=0.5
                    scikit-image
 python_requires = >=3.6
@@ -36,6 +35,7 @@ python_requires = >=3.6
 [options.extras_require]
 test =
     pytest-astropy
+    memory_profiler
 docs =
     sphinx-astropy
 


### PR DESCRIPTION
Fixes #730 by adding `memory_profiler` as a test requirement to `setup.cfg`. Also no longer ignores import errors in testing.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?
