### PR TITLE
A workaround for unfixable header keys in ImageFileCollection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ Alphabetical list of contributors
 * Nathan Walker (@walkerna22)
 * Benjamin Weiner (@bjweiner)
 * Jiyong Youn (@hletrd)
+* Michael Gully-Santiago (@gully)
 
 (If you have contributed to the ccdproc project and your name is missing,
 please send an email to the coordinators, or

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bug Fixes
 - ``test_image_collection.py`` in the test suite no longer produces
  permanent files on disk and cleans up after itself. [#738]
 
+- Workaround malformed header keyword names  [#743]
+
 2.1.0 (2019-12-24)
 ------------------
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -622,9 +622,11 @@ class ImageFileCollection:
         # entries (probably arises the `_dict_from_fits_header` above)
         # For now just check if there are more values than files and
         # if so, fill with None for now.
-        for key in summary_dict.keys():
-            if len(summary_dict[key]) > len(summary_dict['file']):
-                summary_dict[key]= [None]*len(summary_dict['file'])
+        if summary_dict is not None:
+            for key in summary_dict.keys():
+                if len(summary_dict[key]) > len(summary_dict['file']):
+                    logger.warning('malformed header keyword %s cannot be understood.',key)
+                    summary_dict[key] = [None]*len(summary_dict['file'])
 
         summary_table = Table(summary_dict, masked=True)
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -618,6 +618,14 @@ class ImageFileCollection:
                                file_path, e)
                 continue
 
+        ## Bugfix: Unfixable header keywords sometimes yield duplicate
+        # entries (probably arises the `_dict_from_fits_header` above)
+        # For now just check if there are more values than files and
+        # if so, fill with None for now.
+        for key in summary_dict.keys():
+            if len(summary_dict[key]) > len(summary_dict['file']):
+                summary_dict[key]= [None]*len(summary_dict['file'])
+
         summary_table = Table(summary_dict, masked=True)
 
         for column in summary_table.colnames:

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -10,6 +10,9 @@ from astropy.nddata import NDData
 from astropy import units as u
 from astropy.io import fits
 
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning) 
+
 import ccdproc  # really only need Keyword from ccdproc
 
 __all__ = []


### PR DESCRIPTION
Unfixable header keys are currently populating the summary_dict with their genuine values and also missing value place holders, resulting in lists of values that are too long, breaking the ImageFileCollection for data with these malformed headers.  

I tried to track down the root cause, and could pinpoint it to the `_dict_from_fits_header()` method called within `_fits_summary`.  My hunch is there's something special about these unfixable keys that gets them double counted as `missing_in_this_file`.  A key clue is that the resulting list for offending keys is always 2*N-1 long, where N is the number of files.

This workaround is really just that-- a stopgap measure to get this to work on the types of files I have.  I suspect the right solution is to dig a bit deeper on `_dict_from_fits_header`, so I didn't go through with a full check of tests, assuming this workaround won't actually be in the final product.


Here are urls to two example files that reproduce the problem:
```
https://koa.ipac.caltech.edu/cgi-bin/getKOA/nph-getKOA?instrument=NS&filehand=/koadata11/NIRSPEC/20010117/lev0/spec/NS.20010117.25279.fits

https://koa.ipac.caltech.edu/cgi-bin/getKOA/nph-getKOA?instrument=NS&filehand=/koadata11/NIRSPEC/20010117/lev0/spec/NS.20010117.25430.fits
```
The malformed keys are `GAIN.SPE` and `FREQ.SPE`, though they do not appear in the error message, truncated below:

```python

    627                 pass#summary_dict[key]= [None]*len(summary_dict['file'])
    628 
--> 629         summary_table = Table(summary_dict, masked=True)
    630 
    631         for column in summary_table.colnames:


ValueError: Inconsistent data column lengths: {4, 7}
```


Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [x] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
