### PR TITLE
TST: fix compatibility with pytest 8

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -101,4 +101,4 @@ jobs:
     #   run: tox -e ${{ matrix.tox_env }} -- --remote-data=any
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -168,7 +168,13 @@ def test_cosmicray_lacosmic_detects_inconsistent_units():
     assert 'Inconsistent units' in str(e.value)
 
 
-def test_cosmicray_lacosmic_warns_on_ccd_in_electrons(recwarn):
+if OLD_ASTROSCRAPPY:
+    decorator = pytest.mark.filterwarnings("ignore:`np.bool` is a deprecated alias:DeprecationWarning")
+else:
+    decorator = lambda f: f
+
+@decorator
+def test_cosmicray_lacosmic_warns_on_ccd_in_electrons():
     # Check that an input ccd in electrons raises a warning.
     ccd_data = ccd_data_func(data_scale=DATA_SCALE)
     # The unit below is important for the test; this unit on
@@ -183,12 +189,13 @@ def test_cosmicray_lacosmic_warns_on_ccd_in_electrons(recwarn):
     # Don't really need to set this (6.5 is the default value) but want to
     # make lack of units explicit.
     readnoise = 6.5
-    new_ccd = cosmicray_lacosmic(ccd_data,
-                                 gain=gain,
-                                 gain_apply=True,
-                                 readnoise=readnoise)
-
-    assert "Image unit is electron" in str(recwarn.pop())
+    with pytest.warns(UserWarning, match="Image unit is electron"):
+        cosmicray_lacosmic(
+            ccd_data,
+            gain=gain,
+            gain_apply=True,
+            readnoise=readnoise
+        )
 
 
 # The skip can be removed when the oldest supported astroscrappy

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -952,6 +952,7 @@ class TestImageFileCollection:
 
         assert n_heads == expected_heads
 
+    @pytest.mark.filterwarnings("ignore:The following header keyword is invalid:UserWarning")
     def test_less_strict_verify_option(self, triage_setup):
         # Tests for feature request
         #

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ minversion = 2.2
 testpaths = "ccdproc" "docs"
 norecursedirs = build docs/_build
 doctest_plus = enabled
-addopts = --doctest-rst
+addopts = --doctest-rst --color=yes
 filterwarnings=
     error
     ignore:numpy\.ufunc size changed:RuntimeWarning


### PR DESCRIPTION
This should resolve the current CI instability. ([example logs](https://github.com/astropy/ccdproc/actions/runs/8575940098/job/23505969612?pr=819))

For context, what I think is happening is that the `pytest.warns` context manager's behavior was changed in pytest 8.0. In older versions, all warnings *other* than the one we were checking for were silently swallowed, and now they're not. In this specific test, `astropy` would also emit some `AstropyUserWarning`(s), which we don't control but are pointing to the very same problem we're testing for, so we should just filter them explicitly.