### PR TITLE
Restore ValueError expectation in test_generator_ccds_without_unit

### DIFF
--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -391,19 +391,12 @@ class TestImageFileCollection:
         "yet understood.",
     )
     def test_generator_ccds_without_unit(self, triage_setup):
-        from ccdproc.conftest import testing_array_library
-
-        using_jax = testing_array_library.__name__ == "jax.numpy"
-
         collection = ImageFileCollection(
             location=triage_setup.test_dir, keywords=["imagetyp"]
         )
-        if using_jax:
-            ccd = next(collection.ccds())
-            assert isinstance(ccd, CCDData)
-        else:
-            with pytest.raises(ValueError):
-                _ = next(collection.ccds())
+
+        with pytest.raises(ValueError):
+            _ = next(collection.ccds())
 
     def test_generator_ccds(self, triage_setup):
         collection = ImageFileCollection(


### PR DESCRIPTION
Follow-up to a Copilot review comment on #925 (merged), which pointed out that `test_generator_ccds_without_unit` now carries both the `backend_xfail("jax")` marker (added in cf4f4b7) and an explicit jax branch asserting that `ccds()` returns a `CCDData` for unit-less files.

Those two contradict each other. The marker's reason documents that the jax behavior is platform-dependent: on Linux CI `ccds()` fails to raise `ValueError`, while on macOS with identical astropy/jax versions it does raise. The jax branch added in #925 asserts the Linux behavior unconditionally, so on macOS it fails and is silently absorbed by the marker as an xfail; on Linux it passes and is reported as a (non-strict) xpass. Net effect: the test can never fail on jax on any platform, and on macOS it asserts the wrong thing.

This PR reverts the test body to expect `ValueError` on all backends and keeps the `backend_xfail` marker. Raising for unit-less files is the intended behavior; the unexplained Linux-only jax deviation stays visible as an xfail rather than being encoded as correct. (Copilot suggested removing the marker instead, but that would break macOS jax runs given the platform dependence.)

Verified locally: `test_image_collection.py` passes under numpy and dask; under jax on macOS the reverted test xpasses (non-strict), and on Linux CI it should xfail as it did before #925.

## Checklist

- [x] Did you add an entry to the `CHANGES.rst` file? (Not needed — test-only change with no user-facing behavior.)
- [x] Did you add a regression test? (Test-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01463EbSeiTmBJevbvpMNRm8
