### PR TITLE
Bugfix to issue #786

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -62,6 +62,7 @@ Alphabetical list of code contributors
 * Nathan Walker (@walkerna22)
 * Benjamin Weiner (@bjweiner)
 * Jiyong Youn (@hletrd)
+* Attila Bódi (@astrobatty)
 
 Additional contributors
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Other Changes and Additions
 Bug Fixes
 ^^^^^^^^^
 
+- In python 3.7 the ``version`` method from ``packaging`` must be
+  imported directly. [#786]
+
 2.3.0 (2021-12-21)
 ------------------
 

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -5,7 +5,7 @@
 import math
 import numbers
 import logging
-import packaging
+from packaging import version as pkgversion
 import warnings
 
 import numpy as np
@@ -1518,8 +1518,8 @@ def cosmicray_lacosmic(ccd, sigclip=4.5, sigfrac=0.3,
         readnoise = readnoise * u.electron
 
     # Handle transition from old astroscrappy interface to new
-    old_astroscrappy_interface = (packaging.version.parse(asy_version) <
-                                  packaging.version.parse('1.1.0'))
+    old_astroscrappy_interface = (pkgversion.parse(asy_version) <
+                                  pkgversion.parse('1.1.0'))
 
     # Use this dictionary to define which keyword arguments are actually
     # passed to astroscrappy.


### PR DESCRIPTION
This PR fixes issue #786.
In python 3.7 the ``version`` method from ``packaging`` must be imported directly.

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
