### PR TITLE
Fix the tox test for oldest dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ github_project = astropy/ccdproc
 packages = find:
 zip_safe = False
 setup_requires = setuptools_scm
-install_requires = numpy>=1.18
+install_requires = numpy>=1.21
                    astropy>=5.0.1
                    scipy
                    astroscrappy>=1.0.8

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,9 @@ deps =
     oldestdeps: numpy==1.21.*
     oldestdeps: astropy==5.0.*
     oldestdeps: reproject==0.7
-    oldestdeps: astroscrappy==1.0.8
+    # astroscrappy needs to install AFTER numpy so its install is done in
+    # the commands section instead of here.
+    #oldestdeps: astroscrappy==1.0.8
     oldestdeps: cython
 
 commands =
@@ -62,6 +64,8 @@ commands =
     !cov-!oldestdeps: pytest --pyargs ccdproc {toxinidir}/docs {posargs}
     cov: pytest --pyargs ccdproc {toxinidir}/docs --cov ccdproc --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
+    # install astroscrappy after numpy
+    oldestdeps: python -m pip install astroscrappy==1.0.8
     # Do not care about warnings on the oldest builds
     oldestdeps: pytest --pyargs ccdproc {toxinidir}/docs -W ignore {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,8 @@ deps =
     # packages which are constrained in the setup.cfg
     # NOTE ABOUT NUMPY VERSION: for astroscrappy 1.0.8 have to use at least 1.20
     # for the tests to even get to the point of running.
-    oldestdeps: numpy==1.20.*
-    oldestdeps: astropy==4.0.*
+    oldestdeps: numpy==1.21.*
+    oldestdeps: astropy==5.0.*
     oldestdeps: reproject==0.7
     oldestdeps: astroscrappy==1.0.8
     oldestdeps: cython


### PR DESCRIPTION
There were two problems here:

- No wheel for numpy 1.20 and python 3.8
- numpy must install before astroscrappy for the astroscrappy source build to succeed.