### PR TITLE
Return plain CCDData from array API wrappers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bug Fixes
   namespace form ``xp.astype(weights, xp.float64)`` instead of the deprecated
   string-based ``.astype("float64")``. This resolves the ``DeprecationWarning``
   that was being promoted to a test failure in the JAX CI job. [#924]
+- Return plain ``CCDData`` objects from array-API wrapper-copy paths, and
+  public uncertainty types from arithmetic paths. [#953]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/_ccddata_wrapper_for_array_api.py
@@ -375,16 +375,22 @@ def _unwrap_ccddata_for_array_api(ccd):
     Unwrap a CCDData object from array API backends to the original CCDData.
     """
 
-    if ccd.uncertainty is not None:
-        ccd.uncertainty = _unwrap_uncertainty(ccd.uncertainty)
-
-    if isinstance(ccd, CCDData):
-        return ccd
-
-    if not isinstance(ccd, _CCDDataWrapperForArrayAPI):
+    if not isinstance(ccd, CCDData):
         raise TypeError(
             "Input must be a CCDData or _CCDDataWrapperForArrayAPI instance."
         )
 
-    # Convert back to CCDData
-    return CCDData(ccd)
+    if isinstance(
+        ccd.uncertainty,
+        (
+            _StdDevUncertaintyWrapper,
+            _VarianceUncertaintyWrapper,
+            _InverseVarianceWrapper,
+        ),
+    ):
+        ccd.uncertainty = _unwrap_uncertainty(ccd.uncertainty)
+
+    if isinstance(ccd, _CCDDataWrapperForArrayAPI):
+        return CCDData(ccd)
+
+    return ccd

--- a/ccdproc/_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/_ccddata_wrapper_for_array_api.py
@@ -391,6 +391,13 @@ def _unwrap_ccddata_for_array_api(ccd):
         ccd.uncertainty = _unwrap_uncertainty(ccd.uncertainty)
 
     if isinstance(ccd, _CCDDataWrapperForArrayAPI):
-        return CCDData(ccd)
+        # Do not copy-construct through CCDData here. Astropy's mask setter
+        # coerces masks with np.asarray(..., dtype=bool), which would pull
+        # non-NumPy masks out of their array namespace. The wrapper is a
+        # state-free Python subclass created as a copy by
+        # _wrap_ccddata_for_array_api, so changing its public class identity
+        # does not mutate the caller's CCDData or disturb its backend arrays.
+        ccd.__class__ = CCDData
+        return ccd
 
     return ccd

--- a/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
@@ -1,0 +1,112 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import array_api_extra as xpx
+import astropy.units as u
+import pytest
+from astropy.nddata import (
+    CCDData,
+    InverseVariance,
+    StdDevUncertainty,
+    VarianceUncertainty,
+)
+from astropy.wcs import WCS
+
+from ccdproc import flat_correct, trim_image
+from ccdproc._ccddata_wrapper_for_array_api import (
+    _InverseVarianceWrapper,
+    _StdDevUncertaintyWrapper,
+    _unwrap_ccddata_for_array_api,
+    _VarianceUncertaintyWrapper,
+)
+from ccdproc.conftest import testing_array_library as xp
+
+
+def test_trim_image_returns_plain_ccddata():
+    data = xp.asarray([[1.0, 2.0], [3.0, 4.0]])
+    uncertainty = StdDevUncertainty(xp.asarray([[0.1, 0.2], [0.3, 0.4]]))
+    wcs = WCS(naxis=2)
+    ccd = CCDData(
+        data,
+        unit=u.adu,
+        uncertainty=uncertainty,
+        meta={"source": "test"},
+        wcs=wcs,
+    )
+
+    result = trim_image(ccd, add_keyword=None)
+
+    assert type(result) is CCDData
+    assert type(result.uncertainty) is StdDevUncertainty
+    assert xp.all(xpx.isclose(result.data, ccd.data))
+    assert result.mask is None
+    assert xp.all(xpx.isclose(result.uncertainty.array, ccd.uncertainty.array))
+    assert result.meta == ccd.meta
+    assert result.unit == ccd.unit
+    assert result.wcs.wcs.compare(ccd.wcs.wcs)
+
+
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="Astropy uncertainty propagation mixes NumPy and strict arrays",
+)
+def test_flat_correct_returns_public_uncertainty():
+    ccd = CCDData(
+        xp.ones((2, 2)),
+        unit=u.adu,
+        uncertainty=StdDevUncertainty(xp.ones((2, 2))),
+    )
+    flat = CCDData(xp.ones((2, 2)), unit=u.adu)
+
+    result = flat_correct(ccd, flat, add_keyword=None)
+
+    assert type(result) is CCDData
+    assert type(result.uncertainty) is StdDevUncertainty
+
+
+@pytest.mark.parametrize(
+    ("wrapper_type", "public_type"),
+    [
+        (_StdDevUncertaintyWrapper, StdDevUncertainty),
+        (_VarianceUncertaintyWrapper, VarianceUncertainty),
+        (_InverseVarianceWrapper, InverseVariance),
+    ],
+)
+def test_unwrap_plain_ccddata_returns_public_uncertainty(wrapper_type, public_type):
+    ccd = CCDData(
+        xp.ones((1, 1)),
+        unit=u.adu,
+        uncertainty=wrapper_type(xp.ones((1, 1))),
+    )
+
+    result = _unwrap_ccddata_for_array_api(ccd)
+
+    assert result is ccd
+    assert type(result.uncertainty) is public_type
+
+
+def test_unwrap_plain_ccddata_is_identity():
+    uncertainty = StdDevUncertainty(xp.asarray([[0.1]]))
+    ccd = CCDData(xp.asarray([[1.0]]), unit=u.adu, uncertainty=uncertainty)
+    assigned_uncertainty = ccd.uncertainty
+
+    result = _unwrap_ccddata_for_array_api(ccd)
+
+    assert result is ccd
+    assert result.uncertainty is assigned_uncertainty
+
+
+def test_unwrap_ccddata_subclass_is_identity():
+    class CustomCCDData(CCDData):
+        pass
+
+    ccd = CustomCCDData(xp.asarray([[1.0]]), unit=u.adu)
+
+    assert _unwrap_ccddata_for_array_api(ccd) is ccd
+
+
+def test_unwrap_rejects_non_ccddata():
+    with pytest.raises(
+        TypeError,
+        match="Input must be a CCDData or _CCDDataWrapperForArrayAPI instance",
+    ):
+        _unwrap_ccddata_for_array_api(object())

--- a/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
@@ -13,10 +13,12 @@ from astropy.wcs import WCS
 
 from ccdproc import flat_correct, trim_image
 from ccdproc._ccddata_wrapper_for_array_api import (
+    _CCDDataWrapperForArrayAPI,
     _InverseVarianceWrapper,
     _StdDevUncertaintyWrapper,
     _unwrap_ccddata_for_array_api,
     _VarianceUncertaintyWrapper,
+    _wrap_ccddata_for_array_api,
 )
 from ccdproc.conftest import testing_array_library as xp
 
@@ -93,6 +95,30 @@ def test_unwrap_plain_ccddata_is_identity():
 
     assert result is ccd
     assert result.uncertainty is assigned_uncertainty
+
+
+def test_unwrap_wrapper_preserves_backend_arrays():
+    ccd = CCDData(xp.ones((2, 2)), unit=u.adu)
+    ccd._mask = xp.asarray([[True, False], [False, True]])
+    ccd.uncertainty = StdDevUncertainty(xp.ones((2, 2)))
+
+    wrapped = _wrap_ccddata_for_array_api(ccd)
+    assert isinstance(wrapped, _CCDDataWrapperForArrayAPI)
+    assert wrapped is not ccd
+    wrapped_data = wrapped.data
+    wrapped_mask = wrapped.mask
+    wrapped_uncertainty_array = wrapped.uncertainty.array
+
+    result = _unwrap_ccddata_for_array_api(wrapped)
+
+    assert result is wrapped
+    assert type(result) is CCDData
+    assert result.data is wrapped_data
+    assert result.mask is wrapped_mask
+    assert type(result.uncertainty.array) is type(wrapped_uncertainty_array)
+    assert xp.all(xpx.isclose(result.uncertainty.array, wrapped_uncertainty_array))
+    assert type(result.uncertainty) is StdDevUncertainty
+    assert type(ccd) is CCDData
 
 
 def test_unwrap_ccddata_subclass_is_identity():


### PR DESCRIPTION
## Summary

- make `_unwrap_ccddata_for_array_api` validate inputs before accessing uncertainty
- unwrap private uncertainty wrappers even when arithmetic has already produced a plain `CCDData`
- convert `_CCDDataWrapperForArrayAPI` results to concrete `CCDData` while preserving ordinary `CCDData` subclasses
- add focused public and helper-level regressions across the supported uncertainty types

Fixes #927

## Validation

- `python -m pytest ccdproc -q` — 339 passed, 29 skipped
- focused regression module — 8 passed with NumPy, Dask, and JAX
- focused regression module with `array-api-strict` — 7 passed, 1 documented xfail for the pre-existing Astropy uncertainty-propagation boundary
- Ruff, Black, and `git diff --check` — passed

## Checklist

- [ ] For new contributors: Did you add yourself to the `AUTHORS.rst` file? (The entry is already proposed in draft #952, so it is intentionally not duplicated here.)
- [ ] For documentation changes: Does your commit message include a `[skip ci]`? (Not a documentation-only change.)
- [x] For bugfixes: Did you add an entry to the `CHANGES.rst` file?
- [x] For bugfixes: Did you add a regression test?
- [x] For bugfixes: Does the commit message include `Fixes #927`?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

## AI assistance disclosure

OpenAI Codex was used for source inspection, test design, implementation, and automated review. This PR remains a draft pending the contributor's personal review; the contributor will take responsibility for the final contribution before marking it ready.
