### PR TITLE
Respect array namespaces when Bottleneck is installed

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -51,12 +51,17 @@ jobs:
           - name: 'ubuntu-py312-bottleneck'
             os: ubuntu-latest
             python: '3.12'
-            tox_env: 'py312-test-alldeps-numpy126'
+            tox_env: 'py312-test-alldeps-numpy126-bottleneck'
 
           - name: 'macos-py312-dask'
             os: macos-latest
             python: '3.12'
             tox_env: 'py312-alldeps-dask'
+
+          - name: 'ubuntu-py312-dask-bottleneck'
+            os: ubuntu-latest
+            python: '3.12'
+            tox_env: 'py312-alldeps-dask-bottleneck'
 
           # Regression gate: fail if a new array-API "escape" (a silent numpy
           # coercion of a dask array in library code) appears that is not in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug Fixes
 - Return plain ``CCDData`` objects from array-API wrapper-copy paths, and
   public uncertainty types from arithmetic paths. [#953]
 
+- Use Bottleneck combination functions only with NumPy arrays, preserving the
+  selected Array API namespace for other backends. [#904]
+
 2.5.1 (2025-07-05)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Bug Fixes
   public uncertainty types from arithmetic paths. [#953]
 
 - Use Bottleneck combination functions only with NumPy arrays, preserving the
-  selected Array API namespace for other backends. [#904]
+  selected Array API namespace for other backends. [#904, #959]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -26,11 +26,10 @@ __all__ = ["Combiner", "combine"]
 
 
 def _default_median(xp=None):  # pragma: no cover
-    if HAS_BOTTLENECK:
+    if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanmedian
-    else:
-        if xp is None:
-            return None
+    if xp is None:
+        return None
 
     # No bottleneck, but we have a namespace.
     try:
@@ -42,11 +41,10 @@ def _default_median(xp=None):  # pragma: no cover
 
 
 def _default_average(xp=None):  # pragma: no cover
-    if HAS_BOTTLENECK:
+    if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanmean
-    else:
-        if xp is None:
-            return None
+    if xp is None:
+        return None
 
     # No bottleneck, but we have a namespace.
     try:
@@ -58,11 +56,10 @@ def _default_average(xp=None):  # pragma: no cover
 
 
 def _default_sum(xp=None):  # pragma: no cover
-    if HAS_BOTTLENECK:
+    if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nansum
-    else:
-        if xp is None:
-            return None
+    if xp is None:
+        return None
 
     # No bottleneck, but we have a namespace.
     try:
@@ -74,11 +71,10 @@ def _default_sum(xp=None):  # pragma: no cover
 
 
 def _default_std(xp=None):  # pragma: no cover
-    if HAS_BOTTLENECK:
+    if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanstd
-    else:
-        if xp is None:
-            return None
+    if xp is None:
+        return None
 
     # No bottleneck, but we have a namespace.
     try:
@@ -87,10 +83,6 @@ def _default_std(xp=None):  # pragma: no cover
         raise RuntimeError(
             "No NaN-aware std function available. Please install bottleneck."
         ) from e
-
-
-_default_sum_func = _default_sum()
-_default_std_dev_func = _default_std()
 
 
 class Combiner:
@@ -608,8 +600,8 @@ class Combiner:
         self,
         scale_func=None,
         scale_to=None,
-        uncertainty_func=_default_std_dev_func,
-        sum_func=_default_sum_func,
+        uncertainty_func=None,
+        sum_func=None,
     ):
         """
         Average combine together a set of arrays.
@@ -693,9 +685,7 @@ class Combiner:
         # return the combined image
         return combined_image
 
-    def sum_combine(
-        self, sum_func=None, scale_to=None, uncertainty_func=_default_std_dev_func
-    ):
+    def sum_combine(self, sum_func=None, scale_to=None, uncertainty_func=None):
         """
         Sum combine together a set of arrays.
 

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -40,7 +40,7 @@ def _default_median(xp=None):
         ) from e
 
 
-def _default_average(xp=None): 
+def _default_average(xp=None):
     if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanmean
     if xp is None:

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -25,7 +25,7 @@ from .core import sigma_func
 __all__ = ["Combiner", "combine"]
 
 
-def _default_median(xp=None):  # pragma: no cover
+def _default_median(xp=None):
     if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanmedian
     if xp is None:
@@ -40,7 +40,7 @@ def _default_median(xp=None):  # pragma: no cover
         ) from e
 
 
-def _default_average(xp=None):  # pragma: no cover
+def _default_average(xp=None): 
     if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanmean
     if xp is None:
@@ -55,7 +55,7 @@ def _default_average(xp=None):  # pragma: no cover
         ) from e
 
 
-def _default_sum(xp=None):  # pragma: no cover
+def _default_sum(xp=None):
     if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nansum
     if xp is None:
@@ -70,7 +70,7 @@ def _default_sum(xp=None):  # pragma: no cover
         ) from e
 
 
