### PR TITLE
DOC: migrate ReadTheDocs configuration file to v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,13 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  - requirements: docs/rtd-pip-requirements

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,6 +1,3 @@
-numpy>=1.9
-scipy
-scikit-image
+-e .  # install ccdproc itself (and its dependencies)
 numpydoc
-astropy>=3.0
 sphinx-astropy


### PR DESCRIPTION
I noticed RTD builds were failing with
```
Error

Config validation error in build.os. Value os not found.
```
([example logs](https://readthedocs.org/projects/ccdproc/builds/23995793/))

I think it's just a matter of configuration format.
For context: https://test-githubblog.readthedocs.io/en/latest/migrate-configuration-v2/