### PR TITLE
DEPR: deprecate 'clobber' alias for overwrite keyword argument

### DIFF
--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -755,7 +755,7 @@ class TestImageFileCollection:
         ic = ImageFileCollection(triage_setup.test_dir)
         with pytest.raises(NotImplementedError):
             ic.ccds(overwrite=True)
-        with pytest.raises(NotImplementedError):
+        with pytest.deprecated_call(), pytest.raises(NotImplementedError):
             ic.ccds(clobber=True)
 
     def test_glob_matching(self, triage_setup):


### PR DESCRIPTION
While testing the package, I stumbled upon a `_ASTROPY_LT_1_3` constant so I pulled the thread.