### PR TITLE
Allow per-call CCD extension overrides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ New Features
   ``backend_skip`` markers, an escape-site report
   (``CCDPROC_TRIAGE_ESCAPES=1``), and an escape logger
   (``CCDPROC_LOG_ARRAY_ESCAPES=1``). [#942]
-- Allow ``ImageFileCollection.ccds`` to read a per-call FITS extension while
-  retaining the collection extension for summaries and filtering. [#960]
+- Allow ``ImageFileCollection.ccds`` to override the collection's FITS
+  extension per call with ``ccd_kwargs["hdu"]`` while preserving ``ext=`` as
+  a header filter. [#960]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ New Features
   (``CCDPROC_TRIAGE_ESCAPES=1``), and an escape logger
   (``CCDPROC_LOG_ARRAY_ESCAPES=1``). [#942]
 - Allow ``ImageFileCollection.ccds`` to read a per-call FITS extension while
-  retaining the collection extension for summaries and filtering. [#817]
+  retaining the collection extension for summaries and filtering. [#960]
 
 Bug Fixes
 ^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
   ``backend_skip`` markers, an escape-site report
   (``CCDPROC_TRIAGE_ESCAPES=1``), and an escape logger
   (``CCDPROC_LOG_ARRAY_ESCAPES=1``). [#942]
+- Allow ``ImageFileCollection.ccds`` to read a per-call FITS extension while
+  retaining the collection extension for summaries and filtering. [#817]
 
 Bug Fixes
 ^^^^^^^^^

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -897,6 +897,7 @@ class ImageFileCollection:
             See `~astropy.nddata.fits_ccddata_reader` for a complete list of
             parameters that can be passed through ``ccd_kwargs``.
 
+        {ccd_extension}
 
         regex_match : bool, keyword-only
             If ``True``, then string values in the ``**kwd`` dictionary are
@@ -933,7 +934,8 @@ class ImageFileCollection:
         if kwd:
             self._find_keywords_by_values(**kwd)
 
-        ccd_kwargs = ccd_kwargs or {}
+        ccd_kwargs = dict(ccd_kwargs or {})
+        ccd_hdu = ccd_kwargs.pop("hdu", self.ext)
 
         for full_path in self._paths():
             add_kwargs = {"do_not_scale_image_data": do_not_scale_image_data}
@@ -957,9 +959,7 @@ class ImageFileCollection:
                         dtype=return_thing.dtype.type,
                     )
             elif return_type == "ccd":
-                return_thing = fits_ccddata_reader(
-                    full_path, hdu=self.ext, **ccd_kwargs
-                )
+                return_thing = fits_ccddata_reader(full_path, hdu=ccd_hdu, **ccd_kwargs)
                 if xp is not None:
                     return_thing.data = xp.asarray(
                         return_thing.data, dtype=return_thing.data.dtype.type
@@ -1039,7 +1039,10 @@ class ImageFileCollection:
         )
 
     headers.__doc__ = _generator.__doc__.format(
-        name="header", default_scaling="True", return_type="astropy.io.fits.Header"
+        name="header",
+        default_scaling="True",
+        return_type="astropy.io.fits.Header",
+        ccd_extension="",
     )
 
     def hdus(self, do_not_scale_image_data=False, **kwd):
@@ -1053,6 +1056,7 @@ class ImageFileCollection:
         return_type="`, ` ".join(
             ("astropy.io.fits.PrimaryHDU", "astropy.io.fits.ImageHDU")
         ),
+        ccd_extension="",
     )
 
     def data(self, do_not_scale_image_data=False, **kwd):
@@ -1061,10 +1065,18 @@ class ImageFileCollection:
         )
 
     data.__doc__ = _generator.__doc__.format(
-        name="image", default_scaling="False", return_type="numpy.ndarray"
+        name="image",
+        default_scaling="False",
+        return_type="numpy.ndarray",
+        ccd_extension="",
     )
 
-    def ccds(self, ccd_kwargs=None, **kwd):
+    def ccds(self, ccd_kwargs=None, ext=None, **kwd):
+        if ext is not None:
+            if ccd_kwargs is not None and "hdu" in ccd_kwargs:
+                raise ValueError("ext and ccd_kwargs['hdu'] cannot both be specified.")
+            ccd_kwargs = dict(ccd_kwargs or {})
+            ccd_kwargs["hdu"] = ext
         if (clobber := kwd.get("clobber")) is not None:
             warnings.warn(
                 "The 'clobber' keyword argument is a deprecated alias for 'overwrite'",
@@ -1077,5 +1089,15 @@ class ImageFileCollection:
         return self._generator("ccd", ccd_kwargs=ccd_kwargs, **kwd)
 
     ccds.__doc__ = _generator.__doc__.format(
-        name="CCDData", default_scaling="True", return_type="astropy.nddata.CCDData"
+        name="CCDData",
+        default_scaling="True",
+        return_type="astropy.nddata.CCDData",
+        ccd_extension=(
+            "ext : int, str, or tuple, optional\n"
+            "    FITS extension from which to read the CCDData. This overrides the\n"
+            "    collection's extension for this generator only. If omitted,\n"
+            "    ``ccd_kwargs['hdu']`` is used when present, otherwise the\n"
+            "    collection's extension is used. ``ext`` and\n"
+            "    ``ccd_kwargs['hdu']`` cannot both be specified."
+        ),
     )

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -1094,10 +1094,11 @@ class ImageFileCollection:
         return_type="astropy.nddata.CCDData",
         ccd_extension=(
             "ext : int, str, or tuple, optional\n"
-            "    FITS extension from which to read the CCDData. This overrides the\n"
-            "    collection's extension for this generator only. If omitted,\n"
-            "    ``ccd_kwargs['hdu']`` is used when present, otherwise the\n"
-            "    collection's extension is used. ``ext`` and\n"
-            "    ``ccd_kwargs['hdu']`` cannot both be specified."
+            "            FITS extension from which to read the CCDData.\n"
+            "            This overrides the collection's extension for this\n"
+            "            generator only. If omitted, ``ccd_kwargs['hdu']`` is\n"
+            "            used when present; otherwise the collection's extension\n"
+            "            is used. ``ext`` and ``ccd_kwargs['hdu']`` cannot both\n"
+            "            be specified."
         ),
     )

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -894,10 +894,12 @@ class ImageFileCollection:
             For instance, the key ``'unit'`` can be used to specify the unit
             of the data. If ``'unit'`` is not given then ``'adu'`` is used as
             the default unit.
+            For CCDData generators, ``'hdu'`` may be an integer, an extension
+            name, or a ``(name, version)`` tuple. It overrides the collection's
+            extension for that generator call.
             See `~astropy.nddata.fits_ccddata_reader` for a complete list of
             parameters that can be passed through ``ccd_kwargs``.
 
-        {ccd_extension}
 
         regex_match : bool, keyword-only
             If ``True``, then string values in the ``**kwd`` dictionary are
@@ -1039,10 +1041,7 @@ class ImageFileCollection:
         )
 
     headers.__doc__ = _generator.__doc__.format(
-        name="header",
-        default_scaling="True",
-        return_type="astropy.io.fits.Header",
-        ccd_extension="",
+        name="header", default_scaling="True", return_type="astropy.io.fits.Header"
     )
 
     def hdus(self, do_not_scale_image_data=False, **kwd):
@@ -1056,7 +1055,6 @@ class ImageFileCollection:
         return_type="`, ` ".join(
             ("astropy.io.fits.PrimaryHDU", "astropy.io.fits.ImageHDU")
         ),
-        ccd_extension="",
     )
 
     def data(self, do_not_scale_image_data=False, **kwd):
@@ -1065,18 +1063,10 @@ class ImageFileCollection:
         )
 
     data.__doc__ = _generator.__doc__.format(
-        name="image",
-        default_scaling="False",
-        return_type="numpy.ndarray",
-        ccd_extension="",
+        name="image", default_scaling="False", return_type="numpy.ndarray"
     )
 
-    def ccds(self, ccd_kwargs=None, ext=None, **kwd):
-        if ext is not None:
-            if ccd_kwargs is not None and "hdu" in ccd_kwargs:
-                raise ValueError("ext and ccd_kwargs['hdu'] cannot both be specified.")
-            ccd_kwargs = dict(ccd_kwargs or {})
-            ccd_kwargs["hdu"] = ext
+    def ccds(self, ccd_kwargs=None, **kwd):
         if (clobber := kwd.get("clobber")) is not None:
             warnings.warn(
                 "The 'clobber' keyword argument is a deprecated alias for 'overwrite'",
@@ -1089,16 +1079,5 @@ class ImageFileCollection:
         return self._generator("ccd", ccd_kwargs=ccd_kwargs, **kwd)
 
     ccds.__doc__ = _generator.__doc__.format(
-        name="CCDData",
-        default_scaling="True",
-        return_type="astropy.nddata.CCDData",
-        ccd_extension=(
-            "ext : int, str, or tuple, optional\n"
-            "            FITS extension from which to read the CCDData.\n"
-            "            This overrides the collection's extension for this\n"
-            "            generator only. If omitted, ``ccd_kwargs['hdu']`` is\n"
-            "            used when present; otherwise the collection's extension\n"
-            "            is used. ``ext`` and ``ccd_kwargs['hdu']`` cannot both\n"
-            "            be specified."
-        ),
+        name="CCDData", default_scaling="True", return_type="astropy.nddata.CCDData"
     )

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -289,6 +289,93 @@ class TestImageFileCollection:
             assert hdr == hdu.header
             assert hdr == ccd.meta
 
+    @pytest.mark.parametrize("extension", [1, "BLUE", ("BLUE", 1)])
+    @pytest.mark.parametrize("override", ["ext", "hdu"])
+    def test_ccds_extension_override(self, tmp_path, extension, override):
+        blue_data = np.arange(6).reshape(2, 3)
+        red_data = blue_data + 100
+        hdulist = fits.HDUList(
+            [
+                fits.PrimaryHDU(header=fits.Header({"IMAGETYP": "BIAS"})),
+                fits.ImageHDU(blue_data, name="BLUE"),
+                fits.ImageHDU(red_data, name="RED"),
+            ]
+        )
+        hdulist.writeto(tmp_path / "multi-extension.fits")
+        fits.HDUList(
+            [
+                fits.PrimaryHDU(header=fits.Header({"IMAGETYP": "FLAT"})),
+                fits.ImageHDU(blue_data + 1000, name="BLUE"),
+                fits.ImageHDU(red_data + 1000, name="RED"),
+            ]
+        ).writeto(tmp_path / "nonmatching.fits")
+
+        collection = ImageFileCollection(
+            tmp_path,
+            keywords=["IMAGETYP"],
+            ext=0,
+        )
+        filtered_collection = collection.filter(imagetyp="bias")
+        summary_before = filtered_collection.summary.copy()
+        ccd_kwargs = {"unit": "adu"}
+        override_kwargs = {}
+        if override == "ext":
+            override_kwargs["ext"] = extension
+        else:
+            ccd_kwargs["hdu"] = extension
+        original_ccd_kwargs = ccd_kwargs.copy()
+
+        ccds = list(
+            filtered_collection.ccds(
+                ccd_kwargs=ccd_kwargs,
+                **override_kwargs,
+            )
+        )
+
+        assert len(collection.summary) == 2
+        assert [Path(file).name for file in filtered_collection.files] == [
+            "multi-extension.fits"
+        ]
+        assert len(ccds) == 1
+        np.testing.assert_array_equal(ccds[0].data, blue_data)
+        assert collection.ext == 0
+        assert filtered_collection.ext == 0
+        assert ccd_kwargs == original_ccd_kwargs
+        assert filtered_collection.summary.colnames == summary_before.colnames
+        for column in summary_before.colnames:
+            np.testing.assert_array_equal(
+                filtered_collection.summary[column].data,
+                summary_before[column].data,
+            )
+            np.testing.assert_array_equal(
+                filtered_collection.summary[column].mask,
+                summary_before[column].mask,
+            )
+
+    def test_ccds_extension_zero_override(self, tmp_path):
+        primary_data = np.arange(6).reshape(2, 3)
+        fits.HDUList(
+            [
+                fits.PrimaryHDU(primary_data),
+                fits.ImageHDU(primary_data + 100, name="BLUE"),
+            ]
+        ).writeto(tmp_path / "multi-extension.fits")
+        collection = ImageFileCollection(tmp_path, ext=1)
+
+        ccd = next(collection.ccds(ccd_kwargs={"unit": "adu"}, ext=0))
+
+        np.testing.assert_array_equal(ccd.data, primary_data)
+        assert collection.ext == 1
+
+    def test_ccds_extension_override_conflicts_with_hdu(self, triage_setup):
+        collection = ImageFileCollection(triage_setup.test_dir)
+        ccd_kwargs = {"unit": "adu", "hdu": 1}
+
+        with pytest.raises(ValueError, match=r"ext.*ccd_kwargs\['hdu'\]"):
+            collection.ccds(ccd_kwargs=ccd_kwargs, ext=1)
+
+        assert ccd_kwargs == {"unit": "adu", "hdu": 1}
+
     def test_headers(self, triage_setup):
         collection = ImageFileCollection(
             location=triage_setup.test_dir, keywords=["imagetyp"]

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -290,13 +290,12 @@ class TestImageFileCollection:
             assert hdr == ccd.meta
 
     @pytest.mark.parametrize("extension", [1, "BLUE", ("BLUE", 1)])
-    @pytest.mark.parametrize("override", ["ext", "hdu"])
-    def test_ccds_extension_override(self, tmp_path, extension, override):
+    def test_ccds_hdu_override_preserves_ext_filter(self, tmp_path, extension):
         blue_data = np.arange(6).reshape(2, 3)
         red_data = blue_data + 100
         hdulist = fits.HDUList(
             [
-                fits.PrimaryHDU(header=fits.Header({"IMAGETYP": "BIAS"})),
+                fits.PrimaryHDU(header=fits.Header({"EXT": 7})),
                 fits.ImageHDU(blue_data, name="BLUE"),
                 fits.ImageHDU(red_data, name="RED"),
             ]
@@ -304,7 +303,7 @@ class TestImageFileCollection:
         hdulist.writeto(tmp_path / "multi-extension.fits")
         fits.HDUList(
             [
-                fits.PrimaryHDU(header=fits.Header({"IMAGETYP": "FLAT"})),
+                fits.PrimaryHDU(header=fits.Header({"EXT": 8})),
                 fits.ImageHDU(blue_data + 1000, name="BLUE"),
                 fits.ImageHDU(red_data + 1000, name="RED"),
             ]
@@ -312,45 +311,19 @@ class TestImageFileCollection:
 
         collection = ImageFileCollection(
             tmp_path,
-            keywords=["IMAGETYP"],
+            keywords=["EXT"],
             ext=0,
         )
-        filtered_collection = collection.filter(imagetyp="bias")
-        summary_before = filtered_collection.summary.copy()
-        ccd_kwargs = {"unit": "adu"}
-        override_kwargs = {}
-        if override == "ext":
-            override_kwargs["ext"] = extension
-        else:
-            ccd_kwargs["hdu"] = extension
+        ccd_kwargs = {"unit": "adu", "hdu": extension}
         original_ccd_kwargs = ccd_kwargs.copy()
 
-        ccds = list(
-            filtered_collection.ccds(
-                ccd_kwargs=ccd_kwargs,
-                **override_kwargs,
-            )
-        )
+        ccds = list(collection.ccds(ccd_kwargs=ccd_kwargs, ext=7))
 
         assert len(collection.summary) == 2
-        assert [Path(file).name for file in filtered_collection.files] == [
-            "multi-extension.fits"
-        ]
         assert len(ccds) == 1
         np.testing.assert_array_equal(ccds[0].data, blue_data)
         assert collection.ext == 0
-        assert filtered_collection.ext == 0
         assert ccd_kwargs == original_ccd_kwargs
-        assert filtered_collection.summary.colnames == summary_before.colnames
-        for column in summary_before.colnames:
-            np.testing.assert_array_equal(
-                filtered_collection.summary[column].data,
-                summary_before[column].data,
-            )
-            np.testing.assert_array_equal(
-                filtered_collection.summary[column].mask,
-                summary_before[column].mask,
-            )
 
     def test_ccds_extension_zero_override(self, tmp_path):
         primary_data = np.arange(6).reshape(2, 3)
@@ -362,19 +335,10 @@ class TestImageFileCollection:
         ).writeto(tmp_path / "multi-extension.fits")
         collection = ImageFileCollection(tmp_path, ext=1)
 
-        ccd = next(collection.ccds(ccd_kwargs={"unit": "adu"}, ext=0))
+        ccd = next(collection.ccds(ccd_kwargs={"unit": "adu", "hdu": 0}))
 
         np.testing.assert_array_equal(ccd.data, primary_data)
         assert collection.ext == 1
-
-    def test_ccds_extension_override_conflicts_with_hdu(self, triage_setup):
-        collection = ImageFileCollection(triage_setup.test_dir)
-        ccd_kwargs = {"unit": "adu", "hdu": 1}
-
-        with pytest.raises(ValueError, match=r"ext.*ccd_kwargs\['hdu'\]"):
-            collection.ccds(ccd_kwargs=ccd_kwargs, ext=1)
-
-        assert ccd_kwargs == {"unit": "adu", "hdu": 1}
 
     def test_headers(self, triage_setup):
         collection = ImageFileCollection(


### PR DESCRIPTION
## Summary

- add an optional `ext` argument to `ImageFileCollection.ccds()` for selecting a FITS data extension per call
- keep the collection's own extension unchanged for primary-header summaries and filtering
- continue supporting `ccd_kwargs["hdu"]`, avoid mutating caller dictionaries, and reject contradictory selectors explicitly
- cover integer, extension-name, `(name, version)`, and zero-valued selectors with offline multi-extension FITS regressions
- correct the generated NumPy-style parameter indentation so the `ccds()` docstring builds cleanly under Sphinx warnings-as-errors

Compatibility boundary: `ext` is now reserved as the per-call selector; code that needs to filter an `EXT` header keyword should filter the collection before calling `ccds()`.

Fixes #817

## Validation

- initial override/conflict regression on untouched `main`: 7 failed
- `python -m pytest ccdproc/tests/test_image_collection.py -q` — 85 passed
- full NumPy suite — 354 passed, 29 skipped
- full Dask suite — 349 passed, 34 skipped
- full JAX x64 suite — 347 passed, 29 skipped, 7 established xfails
- inspected the final cleaned docstring: `ext` is a parameter and every description line is indented beneath it
- Black, Ruff, `git diff --check`, and `git show --check`

## AI assistance disclosure

OpenAI Codex was used for repository inspection, test design, implementation, CI diagnosis, and automated review. The contributor has completed the final review and takes responsibility for the contribution's correctness and maintenance.

## Checklist

- [x] For new contributors: Did you add yourself to the `AUTHORS.rst` file? (Present on current main through merged #952.)
- [ ] For documentation changes: Does the commit message include a `[skip ci]`? (Not a documentation-only change.)

For new functionality:

- [x] Did you add an entry to `CHANGES.rst`?
- [x] Did you include a meaningful docstring with Parameters?
- [x] Does the commit message include `Fixes #817`?
- [x] Did you include tests for the new functionality?
- [x] Does this PR add, rename, move, or remove an existing function or parameter? (It adds the optional `ext` parameter.)

