### PR TITLE
TST: add CI coverage for Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -96,12 +96,10 @@ jobs:
     - name: Install graphviz dependency
       if: "endsWith(matrix.tox_env, 'build_docs')"
       run: sudo apt-get -y install graphviz
-    - name: Print Python, pip, setuptools, and tox versions
+    - name: Print Python env
       run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -c "import tox; print(f'tox {tox.__version__}')"
+        python --version
+        python -m pip list
     - name: Run tests
       if: "! matrix.use_remote_data"
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -47,15 +47,25 @@ jobs:
             python: '3.10'
             tox_env: 'py310-test-alldeps-numpy121'
 
-          - name: 'macos-py39'
-            os: macos-latest
-            python: '3.9'
-            tox_env: 'py39-test-alldeps'
+          - name: 'ubuntu-py311'
+            os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-numpy123'
 
-          - name: 'windows-py310'
+          - name: 'ubuntu-py312'
+            os: ubuntu-latest
+            python: '3.12'
+            tox_env: 'py310-test-alldeps-numpy126'
+
+          - name: 'macos-py312'
+            os: macos-latest
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
+
+          - name: 'windows-py312'
             os: windows-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
 
           - name: 'ubuntu-codestyle'
             os: ubuntu-latest
@@ -64,7 +74,7 @@ jobs:
 
           - name: 'ubuntu-build_docs'
             os: ubuntu-latest
-            python: '3.10'
+            python: '3.12'
             tox_env: 'build_docs'
 
           - name: 'ubuntu-py310-test-alldeps-devdeps'

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
@@ -31,11 +30,12 @@ description =
 deps =
     cov: coverage
 
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
+    numpy123: numpy==1.23.*
+    numpy126: numpy==1.26.*
 
     astroscrappy11: astroscrappy==1.1.*
     astroscrappy10: astroscrappy==1.0.*


### PR DESCRIPTION
Based off #820