### PR TITLE
Prefix strict-status check names to avoid merge-box name collision

### DIFF
--- a/.github/workflows/strict_status.yml
+++ b/.github/workflows/strict_status.yml
@@ -1,8 +1,9 @@
 # Turn the outcome of the expected-failures strict array-API jobs into
 # check runs on the PR. This runs as a separate workflow_run workflow because
 # pull_request runs for fork PRs get a read-only GITHUB_TOKEN and cannot
-# create check runs themselves. Each check uses a stable name (the matrix
-# entry name); the outcome is carried by the conclusion and output instead.
+# create check runs themselves. Each check uses a stable name ("strict-status
+# / " plus the matrix entry name); the outcome is carried by the conclusion
+# and output instead.
 # These checks are informational only (an expected test failure is reported
 # as neutral, so the PR rollup stays green) and are not intended to be
 # required checks while the failures are expected.
@@ -126,13 +127,16 @@ jobs:
                 'complete its tests step. This is an infrastructure error in the ' +
                 'job itself, not a test failure; see the run log for details.';
             }
-            // Stable check name (just the matrix entry name); the outcome
-            // lives in the conclusion and output so the checks UI does not
-            // accumulate differently-named checks per outcome.
+            // Stable check name; the outcome lives in the conclusion and
+            // output so the checks UI does not accumulate differently-named
+            // checks per outcome. The prefix keeps the name distinct from
+            // the CI job's own check (e.g. "ubuntu-py313-strict") -- the PR
+            // merge box shows only one check per name, so an identically
+            // named check run would be hidden behind the CI job entry.
             await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name,
+              name: `strict-status / ${name}`,
               head_sha: run.head_sha,
               status: 'completed',
               conclusion,


### PR DESCRIPTION
Follow-up to #949. Post-merge verification on #948 showed the strict-status check run is now created correctly, but it does not appear in the PR merge box — only on the Checks tab. Cause: the check run reuses the CI job's exact name (e.g. `ubuntu-py313-strict`), and the merge box shows only one check per name, so the CI job's green entry (from the newer check suite) hides the neutral strict-status entry.

This prefixes the reported check name with `strict-status / `, giving it its own merge-box row. That also reads more clearly: one row for whether the CI job infrastructure ran (green), one for what the strict tests actually did (neutral "failed (expected)" / green "passed").

As with #949, `workflow_run` workflows execute from the default branch, so this takes effect after merging; re-verify by re-triggering CI on an open PR and confirming a `strict-status / ubuntu-py313-strict` check appears near the merge button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5FNYqVHbKLbVSGJGftLrL
