### PR TITLE
Suppress numpy ufunc warning in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ doctest_plus = enabled
 addopts = --doctest-rst
 filterwarnings=
     error
+    ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy.ndarray size changed:RuntimeWarning
     ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning
 markers =


### PR DESCRIPTION
This PR suppresses another numpy warning during tests to get them to pass. See https://github.com/astropy/reproject/issues/313