-def _default_std(xp=None):  # pragma: no cover
+def _default_std(xp=None):
     if HAS_BOTTLENECK and (xp is None or array_api_compat.is_numpy_namespace(xp)):
         return bn.nanstd
     if xp is None:

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -13,7 +13,10 @@ from ccdproc import create_deviation
 from ccdproc.combiner import (
     Combiner,
     _calculate_step_sizes,
+    _default_average,
+    _default_median,
     _default_std,
+    _default_sum,
     combine,
     sigma_func,
 )
@@ -90,6 +93,45 @@ def test_combiner_create():
     # Also test the public properties
     assert c.data.shape == c._data_arr.shape
     assert c.mask.shape == c._data_arr_mask.shape
+
+
+@pytest.mark.parametrize(
+    ("default_func", "function_name"),
+    [
+        (_default_median, "nanmedian"),
+        (_default_average, "nanmean"),
+        (_default_sum, "nansum"),
+        (_default_std, "nanstd"),
+    ],
+)
+def test_bottleneck_defaults_respect_array_namespace(default_func, function_name):
+    bottleneck = pytest.importorskip("bottleneck")
+
+    default = default_func(xp=xp)
+
+    if array_api_compat.is_numpy_namespace(xp):
+        expected = getattr(bottleneck, function_name)
+    else:
+        expected = getattr(xp, function_name)
+    assert default is expected
+
+
+@pytest.mark.parametrize(
+    ("combine_method", "expected"),
+    [("average_combine", 2.0), ("sum_combine", 6.0)],
+)
+def test_bottleneck_combination_defaults_respect_array_namespace(
+    combine_method, expected
+):
+    pytest.importorskip("bottleneck")
+    ccd_list = [
+        CCDData(xp.full((2, 2), value), unit=u.adu) for value in (1.0, 2.0, 3.0)
+    ]
+
+    result = getattr(Combiner(ccd_list), combine_method)()
+
+    assert array_api_compat.array_namespace(result.data) is xp
+    assert xp.all(xpx.isclose(result.data, expected))
 
 
 # test if dtype matches the value that is passed


### PR DESCRIPTION
## Summary

- use Bottleneck's NaN-aware reductions only for NumPy or an unspecified array namespace
- use the selected backend's native reductions for non-NumPy arrays
- resolve average and sum uncertainty/reduction defaults at call time, after the data namespace is known
- exercise both NumPy+Bottleneck and Dask+Bottleneck in CI

Fixes #904

## Validation

- failing-first on untouched `main`, Dask+Bottleneck `test_combiner.py`: 35 failed, 39 passed
- focused namespace regressions: 6 passed with Dask+Bottleneck and 6 passed with NumPy+Bottleneck
- full Combiner module: 80 passed with Dask+Bottleneck and 80 passed with NumPy+Bottleneck
- full NumPy suite: 342 passed, 29 skipped
- full Dask suite: 337 passed, 34 skipped
- full JAX x64 suite: 335 passed, 29 skipped, 7 established xfails
- `black --check ccdproc/combiner.py ccdproc/tests/test_combiner.py`
- `ruff check ccdproc/combiner.py ccdproc/tests/test_combiner.py`
- workflow YAML parse and `git diff --check`

## AI assistance disclosure

I used OpenAI Codex to assist with repository inspection, test design, implementation, and review. I reviewed the resulting changes and take responsibility for their correctness and maintenance.

## Checklist

- [ ] For new contributors: Did you add yourself to the `AUTHORS.rst` file? (The entry is already in draft PR #952 and is not duplicated here.)
- [ ] For documentation changes: Does your commit message include a `[skip ci]`? (Not applicable.)
- [x] Did you add an entry to the `CHANGES.rst` file?
- [x] Did you add a regression test?
- [x] Does the commit message include a `Fixes #issue_number`?
- [ ] Does this PR add, rename, move or remove any existing functions or parameters? (No; existing defaults are resolved at call time.)
