### PR TITLE
Add check for empty IFC in filtering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+2.4.1 (unreleased)
+------------------
+
+New Features
+^^^^^^^^^^^^
+
+Other Changes and Additions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+- Fixes a crash when attempting to filter an already-empty ImageFileCollection,
+  instead simply returning an empty ImageFileCollection.  [#801]
+
 2.4.0 (2022-11-16)
 ------------------
 

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -366,6 +366,10 @@ class ImageFileCollection:
         Value comparison is case *insensitive* for strings, whether matching
         exactly or matching with regular expressions.
         """
+        # If the collection is empty, self.summary == None; return empty list
+        if self.summary is None:
+            return []
+
         # force a copy by explicitly converting to a list
         current_file_mask = self.summary['file'].mask.tolist()
 

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -1015,6 +1015,7 @@ class TestImageFileCollection:
             ic = ImageFileCollection(triage_setup.test_dir)
         assert ic.summary is None
         assert ic.keywords == []
+        assert ic.files_filtered() == []
 
     def test_regex_match_for_search(self, triage_setup):
         # Test regex matching in searches


### PR DESCRIPTION
The ``files_filtered()`` method chokes on a ``'NoneType' object is not subscriptable`` error if the ImageFileCollection is already empty before being asked to filter further.

This commit adds a check for an empty IFC and simply passes an empty list for the set of files in the collection.

	modified:   CHANGES.rst
	modified:   ccdproc/image_collection.py

Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
