### PR TITLE
Fix doc build warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Bug Fixes
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- The `rebin` function has been more clearly marked with a deprecation
+- The ``rebin`` function has been more clearly marked with a deprecation
   milestone. It will be removed in v3. [#780]
 
 Bug Fixes

--- a/tox.ini
+++ b/tox.ini
@@ -67,10 +67,13 @@ commands =
 
 [testenv:build_docs]
 extras = docs
+deps =
+    sphinx-automodapi<=0.13
 setenv =
   HOME = {envtmpdir}
 changedir = docs
 commands =
+  pip freeze
   sphinx-build . _build/html -b html -W {posargs}
 
 [testenv:pycodestyle]


### PR DESCRIPTION
A warnign was happening during the documentation build because of   https://github.com/astropy/sphinx-automodapi/issues/141  (see [this failing run](https://github.com/astropy/ccdproc/runs/4757634889?check_suite_focus=true#step:7:79))

Once a release of `sphinx-automodapi` has been done the pin I added here for `sphinx-automodapi` version should be removed.