### PR TITLE
MNT: Stop using deprecated astropy.tests stuff

### DIFF
--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -14,28 +14,9 @@ try:
     def pytest_configure(config):
         config.option.astropy_header = True
 except ImportError:
-    # TODO: Remove this when astropy 2.x and 3.x support is dropped.
-    # Probably an old pytest-astropy package where the pytest_astropy_header
-    # is not a dependency.
-    try:
-        from astropy.tests.plugins.display import (pytest_report_header,
-                                                   PYTEST_HEADER_MODULES,
-                                                   TESTED_VERSIONS)
-    except ImportError:
-        # TODO: Remove this when astropy 2.x support is dropped.
-        # If that also did not work we're probably using astropy 2.0
-        from astropy.tests.pytest_plugins import (pytest_report_header,
-                                                  PYTEST_HEADER_MODULES,
-                                                  TESTED_VERSIONS)
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
-try:
-    # TODO: Remove this when astropy 2.x support is dropped.
-    # This is the way to get plugins in astropy 2.x
-    from astropy.tests.pytest_plugins import *
-except ImportError:
-    # Otherwise they are installed as separate packages that pytest
-    # automagically finds.
-    pass
 
 from .tests.pytest_fixtures import *
 
@@ -47,10 +28,6 @@ except ImportError:
 
 packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version
-
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions
-# enable_deprecations_as_exceptions()
 
 # Add astropy to test header information and remove unused packages.
 

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -875,7 +875,7 @@ def transform_image(ccd, transform_func, **kwargs):
 
     if nccd.wcs is not None:
         warn = 'WCS information may be incorrect as no transformation was applied to it'
-        logging.warning(warn)
+        warnings.warn(warn, UserWarning)
 
     return nccd
 

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import gzip
-from tempfile import mkdtemp
-import os
 from shutil import rmtree
 
 import numpy as np
@@ -10,7 +7,6 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.utils import NumpyRNGContext
-from astropy.io import fits
 from astropy.nddata import CCDData
 
 from ..utils.sample_directory import directory_for_testing

--- a/ccdproc/tests/run_for_memory_profile.py
+++ b/ccdproc/tests/run_for_memory_profile.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('memory_profiler')
+
 from argparse import ArgumentParser
 from tempfile import TemporaryDirectory
 from pathlib import Path

--- a/ccdproc/tests/test_bitfield.py
+++ b/ccdproc/tests/test_bitfield.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pytest
 
-from astropy.tests.helper import catch_warnings
-
 from ccdproc.core import bitfield_to_boolean_mask
 
 
@@ -69,9 +67,8 @@ def test_bitfield_flag_non_integer():
 
 def test_bitfield_duplicate_flag_throws_warning():
     bm = np.random.randint(0, 10, (10, 10))
-    with catch_warnings(UserWarning) as w:
+    with pytest.warns(UserWarning):
         bitfield_to_boolean_mask(bm, [1, 1])
-    assert len(w)
 
 
 def test_bitfield_none_identical_to_strNone():

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -621,9 +621,9 @@ def test_catch_transform_wcs_warning():
     # No warning.
     transform_image(ccd_data, tran)
 
-    # FIXME: Needs to issue warning when data has WCS.
+    # Issue warning when data has WCS.
     ccd_data.wcs = wcs_for_testing(ccd_data.shape)
-    with pytest.warns(Warning, match='WCS information may be incorrect'):
+    with pytest.warns(UserWarning, match='WCS information may be incorrect'):
         transform_image(ccd_data, tran)
 
 

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -618,7 +618,13 @@ def test_catch_transform_wcs_warning():
     def tran(arr):
         return 10 * arr
 
