### PR TITLE
Allow overwrite of ``output_file`` in ``ccdproc.combiner.combine()``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Other Changes and Additions
   astropy sigma clipping function, and supports specifying the
   functions to use for estimating the center and deviation values
   as strings for common cases (which significantly improves performance). [#794]
+- The image combiner now allows the optional overwrite of the optional
+  output FITS file. [#797]
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -702,7 +702,8 @@ def combine(img_list, output_file=None,
             sigma_clip=False,
             sigma_clip_low_thresh=3, sigma_clip_high_thresh=3,
             sigma_clip_func=ma.mean, sigma_clip_dev_func=ma.std,
-            dtype=None, combine_uncertainty_function=None, **ccdkwargs):
+            dtype=None, combine_uncertainty_function=None,
+            overwrite_output=False, **ccdkwargs):
     """
     Convenience function for combining multiple images.
 
@@ -798,6 +799,12 @@ def combine(img_list, output_file=None,
         If ``None`` use the default uncertainty func when using average, median or
         sum combine, otherwise use the function provided.
         Default is ``None``.
+
+    overwrite_output : bool, optional
+        If ``output_file`` is specified, this is passed to the
+        `astropy.nddata.fits_ccddata_writer` under the keyword ``overwrite``;
+        has no effect otherwise.
+        Default is ``False``.
 
     ccdkwargs : Other keyword arguments for `astropy.nddata.fits_ccddata_reader`.
 
@@ -970,6 +977,6 @@ def combine(img_list, output_file=None,
 
     # Write fits file if filename was provided
     if output_file is not None:
-        ccd.write(output_file)
+        ccd.write(output_file, overwrite=overwrite_output)
 
     return ccd


### PR DESCRIPTION
Add an optional keyword argument to ``ccdproc.combiner.combine()`` to allow for the overwrite of the optional ``output_file``.  The default value of ``overwrite_output = False`` is identical to current behavior, and the user would need to specify this keyword argument as ``True`` to allow overwriting.

	modified:   ccdproc/combiner.py

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [x] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [x] Did you include tests for the new functionality?
- [x] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
