### PR TITLE
Fix typo in array_api docs

### DIFF
--- a/docs/array_api.rst
+++ b/docs/array_api.rst
@@ -22,7 +22,7 @@ What array libraries are supported?
 
 The best list of array libraries that implement the array API is at `array-api-compat`_.
 `ccdproc`_ is currently regularly tested against `numpy`_, `dask`_, and `jax`_. It
-is occasionally tested against `CuPy`_; any errors your encounter running `ccdproc`_
+is occasionally tested against `CuPy`_; any errors you encounter running `ccdproc`_
 on a GPU using `CuPy`_ should be
 `reported as an issue <https://github.com/astropy/ccdproc/issues>`_.
 


### PR DESCRIPTION
Trivial docs typo fix ("your encounter" -> "you encounter"), doubling as the post-merge verification for the strict-status reporting added in #942.

Expected on this PR, now that the workflow file is on the default branch and runs in the real `workflow_run` flow:

- [ ] exactly **one** `ubuntu-py313-strict` check run appears (the `pull_request`-event gate working — not two);
- [ ] its conclusion is **neutral** with a "failing (expected)" title while known strict failures remain;
- [ ] the `strict-job-outcome-ubuntu-py313-strict` JSON artifact exists on the CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5FNYqVHbKLbVSGJGftLrL