### PR TITLE
Change `combine` and `Combiner` to accept a generator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ Alphabetical list of contributors
 * Nathan Walker (@walkerna22)
 * Benjamin Weiner (@bjweiner)
 * Jiyong Youn (@hletrd)
+* Yash Gondhalekar (@Yash-10)
 
 (If you have contributed to the ccdproc project and your name is missing,
 please send an email to the coordinators, or

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bug Fixes
 - ``test_image_collection.py`` in the test suite no longer produces
  permanent files on disk and cleans up after itself. [#738]
 
+- Change ``Combiner`` to allow accepting either a list or a generator [#757]
+
 2.1.0 (2019-12-24)
 ------------------
 

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -22,8 +22,8 @@ class Combiner:
 
     Parameters
     -----------
-    ccd_list : list
-        A list of CCDData objects that will be combined together.
+    ccd_iter : list or generator
+        A list or generator of CCDData objects that will be combined together.
 
     dtype : str or `numpy.dtype` or None, optional
         Allows user to set dtype. See `numpy.array` ``dtype`` parameter
@@ -33,7 +33,7 @@ class Combiner:
     Raises
     ------
     TypeError
-        If the ``ccd_list`` are not `~astropy.nddata.CCDData` objects, have different
+        If the ``ccd_iter`` are not `~astropy.nddata.CCDData` objects, have different
         units, or are different shapes.
 
     Examples
@@ -56,15 +56,18 @@ class Combiner:
                  [ 0.66666667,  0.66666667,  0.66666667,  0.66666667],
                  [ 0.66666667,  0.66666667,  0.66666667,  0.66666667]])
     """
-    def __init__(self, ccd_list, dtype=None):
-        if ccd_list is None:
-            raise TypeError("ccd_list should be a list of CCDData objects.")
+    def __init__(self, ccd_iter, dtype=None):
+        if ccd_iter is None:
+            raise TypeError("ccd_iter should be a list or a generator of CCDData objects.")
 
         if dtype is None:
             dtype = np.float64
 
         default_shape = None
         default_unit = None
+
+        ccd_list = list(ccd_iter)
+
         for ccd in ccd_list:
             # raise an error if the objects aren't CCDData objects
             if not isinstance(ccd, CCDData):

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -696,3 +696,13 @@ def test_ystep_calculation(num_chunks, expected):
 
     xstep, ystep = _calculate_step_sizes(2000, 2000, num_chunks)
     assert xstep == expected[0] and ystep == expected[1]
+
+def test_combiner_gen():
+    ccd_data = ccd_data_func()
+    def create_gen():
+        yield ccd_data
+        yield ccd_data
+        yield ccd_data
+    c = Combiner(create_gen())
+    assert c.data_arr.shape == (3, 100, 100)
+    assert c.data_arr.mask.shape == (3, 100, 100)


### PR DESCRIPTION
This PR  fixes #756 to be able to accept a `generator` instead of a `list` as argument to `Combine` and `combiner`.
### Few details
1) The `generator` input has been converted into a list in the implementation since the idea of allowing a generator is mainly intended for user convenience.
2) The relevant `tests` and other corresponding necessary files have been modified.
3) The starting letter of all the comments in the changed files have been capitalized, wherever applicable, excluding when the comment starts with an identifier, following the PEP guidlines.

@mwcraig Could you please review the PR?
Thanks!!
<hr />

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples? [**Modified existing docstrings**]
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality? [**Modified existing tests**]
- [x] Does this PR add, rename, move or remove any existing functions or parameters?