### PR TITLE
DOC: adapt a docstest for numpy 2 (representation of scalars changed)

### DIFF
--- a/docs/ccddata.rst
+++ b/docs/ccddata.rst
@@ -182,7 +182,7 @@ is between two `~astropy.nddata.CCDData` objects.
 
     >>> result = ccd.multiply(0.2 * u.adu)
     >>> uncertainty_ratio = result.uncertainty.array[0, 0]/ccd.uncertainty.array[0, 0]
-    >>> round(uncertainty_ratio, 5)   # doctest: +FLOAT_CMP
+    >>> float(round(uncertainty_ratio, 5))   # doctest: +FLOAT_CMP
     0.2
     >>> result.unit
     Unit("adu electron")


### PR DESCRIPTION
This is similar to https://github.com/astropy/astropy/pull/15065
Since there is no simple way to have these doctests pass with both versions of numpy, my understanding is that this should be merged after numpy 2.0.0 final comes out.

xref: https://numpy.org/devdocs/release/2.0.0-notes.html#representation-of-numpy-scalars-changed