### PR TITLE
Keep clip_extrema indices in the array namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,13 @@ Bug Fixes
 - Use Bottleneck combination functions only with NumPy arrays, preserving the
   selected Array API namespace for other backends. [#904, #959]
 
+Bug Fixes
+^^^^^^^^^
+
+- Keep ``Combiner.clip_extrema`` index arithmetic in the selected array
+  namespace so GPU-backed arrays do not require an implicit conversion to
+  NumPy.
+
 2.5.1 (2025-07-05)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,10 +37,6 @@ Bug Fixes
 
 - Use Bottleneck combination functions only with NumPy arrays, preserving the
   selected Array API namespace for other backends. [#904, #959]
-
-Bug Fixes
-^^^^^^^^^
-
 - Keep ``Combiner.clip_extrema`` index arithmetic in the selected array
   namespace so GPU-backed arrays do not require an implicit conversion to
   NumPy. [#954]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ Bug Fixes
 
 - Keep ``Combiner.clip_extrema`` index arithmetic in the selected array
   namespace so GPU-backed arrays do not require an implicit conversion to
-  NumPy.
+  NumPy. [#954]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -18,7 +18,6 @@ from astropy.nddata import CCDData, StdDevUncertainty
 from astropy.stats import sigma_clip
 from astropy.utils import deprecated_renamed_argument
 from numpy import mgrid as np_mgrid
-from numpy import ravel_multi_index as np_ravel_multi_index
 
 from .core import sigma_func
 
@@ -341,16 +340,23 @@ class Combiner:
         mg = xp.asarray(
             np_mgrid[
                 [slice(ndim) for i, ndim in enumerate(self._data_arr.shape) if i > 0]
-            ]
+            ],
+            device=array_api_compat.device(self._data_arr),
         )
         for i in range(-1 * nhigh, nlow):
-            # create a tuple with the indices
-            where = tuple([argsorted[i, :, :].ravel()] + [v.ravel() for v in mg])
+            coordinates = [xp.reshape(argsorted[(i, ...)], (-1,))]
+            coordinates.extend(
+                xp.reshape(mg[(axis, ...)], (-1,)) for axis in range(mg.shape[0])
+            )
             # Some array libraries don't support indexing with arrays in multiple
             # dimensions, so we need to flatten the mask array, set the mask
             # values for a flattened array, and then reshape it back to the
             # original shape.
-            flat_index = np_ravel_multi_index(where, self._data_arr.shape)
+            flat_index = coordinates[0]
+            for coordinate, dimension in zip(
+                coordinates[1:], self._data_arr.shape[1:], strict=True
+            ):
+                flat_index = flat_index * dimension + coordinate
             self._data_arr_mask = xp.reshape(
                 xpx.at(xp.reshape(self._data_arr_mask, (-1,)))[flat_index].set(True),
                 self._data_arr.shape,

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1074,26 +1074,23 @@ def test_3d_combiner_with_scaling():
 
 
 def test_clip_extrema_keeps_indices_in_array_namespace(monkeypatch):
-    # Bypass Combiner.__init__ to isolate clip_extrema from the separate
-    # strict-backend limitation on stacking a list of arrays.
-    combiner = object.__new__(Combiner)
-    combiner._xp = xp
-    combiner._data_arr = xp.asarray(
-        [
-            [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
-            [[3.0, 6.0, 5.0], [9.0, 2.0, 8.0]],
-            [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
-        ],
-        device=xp_device,
-    )
-    combiner._data_arr_mask = xp.asarray(
-        [
-            [[False, False, False], [False, False, False]],
-            [[False, False, False], [False, False, False]],
-            [[False, False, False], [False, False, False]],
-        ],
-        device=xp_device,
-    )
+    data = [
+        [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
+        [[3.0, 6.0, 5.0], [9.0, 2.0, 8.0]],
+        [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
+    ]
+
+    if xp.__name__ == "array_api_strict":
+        # Bypass Combiner.__init__ only for array-api-strict, which cannot stack
+        # a list of arrays. This isolates clip_extrema from that separate limit.
+        combiner = object.__new__(Combiner)
+        combiner._xp = xp
+        combiner._data_arr = xp.asarray(data, device=xp_device)
+        combiner._data_arr_mask = xp.zeros(
+            combiner._data_arr.shape, dtype=xp.bool, device=xp_device
+        )
+    else:
+        combiner = Combiner([CCDData(xp.asarray(image), unit=u.adu) for image in data])
 
     captured_indices = []
     if xp.__name__ == "array_api_strict":

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -22,6 +22,7 @@ from ccdproc.combiner import (
 )
 
 # Set up the array library to be used in tests
+from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
 from ccdproc.image_collection import ImageFileCollection
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
@@ -1070,6 +1071,85 @@ def test_3d_combiner_with_scaling():
     avg_ccd = combiner.average_combine()
     assert xp.all(xpx.isclose(avg_ccd.data.mean(), ccd_data.data.mean()))
     assert avg_ccd.shape == ccd_data.shape
+
+
+def test_clip_extrema_keeps_indices_in_array_namespace(monkeypatch):
+    # Bypass Combiner.__init__ to isolate clip_extrema from the separate
+    # strict-backend limitation on stacking a list of arrays.
+    combiner = object.__new__(Combiner)
+    combiner._xp = xp
+    combiner._data_arr = xp.asarray(
+        [
+            [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
+            [[3.0, 6.0, 5.0], [9.0, 2.0, 8.0]],
+            [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
+        ],
+        device=xp_device,
+    )
+    combiner._data_arr_mask = xp.asarray(
+        [
+            [[False, False, False], [False, False, False]],
+            [[False, False, False], [False, False, False]],
+            [[False, False, False], [False, False, False]],
+        ],
+        device=xp_device,
+    )
+
+    captured_indices = []
+    if xp.__name__ == "array_api_strict":
+        # array-api-strict deliberately implements only standard indexing, which
+        # excludes the integer-array assignment performed by xpx.at. Replace that
+        # final update only, so this backend can exercise and inspect the index
+        # calculation on a non-default device.
+        class AtSpy:
+            def __init__(self, array):
+                self.array = array
+
+            def __getitem__(self, index):
+                self.index = index
+                captured_indices.append(index)
+                return self
+
+            def set(self, value):
+                device = array_api_compat.device(self.array)
+                positions = xp.arange(self.array.shape[0], device=device)
+                selected = xp.any(
+                    xp.reshape(positions, (-1, 1)) == xp.reshape(self.index, (1, -1)),
+                    axis=1,
+                )
+                return xp.where(
+                    selected,
+                    xp.asarray(value, dtype=self.array.dtype, device=device),
+                    self.array,
+                )
+
+        monkeypatch.setattr("ccdproc.combiner.xpx.at", AtSpy)
+
+    combiner.clip_extrema(nlow=1, nhigh=1)
+
+    expected_mask = xp.asarray(
+        [
+            [[True, False, True], [False, True, True]],
+            [[True, True, False], [True, True, True]],
+            [[False, True, True], [True, False, False]],
+        ],
+        device=xp_device,
+    )
+    assert xp.all(combiner.mask == expected_mask)
+    assert array_api_compat.device(combiner.mask) == array_api_compat.device(
+        combiner.data
+    )
+    if captured_indices:
+        expected_indices = (
+            xp.asarray([0, 7, 2, 9, 4, 11], device=xp_device),
+            xp.asarray([6, 13, 14, 15, 10, 5], device=xp_device),
+        )
+        assert len(captured_indices) == len(expected_indices)
+        for actual, expected in zip(captured_indices, expected_indices, strict=True):
+            assert xp.all(actual == expected)
+            assert array_api_compat.device(actual) == array_api_compat.device(
+                combiner.data
+            )
 
 
 def test_clip_extrema_3d():


### PR DESCRIPTION
## Summary

- replace NumPy `ravel_multi_index` with equivalent C-order arithmetic in the selected array namespace
- keep coordinate indices on the input array device and use Array API-compatible reshaping/indexing
- add an asymmetric regression that checks the exact high/low flat indices and non-default-device preservation

Fixes #928

## Validation

- `python -m pytest ccdproc -q` — 380 passed, 29 skipped
- `python -m pytest ccdproc/tests/test_combiner.py -q` — 87 passed with NumPy and 87 passed with Dask
- JAX Combiner module with 64-bit enabled — 81 passed, 6 established xfails
- focused regression with `array-api-strict` on a non-default device — 1 passed
- Ruff, Black, `git diff --check`, and `git show --check` — passed

`array-api-strict` deliberately excludes integer-array assignment, so the focused strict regression replaces only the final `xpx.at` update with a test spy. The production update path is exercised by the NumPy, Dask, and JAX runs; strict verifies that the exact C-order indices are computed in the selected namespace and remain on the data device.

## Checklist

- [ ] For new contributors: Did you add yourself to the `AUTHORS.rst` file? (The entry is already present on current main, so it is intentionally not duplicated here.)
- [ ] For documentation changes: Does your commit message include a `[skip ci]`? (Not a documentation-only change.)
- [x] For bugfixes: Did you add an entry to the `CHANGES.rst` file?
- [x] For bugfixes: Did you add a regression test?
- [x] For bugfixes: Does the commit message include `Fixes #928`?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

## AI assistance disclosure

OpenAI Codex was used for source inspection, test design, implementation, and automated review. I have personally reviewed the current diff and validation evidence and take responsibility for this contribution.