### PR TITLE
Fix bug when ImageFileCollection.filter() would return an empty collection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Alphabetical list of contributors
 * Mihai Cara (@mcara)
 * James Davenport (@jradavenport)
 * Christoph Deil (@cdeil)
+* Timothy P. Ellsworth-Bowers (@tbowers7)
 * Carlos Gomez (@carlgogo)
 * Hans Moritz Günther (@hamogu)
 * Forrest Gasdia (@EP-Guy)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ Bug Fixes
 - ``test_image_collection.py`` in the test suite no longer produces
  permanent files on disk and cleans up after itself. [#738]
 
+- ``ImageFileCollection`` now correctly returns an empty collection when
+  an existing collection is filtered restrictively enough to remove all
+  files.  [#750]
+
 2.1.0 (2019-12-24)
 ------------------
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -448,7 +448,9 @@ class ImageFileCollection:
             else:
                 files = self._filenames
         else:
-            files = self._fits_files_in_directory()
+            # Check if self.location is set, otherwise proceed with empty list
+            if self.location != '':
+                files = self._fits_files_in_directory()
 
             if self.glob_include is not None:
                 files = fnmatch.filter(files, self.glob_include)


### PR DESCRIPTION
If the filtering criteria passed to ImageFileCollection.filter() would return
an empty collection, a crash occurs because the method instantiates a new
ImageFileCollection() with a list of filenames returned from .files_filtered().
When a new instance of ImageFileCollection() is called without a filenames
list, _get_files() -> _fits_files_in_directory() attempts to create a list
of all FITS files within the directory contained in self.location.  If this
new instance of ImageFileCollection() is called without setting location, then
self.location is set to "".  When _fits_files_in_directory() attempts to do a
directory listing via listdir(), an error is raised:
    FileNotFoundError: [Errno 2] No such file or directory: ''

This commit adds a check for empty self.location before any attempted call to
listdir().  The function simply returns an empty string, leading to an empty
ImageFileCollection instance.  This is the expected behavior for filtering a
collection such that no files meet the criteria.

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?  Yes.

For documentation changes:

- [x] For documentation changes: Does your commit message include a "[skip ci]"?  N/A
      Note that it should not if you changed any examples!

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file? Yes.
- [ ] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").  N/A
- [x] Does this PR add, rename, move or remove any existing functions or parameters?  No.

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?  N/A
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?  N/A
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").  N/A
- [x] Did you include tests for the new functionality?  N/A
- [x] Does this PR add, rename, move or remove any existing functions or parameters?  N/A

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
