### PR TITLE
Make array API escape logging thread-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bug Fixes
   support immutable array-API backends. [#956]
 - Fix the fallback percentile calculation for array namespaces that do not
   provide ``percentile``. [#957]
+- Make array-API escape logging thread-safe so concurrent worker escapes are
+  not missed. [#955]
 - Fix dtype conversion in ``Combiner._weighted_sum`` to use the array-API
   namespace form ``xp.astype(weights, xp.float64)`` instead of the deprecated
   string-based ``.astype("float64")``. This resolves the ``DeprecationWarning``

--- a/ccdproc/conftest.py
+++ b/ccdproc/conftest.py
@@ -5,6 +5,7 @@
 # no matter how it is invoked within the source tree.
 import logging
 import os
+import threading
 import traceback
 
 import array_api_compat
@@ -239,7 +240,7 @@ def _describe_escape_site(frame):
     return f"{frame.filename}:{frame.lineno} {frame.name}"
 
 
-class _ReentrancyGuard:
+class _ReentrancyGuard(threading.local):
     """Small helper to keep our wrappers from recursing into themselves."""
 
     def __init__(self):

--- a/ccdproc/tests/_escape_triage.py
+++ b/ccdproc/tests/_escape_triage.py
@@ -29,6 +29,7 @@ batch of failures.
 import os
 import traceback
 from collections import defaultdict
+from threading import Lock
 
 import pytest
 
@@ -69,6 +70,7 @@ _ESCAPE_SITES = defaultdict(list)
 #: collapse the streamed warnings into a summary, and it is the observed-set
 #: input to the baseline ratchet.
 _ESCAPE_LOG_COUNTS = defaultdict(int)
+_ESCAPE_LOG_COUNTS_LOCK = Lock()
 
 
 def record_escape_log(frame, funcname):
@@ -81,7 +83,8 @@ def record_escape_log(frame, funcname):
         key = ("<unknown location>", 0, "", funcname)
     else:
         key = (_relpath(frame.filename), frame.lineno, frame.name, funcname)
-    _ESCAPE_LOG_COUNTS[key] += 1
+    with _ESCAPE_LOG_COUNTS_LOCK:
+        _ESCAPE_LOG_COUNTS[key] += 1
 
 
 # Anchor frame classification on this file's actual location rather than

--- a/ccdproc/tests/test_escape_triage.py
+++ b/ccdproc/tests/test_escape_triage.py
@@ -1,0 +1,102 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock, get_ident
+
+from ccdproc import conftest as escape_log
+from ccdproc.tests import _escape_triage
+
+
+def test_escape_wrapper_guard_is_thread_local(monkeypatch):
+    first_entered = Event()
+    release_first = Event()
+    inspected = []
+    logged = []
+    original_calls = []
+
+    def original(value):
+        original_calls.append(value)
+        return value
+
+    guard = escape_log._ReentrancyGuard()
+    wrapper = escape_log._make_escape_logging_wrapper(original, "numpy.asarray", guard)
+    nested_wrapper = escape_log._make_escape_logging_wrapper(
+        original, "numpy.asanyarray", guard
+    )
+
+    def foreign_namespace(value):
+        inspected.append(value)
+        if value == "first":
+            assert nested_wrapper("nested") == "nested"
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        return "foreign"
+
+    def record_escape(_frame, funcname):
+        logged.append(funcname)
+
+    monkeypatch.setattr(escape_log, "_foreign_namespace", foreign_namespace)
+    monkeypatch.setattr(escape_log, "_escape_site_frame", lambda: None)
+    monkeypatch.setattr(escape_log, "record_escape_log", record_escape)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(wrapper, "first")
+        try:
+            assert first_entered.wait(timeout=5)
+            second = executor.submit(wrapper, "second")
+            assert second.result(timeout=5) == "second"
+        finally:
+            release_first.set()
+        assert first.result(timeout=5) == "first"
+
+    assert inspected == ["first", "second"]
+    assert logged == ["numpy.asarray", "numpy.asarray"]
+    assert original_calls == ["nested", "second", "first"]
+
+
+def test_escape_log_tally_increment_is_serialized(monkeypatch):
+    class TrackingLock:
+        def __init__(self):
+            self.lock = Lock()
+            self.owner = None
+
+        def __enter__(self):
+            self.lock.acquire()
+            self.owner = get_ident()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.owner = None
+            self.lock.release()
+
+        def held_by_current_thread(self):
+            return self.owner == get_ident()
+
+    class GuardedCounts(dict):
+        def __init__(self, lock):
+            super().__init__()
+            self.lock = lock
+
+        def __getitem__(self, key):
+            assert self.lock.held_by_current_thread()
+            return self.get(key, 0)
+
+        def __setitem__(self, key, value):
+            assert self.lock.held_by_current_thread()
+            super().__setitem__(key, value)
+
+    lock = TrackingLock()
+    counts = GuardedCounts(lock)
+    monkeypatch.setattr(_escape_triage, "_ESCAPE_LOG_COUNTS", counts)
+    monkeypatch.setattr(_escape_triage, "_ESCAPE_LOG_COUNTS_LOCK", lock, raising=False)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(_escape_triage.record_escape_log, None, "numpy.asarray")
+            for _ in range(20)
+        ]
+        for future in futures:
+            future.result(timeout=5)
+
+    key = ("<unknown location>", 0, "", "numpy.asarray")
+    assert counts.get(key) == 20

--- a/ccdproc/tests/test_escape_triage.py
+++ b/ccdproc/tests/test_escape_triage.py
@@ -25,6 +25,8 @@ def test_escape_wrapper_guard_is_thread_local(monkeypatch):
     )
 
     def foreign_namespace(value):
+        if not isinstance(value, str) or value not in ("first", "second"):
+            return None
         inspected.append(value)
         if value == "first":
             assert nested_wrapper("nested") == "nested"
@@ -43,6 +45,8 @@ def test_escape_wrapper_guard_is_thread_local(monkeypatch):
         first = executor.submit(wrapper, "first")
         try:
             assert first_entered.wait(timeout=5)
+            unrelated = object()
+            assert wrapper(unrelated) is unrelated
             second = executor.submit(wrapper, "second")
             assert second.result(timeout=5) == "second"
         finally:
@@ -51,11 +55,13 @@ def test_escape_wrapper_guard_is_thread_local(monkeypatch):
 
     assert inspected == ["first", "second"]
     assert logged == ["numpy.asarray", "numpy.asarray"]
-    assert original_calls == ["nested", "second", "first"]
+    assert original_calls == ["nested", unrelated, "second", "first"]
 
 
 def test_escape_log_tally_increment_is_serialized(monkeypatch):
     class TrackingLock:
+        """Track which thread owns the lock used by the tally."""
+
         def __init__(self):
             self.lock = Lock()
             self.owner = None
@@ -73,6 +79,8 @@ def test_escape_log_tally_increment_is_serialized(monkeypatch):
             return self.owner == get_ident()
 
     class GuardedCounts(dict):
+        """Assert every tally read and write happens while holding the lock."""
+
         def __init__(self, lock):
             super().__init__()
             self.lock = lock
@@ -88,7 +96,7 @@ def test_escape_log_tally_increment_is_serialized(monkeypatch):
     lock = TrackingLock()
     counts = GuardedCounts(lock)
     monkeypatch.setattr(_escape_triage, "_ESCAPE_LOG_COUNTS", counts)
-    monkeypatch.setattr(_escape_triage, "_ESCAPE_LOG_COUNTS_LOCK", lock, raising=False)
+    monkeypatch.setattr(_escape_triage, "_ESCAPE_LOG_COUNTS_LOCK", lock)
 
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = [


### PR DESCRIPTION
## Summary

- keep the shared escape-wrapper reentrancy guard while making its active state local to each worker thread
- serialize the complete escape-count read-modify-write operation
- add deterministic regressions for cross-wrapper same-thread recursion, concurrent wrapper inspection, and protected tally updates

Fixes #944

## Validation

- `python -m pytest ccdproc/tests/test_escape_triage.py -q` — 2 passed
- refreshed full NumPy suite — 348 passed, 29 skipped
- refreshed Dask escape-baseline enforcement — 343 passed, 34 skipped; 191 escapes at 22 sites; no escapes outside the baseline
- Ruff, Black, `git diff --check`, and `git show --check` — passed

The guard remains shared across all three NumPy wrappers, preserving same-thread cross-wrapper recursion suppression. Only its `active` state becomes thread-local. The tally lock covers the full `counts[key] += 1` operation while preserving the existing keys and reporting format.

## Checklist

- [x] For new contributors: Did you add yourself to the `AUTHORS.rst` file? (The entry is present on `main` through merged PR #952.)
- [ ] For documentation changes: Does your commit message include a `[skip ci]`? (Not a documentation-only change.)
- [x] For bugfixes: Did you add an entry to the `CHANGES.rst` file?
- [x] For bugfixes: Did you add a regression test?
- [x] For bugfixes: Does the commit message include `Fixes #944`?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

## AI assistance disclosure

OpenAI Codex was used for source inspection, test design, implementation, and automated review. The contributor has completed the final review and takes responsibility for the contribution's correctness and maintenance.

