### PR TITLE
TST: avoid capturing stderr in tests using subprocesses

### DIFF
--- a/ccdproc/tests/test_combine_open_files.py
+++ b/ccdproc/tests/test_combine_open_files.py
@@ -30,8 +30,7 @@ def test_open_files_combine_no_chunks():
     # Make a copy
     args = list(common_args)
     args.extend(['--open-by', 'combine-nochunk', NUM_FILE_LIMIT])
-    p = subprocess.run(args=args, stderr=subprocess.PIPE,
-                       cwd=str(subprocess_dir))
+    p = subprocess.run(args=args, cwd=str(subprocess_dir))
     # If we have succeeded the test passes. We are only checking that
     # we don't have too many files open.
     assert p.returncode == 0
@@ -50,8 +49,7 @@ def test_open_files_combine_chunks():
     # Make a copy
     args = list(common_args)
     args.extend(['--open-by', 'combine-chunk', NUM_FILE_LIMIT])
-    p = subprocess.run(args=args, stderr=subprocess.PIPE,
-                       cwd=str(subprocess_dir))
+    p = subprocess.run(args=args, cwd=str(subprocess_dir))
     # If we have succeeded the test passes. We are only checking that
     # we don't have too many files open.
     assert p.returncode == 0


### PR DESCRIPTION
I scratched my head a couple minutes as I tried to understand why these tests were failing locally against numpy 2. Turns out, the error was trivial and had nothing to do with numpy:

```
ModuleNotFoundError: No module named 'psutil'
```

but it originally was not visible in pytest logs, so I propose to let stderr propagate naturally in this context to help future debugging.