### PR TITLE
Cast mask to data dtype in create_deviation for strict array API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bug Fixes
   support immutable array-API backends. [#956]
 - Fix the fallback percentile calculation for array namespaces that do not
   provide ``percentile``. [#957]
+- Cast the boolean mask to the data dtype in ``create_deviation`` so that
+  ``disregard_nan=True`` works with strict array-API backends. [#968]
 - Make array-API escape logging thread-safe so concurrent worker escapes are
   not missed. [#955]
 - Fix dtype conversion in ``Combiner._weighted_sum`` to use the array-API

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -473,7 +473,7 @@ def create_deviation(ccd_data, gain=None, readnoise=None, disregard_nan=False, x
     mask = data < 0
 
     if disregard_nan:
-        data = data * ~mask
+        data = data * xp.astype(~mask, data.dtype)
     else:
         # data[mask] = xp.nan
         logging.warning("Negative values in array will be replaced with nan")

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -121,8 +121,8 @@ def test_create_deviation_from_negative_2():
     # Set the variance to zero where the data is negative
     # In-place replacement of values does not work in some array
     # libraries.
-    ccd_data.data = ccd_data.data * ~mask
-    expected_var = xp.sqrt(ccd_data.data + readnoise.value**2)
+    ccd_data.data = ccd_data.data * xp.astype(~mask, ccd_data.data.dtype)
+    expected_var = xp.sqrt(ccd_data.data + float(readnoise.value) ** 2)
     assert xp.all(xpx.isclose(ccd_var.uncertainty.array, expected_var))
 
 


### PR DESCRIPTION
`create_deviation(..., disregard_nan=True)` multiplied a float array by a boolean mask (`data * ~mask`). The Array API standard only allows arithmetic between numeric dtypes, so array-api-strict raised `TypeError: Only numeric dtypes are allowed in __mul__`. This casts the inverted mask to the data dtype first; the double-sqrt NaN trick that follows is unchanged.

`test_create_deviation_from_negative_2` used the same idiom and also added a `numpy.float64` scalar to a strict array, so the test is adjusted the same way. No `backend_xfail` markers existed on the create_deviation tests, so none needed removing.

**Test matrix**

| backend | `pytest ccdproc` |
|---|---|
| numpy | 380 passed, 5 skipped |
| jax (`JAX_ENABLE_X64=True`) | 366 passed, 10 skipped, 2 xfailed, 7 xpassed (all pre-existing, in test_combiner / test_image_collection) |
| dask | 370 passed, 15 skipped |
| dask + `CCDPROC_LOG_ARRAY_ESCAPES=1 CCDPROC_ENFORCE_ESCAPE_BASELINE=1` | 370 passed, 15 skipped; "OK: no library escapes outside the baseline" |

`ccdproc/tests/test_ccdproc.py` under array-api-strict: 32 failed / 31 passed / 10 xfailed before, 31 failed / 32 passed / 10 xfailed after. All 11 `create_deviation` tests pass under strict.

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA