### PR TITLE
Add `HDUList` generator to `ImageFileCollection`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@
 New Features
 ^^^^^^^^^^^^
 
-- Add ``.hduls()`` generator to ImageFileCollection to return the full
+- Add ``.hdulists()`` generator to ImageFileCollection to return the full
   HDUList for each file in the collection.  Clarify that the ``.hdus()``
-  returns only the ImageHDU or BinTableHDU for the extension specified
-  in the initialization of the collection.  [#78x]
+  generator returns only the PrimaryHDU for the extension specified
+  in the initialization of the collection.  [#788]
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 New Features
 ^^^^^^^^^^^^
 
+- Add ``.hduls()`` generator to ImageFileCollection to return the full
+  HDUList for each file in the collection.  Clarify that the ``.hdus()``
+  returns only the ImageHDU or BinTableHDU for the extension specified
+  in the initialization of the collection.  [#78x]
+
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -914,6 +914,11 @@ class ImageFileCollection:
                     # Need to copy the HDU to prevent lazy loading problems
                     # and "IO operations on closed file" errors
                     return_thing = hdulist[ext_index].copy()
+            elif return_type == 'hdul':
+                with fits.open(full_path, **add_kwargs) as hdulist:
+                    # Need to copy the HDU to prevent lazy loading problems
+                    # and "IO operations on closed file" errors
+                    return_thing = hdulist.copy()
             else:
                 raise ValueError('no generator for {}'.format(return_type))
 
@@ -956,6 +961,8 @@ class ImageFileCollection:
                         hdulist[ext_index].data = return_thing
                     elif return_type == 'header':
                         hdulist[ext_index].header = return_thing
+                    elif return_type == 'hdul':
+                        hdulist = return_thing
 
                     try:
                         hdulist.writeto(new_path, **nuke_existing)
@@ -987,6 +994,14 @@ class ImageFileCollection:
                                do_not_scale_image_data=do_not_scale_image_data,
                                **kwd)
     hdus.__doc__ = _generator.__doc__.format(
+        name='ImageHDU or BinTableHDU', default_scaling='False',
+        return_type='astropy.io.fits.ImageHDU or astropy.io.fits.BinTableHDU')
+
+    def hduls(self, do_not_scale_image_data=False, **kwd):
+        return self._generator('hdul',
+                               do_not_scale_image_data=do_not_scale_image_data,
+                               **kwd)
+    hduls.__doc__ = _generator.__doc__.format(
         name='HDUList', default_scaling='False',
         return_type='astropy.io.fits.HDUList')
 

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1112,10 +1112,10 @@ class TestImageFileCollection:
             assert len(new_ic.files) == 1
             assert kw in new_ic.summary['regex_fl']
 
-    def test_hduls(self, triage_setup):
+    def test_hdulists_generator(self, triage_setup):
         # Test for implementation of new feaature at:
         #
-        #    https://github.com/astropy/ccdproc/issues/78x
+        #    https://github.com/astropy/ccdproc/issues/788
         #
         # which adds .hduls() generator method to ImageFileCollection.  This
         # feature returns the full HDUList for each file in the collection,
@@ -1127,7 +1127,18 @@ class TestImageFileCollection:
             location=triage_setup.test_dir, keywords=['imagetyp'])
 
         n_hduls = 0
-        for hdul in collection.hduls():
+        for hdul in collection.hdulists():
             assert isinstance(hdul, fits.HDUList)
             n_hduls += 1
         assert n_hduls == triage_setup.n_test['files']
+
+    def test_hdulists_generator_does_not_support_overwrite(self, triage_setup):
+        """
+        The complexity of HDULists makes it infeasable to support overwrite.
+        https://github.com/astropy/ccdproc/issues/788
+        """
+        ic = ImageFileCollection(triage_setup.test_dir)
+        with pytest.raises(NotImplementedError):
+            ic.hdulists(overwrite=True)
+        with pytest.raises(NotImplementedError):
+            ic.hdulists(clobber=True)

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1111,3 +1111,23 @@ class TestImageFileCollection:
             new_ic = ic.filter(regex_fl=kw)
             assert len(new_ic.files) == 1
             assert kw in new_ic.summary['regex_fl']
+
+    def test_hduls(self, triage_setup):
+        # Test for implementation of new feaature at:
+        #
+        #    https://github.com/astropy/ccdproc/issues/78x
+        #
+        # which adds .hduls() generator method to ImageFileCollection.  This
+        # feature returns the full HDUList for each file in the collection,
+        # not just the specified extension, as with .hdus().
+
+        # Ensure that the generator returns an HDUList, and that the number of
+        # HDULists returned equals the number of files in the setup
+        collection = ImageFileCollection(
+            location=triage_setup.test_dir, keywords=['imagetyp'])
+
+        n_hduls = 0
+        for hdul in collection.hduls():
+            assert isinstance(hdul, fits.HDUList)
+            n_hduls += 1
+        assert n_hduls == triage_setup.n_test['files']

--- a/docs/image_management.rst
+++ b/docs/image_management.rst
@@ -139,7 +139,7 @@ Note that the names of the arguments to ``hdus`` here are the names of FITS
 keywords in the collection and the values are the values of those keywords you
 want to select. Note also that string comparisons are not case sensitive.
 
-The other iterators are ``headers``, ``data``, and ``ccds``.
+The other iterators are ``hduls``, ``headers``, ``data``, and ``ccds``.
 
 All of them have the option to also provide the file name in addition to the
 hdu (or header or data)::

--- a/docs/image_management.rst
+++ b/docs/image_management.rst
@@ -139,7 +139,7 @@ Note that the names of the arguments to ``hdus`` here are the names of FITS
 keywords in the collection and the values are the values of those keywords you
 want to select. Note also that string comparisons are not case sensitive.
 
-The other iterators are ``hduls``, ``headers``, ``data``, and ``ccds``.
+The other iterators are ``hdulists``, ``headers``, ``data``, and ``ccds``.
 
 All of them have the option to also provide the file name in addition to the
 hdu (or header or data)::


### PR DESCRIPTION
Presently, the `ImageFileCollection` generator `.hdus()` states in the
documentation that it returns the `HDUList` for each file in the collection,
but in fact it returns only the `PrimaryHDU` for the extension specified in the
initialization of the collection.

This PR clarifies that the `.hdus()` generator returns a `PrimaryHDU`
for the specified extension, and adds a new `.hdulists()` generator that
actually returns the `HDUList` for the entire file.

Regression test for the new generator added to `test_image_collection.py`.
Updated Image Management documentation to include new generator.
Updated `Changes.rst` file.

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?  _Already added._

For documentation changes:

- [x] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!  _Not just documentation change._

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").  _No existing issue._
- [x] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