-    tran = transform_image(ccd_data, tran)
+    # No warning.
+    transform_image(ccd_data, tran)
+
+    # FIXME: Needs to issue warning when data has WCS.
+    ccd_data.wcs = wcs_for_testing(ccd_data.shape)
+    with pytest.warns(Warning, match='WCS information may be incorrect'):
+        transform_image(ccd_data, tran)
 
 
 @pytest.mark.parametrize('mask_data, uncertainty', [
@@ -876,7 +882,6 @@ def test_wcs_project_onto_same_wcs_remove_headers():
     # Remove an example WCS keyword from the header
     target_wcs = wcs_for_testing(ccd_data.shape)
     ccd_data.wcs = wcs_for_testing(ccd_data.shape)
-    print(ccd_data.header)
     ccd_data.header = ccd_data.wcs.to_header()
 
     new_ccd = wcs_project(ccd_data, target_wcs)

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -6,7 +6,6 @@ from astropy.modeling import models
 from astropy.units.quantity import Quantity
 import astropy.units as u
 from astropy.wcs import WCS
-from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 
 from astropy.nddata import StdDevUncertainty, CCDData
@@ -80,7 +79,7 @@ def test_create_deviation_from_negative():
                                   np.isnan(ccd_var.uncertainty.array))
 
 
-def test_create_deviation_from_negative():
+def test_create_deviation_from_negative_2():
     ccd_data = ccd_data_func(data_mean=0, data_scale=10)
     ccd_data.unit = u.electron
     readnoise = 5 * u.electron
@@ -619,8 +618,7 @@ def test_catch_transform_wcs_warning():
     def tran(arr):
         return 10 * arr
 
-    with catch_warnings() as w:
-        tran = transform_image(ccd_data, tran)
+    tran = transform_image(ccd_data, tran)
 
 
 @pytest.mark.parametrize('mask_data, uncertainty', [
@@ -661,7 +659,7 @@ def test_block_reduce():
                   mask=np.zeros((4, 4), dtype=bool),
                   uncertainty=StdDevUncertainty(np.ones((4, 4)))
                   )
-    with catch_warnings(AstropyUserWarning) as w:
+    with pytest.warns(AstropyUserWarning) as w:
         ccd_summed = block_reduce(ccd, (2, 2))
     assert len(w) == 1
     assert 'following attributes were set' in str(w[0].message)
@@ -690,7 +688,7 @@ def test_block_average():
                   mask=np.zeros((4, 4), dtype=bool),
                   uncertainty=StdDevUncertainty(np.ones((4, 4))))
     ccd.data[::2, ::2] = 2
-    with catch_warnings(AstropyUserWarning) as w:
+    with pytest.warns(AstropyUserWarning) as w:
         ccd_avgd = block_average(ccd, (2, 2))
     assert len(w) == 1
     assert 'following attributes were set' in str(w[0].message)
@@ -716,7 +714,7 @@ def test_block_replicate():
     ccd = CCDData(np.ones((4, 4)), unit='adu', meta={'testkw': 1},
                   mask=np.zeros((4, 4), dtype=bool),
                   uncertainty=StdDevUncertainty(np.ones((4, 4))))
-    with catch_warnings(AstropyUserWarning) as w:
+    with pytest.warns(AstropyUserWarning) as w:
         ccd_repl = block_replicate(ccd, (2, 2))
     assert len(w) == 1
     assert 'following attributes were set' in str(w[0].message)
@@ -772,7 +770,7 @@ def test__overscan_schange():
 def test_create_deviation_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    ccd = create_deviation(ccd_data, gain=5 * u.electron / u.adu, readnoise=10 * u.electron)
+    _ = create_deviation(ccd_data, gain=5 * u.electron / u.adu, readnoise=10 * u.electron)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 
@@ -790,8 +788,7 @@ def test_cosmicray_median_does_not_change_input():
 def test_cosmicray_lacosmic_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    error = np.zeros_like(ccd_data)
-    ccd = cosmicray_lacosmic(ccd_data)
+    _ = cosmicray_lacosmic(ccd_data)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 
@@ -809,7 +806,7 @@ def test_flat_correct_does_not_change_input():
 def test_gain_correct_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    ccd = gain_correct(ccd_data, gain=1, gain_unit=ccd_data.unit)
+    _ = gain_correct(ccd_data, gain=1, gain_unit=ccd_data.unit)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 
@@ -818,7 +815,7 @@ def test_subtract_bias_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
     master_frame = CCDData(np.zeros_like(ccd_data), unit=ccd_data.unit)
-    ccd = subtract_bias(ccd_data, master=master_frame)
+    _ = subtract_bias(ccd_data, master=master_frame)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 
@@ -826,7 +823,7 @@ def test_subtract_bias_does_not_change_input():
 def test_trim_image_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    ccd = trim_image(ccd_data, fits_section=None)
+    _ = trim_image(ccd_data, fits_section=None)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 
@@ -988,8 +985,8 @@ def test_wcs_project_onto_scale_wcs():
 def test_ccd_process_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    ccd = ccd_process(ccd_data, gain=5 * u.electron / u.adu,
-                      readnoise=10 * u.electron)
+    _ = ccd_process(ccd_data, gain=5 * u.electron / u.adu,
+                    readnoise=10 * u.electron)
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
 

--- a/ccdproc/tests/test_rebin.py
+++ b/ccdproc/tests/test_rebin.py
@@ -5,7 +5,6 @@ import pytest
 
 from astropy.nddata import StdDevUncertainty
 
-from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ccdproc.core import rebin
@@ -14,21 +13,21 @@ from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 # test rebinning ndarray
 def test_rebin_ndarray():
-    with pytest.raises(TypeError), catch_warnings(AstropyDeprecationWarning):
+    with pytest.raises(TypeError), pytest.warns(AstropyDeprecationWarning):
         rebin(1, (5, 5))
 
 
 # test rebinning dimensions
 def test_rebin_dimensions():
     ccd_data = ccd_data_func(data_size=10)
-    with pytest.raises(ValueError), catch_warnings(AstropyDeprecationWarning):
-            rebin(ccd_data.data, (5,))
+    with pytest.raises(ValueError), pytest.warns(AstropyDeprecationWarning):
+        rebin(ccd_data.data, (5,))
 
 
 # test rebinning dimensions
 def test_rebin_ccddata_dimensions():
     ccd_data = ccd_data_func(data_size=10)
-    with pytest.raises(ValueError), catch_warnings(AstropyDeprecationWarning):
+    with pytest.raises(ValueError), pytest.warns(AstropyDeprecationWarning):
         rebin(ccd_data, (5,))
 
 
@@ -36,9 +35,8 @@ def test_rebin_ccddata_dimensions():
 def test_rebin_larger():
     ccd_data = ccd_data_func(data_size=10)
     a = ccd_data.data
-    with catch_warnings(AstropyDeprecationWarning) as w:
+    with pytest.warns(AstropyDeprecationWarning):
         b = rebin(a, (20, 20))
-    assert len(w) >= 1
 
     assert b.shape == (20, 20)
     np.testing.assert_almost_equal(b.sum(), 4 * a.sum())
@@ -48,10 +46,9 @@ def test_rebin_larger():
 def test_rebin_smaller():
     ccd_data = ccd_data_func(data_size=10)
     a = ccd_data.data
-    with catch_warnings(AstropyDeprecationWarning) as w:
+    with pytest.warns(AstropyDeprecationWarning):
         b = rebin(a, (20, 20))
         c = rebin(b, (10, 10))
-    assert len(w) >= 1
 
     assert c.shape == (10, 10)
     assert (c - a).sum() == 0
@@ -69,9 +66,8 @@ def test_rebin_ccddata(mask_data, uncertainty):
         err = np.random.normal(size=ccd_data.shape)
         ccd_data.uncertainty = StdDevUncertainty(err)
 
-    with catch_warnings(AstropyDeprecationWarning) as w:
+    with pytest.warns(AstropyDeprecationWarning):
         b = rebin(ccd_data, (20, 20))
-    assert len(w) >= 1
 
     assert b.shape == (20, 20)
     if mask_data:
@@ -83,8 +79,7 @@ def test_rebin_ccddata(mask_data, uncertainty):
 def test_rebin_does_not_change_input():
     ccd_data = ccd_data_func()
     original = ccd_data.copy()
-    with catch_warnings(AstropyDeprecationWarning) as w:
+    with pytest.warns(AstropyDeprecationWarning):
         _ = rebin(ccd_data, (20, 20))
-    assert len(w) >= 1
     np.testing.assert_array_equal(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit


### PR DESCRIPTION
Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [x] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file? Not needed
- [x] Did you add a regression test? Not needed
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number"). N/A
- [x] Does this PR add, rename, move or remove any existing functions or parameters? No

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file? Not needed
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples? N/A
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number"). N/A
- [x] Did you include tests for the new functionality? N/A
- [x] Does this PR add, rename, move or remove any existing functions or parameters? No

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------

This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .