### PR TITLE
Remove scikit-image runtime dependency

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ Alphabetical list of code contributors
 * Yash Gondhalekar (@Yash-10)
 * Hans Moritz Günther (@hamogu)
 * Nathan Heidt (@heidtha)
+* Karl Hill (@karlhillx)
 * Michael Hlabathe (@hlabathems)
 * Elias Holte (@Sondanaa)
 * Anthony Horton (@AnthonyHorton)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Remove superfluous license file from the package. [#899]
+- scikit-image is no longer a runtime dependency. [#921]
 
 2.5.0 (2025-07-03)
 ------------------

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -7,7 +7,6 @@ import array_api_extra as xpx
 import astropy
 import astropy.units as u
 import pytest
-import skimage
 from astropy.io import fits
 from astropy.modeling import models
 from astropy.nddata import (
@@ -801,10 +800,6 @@ def test_transform_image(mask_data, uncertainty):
 
 # Test block_reduce and block_replicate wrapper
 @pytest.mark.skipif(not HAS_BLOCK_X_FUNCS, reason="needs astropy >= 1.1.x")
-@pytest.mark.skipif(
-    (skimage.__version__ < "0.14.2") and ("dev" in xp.__version__),
-    reason="Incompatibility between scikit-image " "and numpy 1.16",
-)
 def test_block_reduce():
     ccd = CCDData(
         xp.ones((4, 4)),
@@ -834,10 +829,6 @@ def test_block_reduce():
 
 
 @pytest.mark.skipif(not HAS_BLOCK_X_FUNCS, reason="needs astropy >= 1.1.x")
-@pytest.mark.skipif(
-    (skimage.__version__ < "0.14.2") and ("dev" in xp.__version__),
-    reason="Incompatibility between scikit-image " "and numpy 1.16",
-)
 def test_block_average():
     data = xp.asarray(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "astroscrappy>=1.1.0",
     "numpy>=1.26",
     "reproject>=0.9.1",
-    "scikit-image",
     "scipy",
 ]
 


### PR DESCRIPTION
ccdproc's block_reduce/block_average/block_replicate wrappers all delegate to astropy.nddata. scikit-image was never imported at runtime -- only in the test file, and only for a version-check skip condition that used broken string comparison.

Removed it from runtime deps and cleaned up the test imports.