### PR TITLE
Increment minimum astropy version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ improvements outside of GitHub, or otherwise assisted the project.
 
 * Juan Cabanela (@JuanCab)
 * @mheida
+* Aaron W Morris (@aaronwmorris)
 * Sara Ogaz (@SaOgaz)
 * Jean-Paul Ventura (@jvntra)
 * Kerry Paterson (@KerryPaterson)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ packages = find:
 zip_safe = False
 setup_requires = setuptools_scm
 install_requires = numpy>=1.18
-                   astropy>=4.3
+                   astropy>=5.0.1
                    scipy
                    astroscrappy>=1.0.8
                    reproject>=0.7
                    scikit-image
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.package_data]
 * = data/*


### PR DESCRIPTION
ccdproc requires astropy 5.0.1 which forces dropping python 3.7 compatibility

edit: fixes #798 