### PR TITLE
Update test matrix for newer versions of numpy

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -35,22 +35,22 @@ jobs:
           - name: 'ubuntu-py39'
             os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps-numpy119-cov'
+            tox_env: 'py39-test-alldeps-numpy124-cov'
 
           - name: 'ubuntu-py39-bottleneck'
             os: ubuntu-latest
             python: '3.9'
-            tox_env: 'py39-test-alldeps-numpy119-cov-bottleneck'
+            tox_env: 'py39-test-alldeps-numpy124-cov-bottleneck'
 
           - name: 'ubuntu-py310'
             os: ubuntu-latest
             python: '3.10'
-            tox_env: 'py310-test-alldeps-numpy121'
+            tox_env: 'py310-test-alldeps-numpy124'
 
           - name: 'ubuntu-py311'
             os: ubuntu-latest
             python: '3.11'
-            tox_env: 'py311-test-alldeps-numpy123'
+            tox_env: 'py311-test-alldeps-numpy124'
 
           - name: 'ubuntu-py312'
             os: ubuntu-latest
@@ -60,12 +60,12 @@ jobs:
           - name: 'macos-py312'
             os: macos-latest
             python: '3.12'
-            tox_env: 'py312-test-alldeps'
+            tox_env: 'py312-test-alldeps-numpy200'   #DROP numpy200 restriction after astropy 6.1.3 is out
 
           - name: 'windows-py312'
             os: windows-latest
             python: '3.12'
-            tox_env: 'py312-test-alldeps'
+            tox_env: 'py312-test-alldeps-numpy200'   #DROP numpy200 restriction after astropy 6.1.3 is out
 
           - name: 'ubuntu-codestyle'
             os: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -77,10 +77,10 @@ jobs:
             python: '3.12'
             tox_env: 'build_docs'
 
-          - name: 'ubuntu-py310-test-alldeps-devdeps'
+          - name: 'ubuntu-py312-test-alldeps-devdeps'
             os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps-devdeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps-devdeps'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -60,12 +60,12 @@ jobs:
           - name: 'macos-py312'
             os: macos-latest
             python: '3.12'
-            tox_env: 'py312-test-alldeps-numpy200'   #DROP numpy200 restriction after astropy 6.1.3 is out
+            tox_env: 'py312-test-alldeps'
 
           - name: 'windows-py312'
             os: windows-latest
             python: '3.12'
-            tox_env: 'py312-test-alldeps-numpy200'   #DROP numpy200 restriction after astropy 6.1.3 is out
+            tox_env: 'py312-test-alldeps'
 
           - name: 'ubuntu-codestyle'
             os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ authors = [
 ]
 dependencies = [
     "astropy>=5.0.1",
-    "astroscrappy>=1.0.8",
-    "numpy>=1.21",
+    "astroscrappy>=1.1.0",
+    "numpy>=1.24",
     "reproject>=0.7",
     "scikit-image",
     "scipy",

--- a/tox.ini
+++ b/tox.ini
@@ -44,14 +44,9 @@ deps =
 
     # Remember to transfer any changes here to setup.cfg also. Only listing
     # packages which are constrained in the setup.cfg
-    # NOTE ABOUT NUMPY VERSION: for astroscrappy 1.0.8 have to use at least 1.20
-    # for the tests to even get to the point of running.
     oldestdeps: numpy==1.24.*
     oldestdeps: astropy==5.0.*
     oldestdeps: reproject==0.7
-    # astroscrappy needs to install AFTER numpy so its install is done in
-    # the commands section instead of here.
-    #oldestdeps: astroscrappy==1.0.8
     oldestdeps: cython
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
     cov: pytest --pyargs ccdproc {toxinidir}/docs --cov ccdproc --cov-config={toxinidir}/pyproject.toml {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
     # install astroscrappy after numpy
-    oldestdeps: python -m pip install astroscrappy==1.0.8
+    oldestdeps: python -m pip install astroscrappy==1.1.0
     # Do not care about warnings on the oldest builds
     oldestdeps: pytest --pyargs ccdproc {toxinidir}/docs -W ignore {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,28 +19,23 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy118: with numpy 1.18.*
-    numpy119: with numpy 1.19.*
-    numpy120: with numpy 1.20.*
-    numpy121: with numpy 1.21.*
-    astropylts: with the latest astropy LTS
+    numpy124: with numpy 1.24.*
+    numpy126: with numpy 1.26.*
+    numpy200: with numpy 2.0.*
+    numpy210: with numpy 2.1.*
     bottleneck: with bottleneck
 
 # The following provides some specific pinnings for key packages
 deps =
     cov: coverage
 
-    numpy118: numpy==1.18.*
-    numpy119: numpy==1.19.*
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy123: numpy==1.23.*
+    numpy124: numpy==1.24.*   # current oldest suppported numpy
     numpy126: numpy==1.26.*
+    numpy200: numpy==2.0.*
+    numpy210: numpy==2.1.*
 
     astroscrappy11: astroscrappy==1.1.*
     astroscrappy11: numpy<2.0
-
-    astropylts: astropy==4.0.*
 
     bottleneck: bottleneck>=1.3.2
 
@@ -51,7 +46,7 @@ deps =
     # packages which are constrained in the setup.cfg
     # NOTE ABOUT NUMPY VERSION: for astroscrappy 1.0.8 have to use at least 1.20
     # for the tests to even get to the point of running.
-    oldestdeps: numpy==1.21.*
+    oldestdeps: numpy==1.24.*
     oldestdeps: astropy==5.0.*
     oldestdeps: reproject==0.7
     # astroscrappy needs to install AFTER numpy so its install is done in


### PR DESCRIPTION
This drops testing on several no-longer-supported versions of numpy.