### PR TITLE
TST: pin numpy<2 for tests with old astroscrappy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     numpy126: numpy==1.26.*
 
     astroscrappy11: astroscrappy==1.1.*
-    astroscrappy10: astroscrappy==1.0.*
+    astroscrappy11: numpy<2.0
 
     astropylts: astropy==4.0.*
 


### PR DESCRIPTION
I noticed CI was broken since numpy 2.0 was released: [example logs](https://github.com/astropy/ccdproc/actions/runs/9542750335/job/26298102524)
This should address it.
