### PR TITLE
Update the mimnimum required version for pytest-astropy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ python_requires = >=3.8
 
 [options.extras_require]
 test =
-    pytest-astropy
+    pytest-astropy>=0.10.0
     memory_profiler
 docs =
     sphinx-astropy


### PR DESCRIPTION
This fixes #805 by ensuring that the version of pytest-remotedata that is used is 0.3.3, the first version which switched from distutils to packaging for version number handling.

