### PR TITLE
Fix Read-the-docs ccdproc version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,15 +77,11 @@ copyright = '{0}, {1}'.format(
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
+__import__(project)
+package = sys.modules[project]
 
-from pkg_resources import get_distribution, DistributionNotFound
-try:
-    __version__ = get_distribution(__name__)
-except DistributionNotFound:
-    __version__ = 'unknown'
-
-version = __version__
-release = __version__
+version = package.__version__
+release = package.__version__
 
 # -- Options for HTML output --------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,8 +80,9 @@ copyright = '{0}, {1}'.format(
 __import__(project)
 package = sys.modules[project]
 
-version = package.__version__
-release = package.__version__
+ver = package.__version__
+version = '.'.join(ver.split('.'))[:5]
+release = ver
 
 # -- Options for HTML output --------------------------------------------------
 


### PR DESCRIPTION
This PR addresses #725 with a minor fix by providing the relevant `release` of ccdproc in the `html_title` which currently shows up as `vunknown` in the docs. This was done by importing `project` and accessing the `version` from it, which can also be seen done in other astropy affiliated packages like `photutils`, reference: [here](https://github.com/astropy/photutils/blob/master/docs/conf.py#L70-L76)

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

