### PR TITLE
Always use astropy's sigma clipping and default to string-based functions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Alphabetical list of code contributors
 * Adrian Price-Whelan (@adrn)
 * JVSN Reddy (@janga1997)
 * Luca Rizzi (@lucarizzi)
+* Thomas Robitaille (@astrofrog)
 * Evert Rol (@evertrol)
 * Jenna Ryon (@jryon)
 * William Schoenell (@wschoenell)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-3.0.0 (unreleased)
+2.4.0 (unreleased)
 ------------------
 
 New Features
@@ -6,6 +6,11 @@ New Features
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- The sigma clipping option in the image combiner now always uses the
+  astropy sigma clipping function, and supports specifying the
+  functions to use for estimating the center and deviation values
+  as strings for common cases (which significantly improves performance). [#794]
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -16,6 +16,7 @@ from .core import sigma_func
 
 from astropy.nddata import CCDData, StdDevUncertainty
 from astropy.stats import sigma_clip
+from astropy.utils import deprecated_renamed_argument
 from astropy import log
 
 __all__ = ['Combiner', 'combine']
@@ -294,6 +295,11 @@ class Combiner:
             self.data_arr.mask[mask] = True
 
     # set up sigma  clipping algorithms
+    @deprecated_renamed_argument('use_astropy', None, arg_in_kwargs=True,
+                                 since='2.4.0',
+                                 message='The use_astropy argument has been removed because '
+                                         'astropy sigma clipping is now always used.'
+                                 )
     def sigma_clipping(self, low_thresh=3, high_thresh=3,
                        func='mean', dev_func='std', **kwd):
         """
@@ -338,6 +344,10 @@ class Combiner:
             Any remaining keyword arguments are passed to astropy's
             :func:`~astropy.stats.sigma_clip` function.
         """
+
+        # Remove in 3.0
+        _ = kwd.pop('use_astropy', True)
+
         self.data_arr.mask = sigma_clip(self.data_arr.data,
                                         sigma_lower=low_thresh,
                                         sigma_upper=high_thresh,

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -227,21 +227,6 @@ def test_combiner_sigmaclip_low():
     assert c.data_arr[5].mask.all()
 
 
-@pytest.mark.parametrize('threshold', [1, 10])
-def test_combiner_sigma_clip_use_astropy_same_result(threshold):
-    # If we turn on use_astropy and make no other changes we should get exactly
-    # the same result as if we use ccdproc sigma_clipping
-    ccd_list = [ccd_data_func(rng_seed=seed + 1) for seed in range(10)]
-    c_ccdp = Combiner(ccd_list)
-    c_apy = Combiner(ccd_list)
-
-    c_ccdp.sigma_clipping(low_thresh=threshold, high_thresh=threshold)
-    c_apy.sigma_clipping(low_thresh=threshold, high_thresh=threshold,
-                         use_astropy=True)
-
-    np.testing.assert_allclose(c_ccdp.data_arr.mask, c_apy.data_arr.mask)
-
-
 # test that the median combination works and returns a ccddata object
 def test_combiner_median():
     ccd_data = ccd_data_func()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find:
 zip_safe = False
 setup_requires = setuptools_scm
 install_requires = numpy>=1.18
-                   astropy>=4.0.6  # Support LTS, but only with bug fixes
+                   astropy>=4.3
                    scipy
                    astroscrappy>=1.0.8
                    reproject>=0.7


### PR DESCRIPTION
This switches the sigma clipping to always use the astropy sigma clipping, and default to using strings for the statistics/functions to use by default as this provides the best performance. This requires bumping the minimum version of astropy to 4.3 which I hope should be ok now that LTS is now 5.x?

I haven't done extensive testing beyond the built-in test suite and my own use case, but for my case the sigma clipping became almost 3x faster.

- [x] For new contributors: Did you add yourself to the "Authors.rst" file?
- [x] Did you add an entry to the "Changes.rst" file?

Fixes https://github.com/astropy/ccdproc/issues/793

I also think https://github.com/astropy/ccdproc/issues/753 could be closed with this merged.

Perhaps https://github.com/astropy/ccdproc/issues/624 would also be resolved by this? (but make sure you change the functions for sigma clipping to be strings)