### PR TITLE
Use more appropriate comparison for floating point tests

### DIFF
--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -563,12 +563,12 @@ def test_average_combine_uncertainty():
     c = Combiner(ccd_list)
     ccd = c.average_combine(uncertainty_func=np.sum)
     uncert_ref = np.sum(c.data_arr, 0) / np.sqrt(3)
-    np.testing.assert_array_equal(ccd.uncertainty.array, uncert_ref)
+    np.testing.assert_allclose(ccd.uncertainty.array, uncert_ref)
 
     # Compare this also to the "combine" call
     ccd2 = combine(ccd_list, method="average", combine_uncertainty_function=np.sum)
-    np.testing.assert_array_equal(ccd.data, ccd2.data)
-    np.testing.assert_array_equal(ccd.uncertainty.array, ccd2.uncertainty.array)
+    np.testing.assert_allclose(ccd.data, ccd2.data)
+    np.testing.assert_allclose(ccd.uncertainty.array, ccd2.uncertainty.array)
 
 
 # test the optional uncertainty function in median_combine
@@ -578,12 +578,12 @@ def test_median_combine_uncertainty():
     c = Combiner(ccd_list)
     ccd = c.median_combine(uncertainty_func=np.sum)
     uncert_ref = np.sum(c.data_arr, 0) / np.sqrt(3)
-    np.testing.assert_array_equal(ccd.uncertainty.array, uncert_ref)
+    np.testing.assert_allclose(ccd.uncertainty.array, uncert_ref)
 
     # Compare this also to the "combine" call
     ccd2 = combine(ccd_list, method="median", combine_uncertainty_function=np.sum)
-    np.testing.assert_array_equal(ccd.data, ccd2.data)
-    np.testing.assert_array_equal(ccd.uncertainty.array, ccd2.uncertainty.array)
+    np.testing.assert_allclose(ccd.data, ccd2.data)
+    np.testing.assert_allclose(ccd.uncertainty.array, ccd2.uncertainty.array)
 
 
 # test the optional uncertainty function in sum_combine
@@ -597,8 +597,8 @@ def test_sum_combine_uncertainty():
 
     # Compare this also to the "combine" call
     ccd2 = combine(ccd_list, method="sum", combine_uncertainty_function=np.sum)
-    np.testing.assert_array_equal(ccd.data, ccd2.data)
-    np.testing.assert_array_equal(ccd.uncertainty.array, ccd2.uncertainty.array)
+    np.testing.assert_allclose(ccd.data, ccd2.data)
+    np.testing.assert_allclose(ccd.uncertainty.array, ccd2.uncertainty.array)
 
 
 # Ignore warnings generated because most values are masked
@@ -809,7 +809,7 @@ def test_clip_extrema_3d():
     c.clip_extrema(nlow=1, nhigh=1)
     result = c.average_combine()
     expected = CCDData(np.ones((3, 3, 3)) * 30, unit="adu")
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -846,7 +846,7 @@ def test_clip_extrema():
         [30.0, 30.0, 47.5, 30.0, 30.0],
         [47.5, 30.0, 30.0, 30.0, 30.0],
     ]
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_clip_extrema_via_combine():
@@ -872,7 +872,7 @@ def test_clip_extrema_via_combine():
         [30.0, 30.0, 47.5, 30.0, 30.0],
         [47.5, 30.0, 30.0, 30.0, 30.0],
     ]
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 def test_clip_extrema_with_other_rejection():
@@ -900,7 +900,7 @@ def test_clip_extrema_with_other_rejection():
         [30.0, 30.0, 47.5, 30.0, 30.0],
         [47.5, 30.0, 30.0, 30.0, 30.0],
     ]
-    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
 # The expected values below assume an image that is 2000x2000

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -280,11 +280,11 @@ class TestImageFileCollection:
         for data, hdr, hdu, ccd in zip(
             ic2.data(), ic2.headers(), ic2.hdus(), ic2.ccds(ccd_kwargs)
         ):
-            np.testing.assert_array_equal(data, ext2.data)
+            np.testing.assert_allclose(data, ext2.data)
             assert hdr == ext2.header
             # Now compare that the generators each give the same stuff
-            np.testing.assert_array_equal(data, ccd.data)
-            np.testing.assert_array_equal(data, hdu.data)
+            np.testing.assert_allclose(data, ccd.data)
+            np.testing.assert_allclose(data, hdu.data)
             assert hdr == hdu.header
             assert hdr == ccd.meta
 

--- a/ccdproc/tests/test_rebin.py
+++ b/ccdproc/tests/test_rebin.py
@@ -77,5 +77,5 @@ def test_rebin_does_not_change_input():
     original = ccd_data.copy()
     with pytest.warns(AstropyDeprecationWarning):
         _ = rebin(ccd_data, (20, 20))
-    np.testing.assert_array_equal(original.data, ccd_data.data)
+    np.testing.assert_allclose(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit

--- a/ccdproc/tests/test_wrapped_external_funcs.py
+++ b/ccdproc/tests/test_wrapped_external_funcs.py
@@ -73,4 +73,4 @@ def test_medianfilter_ndarray():
     result = core.median_filter(arr, 3)
     reference = ndimage.median_filter(arr, 3)
     # It's a wrapped function so we can use the equal comparison.
-    np.testing.assert_array_equal(result, reference)
+    np.testing.assert_allclose(result, reference)

--- a/ccdproc/utils/tests/test_slices.py
+++ b/ccdproc/utils/tests/test_slices.py
@@ -40,13 +40,13 @@ def test_slice_from_string_1d(start, stop, step):
         slice_str = ":".join([start_str, stop_str])
     sli = slice_from_string("[" + slice_str + "]")
     expected = an_array[slice(start, stop, step)]
-    np.testing.assert_array_equal(expected, an_array[sli])
+    np.testing.assert_allclose(expected, an_array[sli])
 
 
 @pytest.mark.parametrize("arg", ["  [ 1:  45]", "[ 1  :4 5]", "  [1:45] "])
 def test_slice_from_string_spaces(arg):
     an_array = np.zeros([100])
-    np.testing.assert_array_equal(an_array[1:45], an_array[slice_from_string(arg)])
+    np.testing.assert_allclose(an_array[1:45], an_array[slice_from_string(arg)])
 
 
 def test_slice_from_string_2d():
@@ -55,13 +55,13 @@ def test_slice_from_string_2d():
     # manually writing a few cases here rather than parametrizing because the
     # latter seems not worth the trouble.
     sli = slice_from_string("[:-1:2, :]")
-    np.testing.assert_array_equal(an_array[:-1:2, :], an_array[sli])
+    np.testing.assert_allclose(an_array[:-1:2, :], an_array[sli])
 
     sli = slice_from_string("[:, 15:90]")
-    np.testing.assert_array_equal(an_array[:, 15:90], an_array[sli])
+    np.testing.assert_allclose(an_array[:, 15:90], an_array[sli])
 
     sli = slice_from_string("[10:80:5, 15:90:-1]")
-    np.testing.assert_array_equal(an_array[10:80:5, 15:90:-1], an_array[sli])
+    np.testing.assert_allclose(an_array[10:80:5, 15:90:-1], an_array[sli])
 
 
 def test_slice_from_string_fits_style():


### PR DESCRIPTION
Please have a look at the following list and replace the "[ ]" with a "[x]" if
the answer to this question is yes.

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?
      Note that it should not if you changed any examples!

For bugfixes:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you add a regression test?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number" (replace "issue_number").
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

Please note that the last point is not a requirement. It is meant as a check if
the pull request potentially breaks backwards-compatibility.

-----------------------------------------
