### PR TITLE
Fix fallback percentile calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Bug Fixes
   average combinations. [#952]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
+- Fix the fallback percentile calculation for array namespaces that do not
+  provide ``percentile``. [#957]
 - Fix dtype conversion in ``Combiner._weighted_sum`` to use the array-API
   namespace form ``xp.astype(weights, xp.float64)`` instead of the deprecated
   string-based ``.astype("float64")``. This resolves the ``DeprecationWarning``

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -125,14 +125,17 @@ def _percentile_fallback(array, percentiles, xp=None):
     except AttributeError:
         pass
 
-    # Fall back to using sort
-    sorted_array = xp.sort(array)
-
     percentile_array = xp.asarray(
         percentiles,
         dtype=xp.float64,
-        device=array_api_compat.device(sorted_array),
+        device=array_api_compat.device(array),
     )
+    if bool(xp.any((percentile_array < 0) | (percentile_array > 100))):
+        raise ValueError("Percentiles must be in the range [0, 100]")
+
+    # Fall back to using sort
+    sorted_array = xp.sort(array)
+
     indexes = xp.astype(
         sorted_array.shape[0] * percentile_array / 100,
         xp.int64,

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -96,9 +96,7 @@ def _is_array(arr):
     return True
 
 
-# Ideally this would eventually be covered by tests. Looks like Sparse
-# could be used to test this, since it has no percentile...
-def _percentile_fallback(array, percentiles, xp=None):  # pragma: no cover
+def _percentile_fallback(array, percentiles, xp=None):
     """
     Try calculating percentile using namespace, otherwise fall back to
     an implmentation that uses sort. As of the 2023 version of the array API
@@ -130,7 +128,23 @@ def _percentile_fallback(array, percentiles, xp=None):  # pragma: no cover
     # Fall back to using sort
     sorted_array = xp.sort(array)
 
-    indexes = xp.astype(len(sorted_array) * xp.asarray(percentiles), int)
+    percentile_array = xp.asarray(
+        percentiles,
+        dtype=xp.float64,
+        device=array_api_compat.device(sorted_array),
+    )
+    indexes = xp.astype(
+        sorted_array.shape[0] * percentile_array / 100,
+        xp.int64,
+    )
+    indexes = xp.minimum(
+        indexes,
+        xp.asarray(
+            sorted_array.shape[0] - 1,
+            dtype=xp.int64,
+            device=array_api_compat.device(sorted_array),
+        ),
+    )
     return sorted_array[indexes]
 
 

--- a/ccdproc/tests/test_ccdmask.py
+++ b/ccdproc/tests/test_ccdmask.py
@@ -7,7 +7,55 @@ from numpy.testing import assert_array_equal
 
 from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
-from ccdproc.core import ccdmask
+from ccdproc.core import _percentile_fallback, ccdmask
+
+
+class _PercentileFallbackNamespace:
+    """NumPy proxy without ``percentile``, used to exercise the fallback."""
+
+    float64 = np.float64
+    int64 = np.int64
+    minimum = staticmethod(np.minimum)
+    sort = staticmethod(np.sort)
+
+    @staticmethod
+    def asarray(value, *, dtype=None, device=None):
+        del device
+        return np.asarray(value, dtype=dtype)
+
+    @staticmethod
+    def astype(array, dtype):
+        return array.astype(dtype)
+
+
+@pytest.mark.parametrize(
+    ("percentile", "expected"),
+    [
+        (30.9, 1.0),
+        (69.1, 9.0),
+        ([0, 50, 100], [1.0, 5.0, 9.0]),
+    ],
+)
+def test_percentile_fallback(percentile, expected):
+    if xp.__name__ == "array_api_strict":
+        fallback_xp = xp
+    elif xp.__name__ == "array_api_compat.numpy":
+        fallback_xp = _PercentileFallbackNamespace
+    else:
+        pytest.skip("the fallback regression runs with NumPy and array-api-strict")
+
+    values_list = [1.0] * 40 + [9.0] * 40 + [5.0] * 20
+    values = fallback_xp.asarray(values_list, device=xp_device)
+    original = fallback_xp.asarray(values_list, device=xp_device)
+
+    result = _percentile_fallback(values, percentile, xp=fallback_xp)
+
+    expected = fallback_xp.asarray(expected, dtype=values.dtype, device=xp_device)
+    assert result.shape == expected.shape
+    if xp.__name__ == "array_api_strict":
+        assert result.device == values.device
+    assert xp.all(result == expected)
+    assert xp.all(values == original)
 
 
 # Construct the CCD in the selected test namespace so every backend exercises

--- a/ccdproc/tests/test_ccdmask.py
+++ b/ccdproc/tests/test_ccdmask.py
@@ -15,6 +15,7 @@ class _PercentileFallbackNamespace:
 
     float64 = np.float64
     int64 = np.int64
+    any = staticmethod(np.any)
     minimum = staticmethod(np.minimum)
     sort = staticmethod(np.sort)
 
@@ -56,6 +57,21 @@ def test_percentile_fallback(percentile, expected):
         assert result.device == values.device
     assert xp.all(result == expected)
     assert xp.all(values == original)
+
+
+@pytest.mark.parametrize("percentile", [-5, 105])
+def test_percentile_fallback_rejects_out_of_range(percentile):
+    if xp.__name__ == "array_api_strict":
+        fallback_xp = xp
+    elif xp.__name__ == "array_api_compat.numpy":
+        fallback_xp = _PercentileFallbackNamespace
+    else:
+        pytest.skip("the fallback regression runs with NumPy and array-api-strict")
+
+    values = fallback_xp.asarray([0.0, 1.0, 2.0], device=xp_device)
+
+    with pytest.raises(ValueError, match=r"range \[0, 100\]"):
+        _percentile_fallback(values, percentile, xp=fallback_xp)
 
 
 # Construct the CCD in the selected test namespace so every backend exercises


### PR DESCRIPTION
## Summary

- exercise `_percentile_fallback` with both the ordinary NumPy coverage lane and the existing `array-api-strict` backend on a non-default device
- calculate fallback indexes with Array API shape, dtype, percent-scale, and device-aware operations
- support integer and list-like percentiles and keep the 100th percentile inside the valid index range
- keep the existing sort-and-order-statistic behavior without selecting a new percentile interpolation convention

Fixes #888

## Validation

- failing-first strict regression: 2 failures at `len(Array)` before the original fix
- refreshed NumPy regression: 6 passed, with a test-only namespace proxy that omits `percentile` so the production fallback executes in the coverage job
- refreshed strict regression: 6 passed on the non-default device, including scalar floats and integer `[0, 50, 100]` endpoints
- refreshed full NumPy suite: 349 passed, 29 skipped
- the earlier full JAX suite passed with 324 passed, 31 skipped, and 7 existing xfailed
- the earlier full Dask suite passed with 326 passed and 36 skipped
- Ruff, Black, and `git diff --check`

## Checklist

- [ ] For new contributors: Did you add yourself to the "Authors.rst" file?

For documentation changes:

- [ ] For documentation changes: Does your commit message include a "[skip ci]"?

For bugfixes:

- [x] Did you add an entry to the "Changes.rst" file?
- [x] Did you add a regression test?
- [x] Does the commit message include a "Fixes #issue_number"?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

For new functionality:

- [ ] Did you add an entry to the "Changes.rst" file?
- [ ] Did you include a meaningful docstring with Parameters, Returns and Examples?
- [ ] Does the commit message include a "Fixes #issue_number"?
- [ ] Did you include tests for the new functionality?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters?

## AI assistance

OpenAI Codex was used for source inspection, test design, implementation, and automated review. The contributor has completed the final review and takes responsibility for the contribution's correctness and maintenance.

