### PR TITLE
Fix logging when user omits keyword argument name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug Fixes
   an existing collection is filtered restrictively enough to remove all
   files.  [#750]
 
+- Logging now preserves all of the arguments when the keyword argument
+  names are not used. [#756]
+
 2.1.0 (2019-12-24)
 ------------------
 

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -106,7 +106,11 @@ def log_to_metadata(func):
             # so construct one unless the config parameter auto_logging is set to False
             if ccdproc.conf.auto_logging:
                 key = func.__name__
-                all_args = chain(zip(original_positional_args, args), kwd.items())
+                # Get names of arguments, which may or may not have
+                # been called as keywords.
+                positional_args = original_args[:len(args)]
+
+                all_args = chain(zip(positional_args, args), kwd.items())
                 all_args = ["{0}={1}".format(name,
                                             _replace_array_with_placeholder(val))
                             for name, val in all_args]

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -5,7 +5,8 @@ import numpy as np
 from astropy.nddata import CCDData
 import pytest
 
-from ccdproc import subtract_bias, create_deviation, Keyword
+from ccdproc import subtract_bias, create_deviation, Keyword, trim_image
+from ccdproc.core import _short_names
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
@@ -89,3 +90,14 @@ def test_implicit_logging():
         'creatvar', 'Shortened name for ccdproc command')
     assert ("readnoise=" + str(3 * ccd_data.unit) in
             result.header['creatvar'])
+
+
+def test_loggin_without_keyword_args():
+    # Regression test for the first failure in #704, which fails because
+    # there is no "fits_section" keyword in the call to trim_image.
+    ccd = CCDData(data=np.arange(1000).reshape(20, 50),
+                  header=None,
+                  unit='adu')
+    section = "[10:20, 10:20]"
+    trim_1 = trim_image(ccd, "[10:20, 10:20]")
+    assert section in trim_1.header[_short_names['trim_image']]

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -101,3 +101,14 @@ def test_loggin_without_keyword_args():
     section = "[10:20, 10:20]"
     trim_1 = trim_image(ccd, "[10:20, 10:20]")
     assert section in trim_1.header[_short_names['trim_image']]
+
+
+def test_logging_with_really_long_parameter_value():
+    # Another regression test for the trim_3 case in #704
+    ccd = CCDData(data=np.arange(1000).reshape(20, 50),
+                  header=None,
+                  unit='adu')
+    section = ("[10:2000000000000000000000000000000000000000000000000000000, "
+               "10:2000000000000000000000000000000]")
+    trim_3 = trim_image(ccd, fits_section=section)
+    assert section in trim_3.header[_short_names['trim_image']]


### PR DESCRIPTION
For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [x] Does this PR add, rename, move or remove any existing functions or parameters? Nope

Fuxes #704 