### PR TITLE
Fix device bug in subtract_dark(scale=True) misreported as unit mismatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug Fixes
   provide ``percentile``. [#957]
 - Make array-API escape logging thread-safe so concurrent worker escapes are
   not missed. [#955]
+- Create the dark scale factor in ``subtract_dark(scale=True)`` on the same
+  device as the master dark, and stop reporting non-unit errors from the
+  subtraction as unit mismatches. [#966]
 - Fix dtype conversion in ``Combiner._weighted_sum`` to use the array-API
   namespace form ``xp.astype(weights, xp.float64)`` instead of the deprecated
   string-based ``.astype("float64")``. This resolves the ``DeprecationWarning``

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -869,11 +869,15 @@ def subtract_dark(
             # The xp.asarray ensures that even the scale factor is an instance
             # of the array class. Using a plain float leads (because of a conversion
             # to numpy float) to numpy being used for the calculation.
-            _master_scaled = _master_scaled.multiply(xp.asarray(scale_factor))
+            _master_scaled = _master_scaled.multiply(
+                xp.asarray(
+                    scale_factor, device=array_api_compat.device(_master_scaled.data)
+                )
+            )
             _result = _ccd.subtract(_master_scaled, handle_mask=xp.logical_or)
         else:
             _result = _ccd.subtract(_master, handle_mask=xp.logical_or)
-    except (u.UnitsError, u.UnitConversionError, ValueError) as err:
+    except (u.UnitsError, u.UnitConversionError) as err:
         # Make the error message a little more explicit than what is returned
         # by default.
         raise u.UnitsError(


### PR DESCRIPTION
`subtract_dark(scale=True)` created the scale factor with a bare `xp.asarray(scale_factor)`, which on a device-aware backend (array-api-strict on a non-default device, CuPy) lands on the default device and cannot be multiplied with the master dark. The resulting backend error was caught by the `ValueError` clause of the surrounding `except` and re-raised as a spurious `UnitsError` about mismatched units.

This PR creates the scale factor on the master dark's device (same pattern as `gain_correct`) and drops `ValueError` from the caught exceptions; the real unit check raises `UnitsError` from the CCDData wrapper, and `test_subtract_dark_fails` only relies on `TypeError`/`UnitsError`.

Test matrix (full `pytest ccdproc`):

| backend | result |
|---|---|
| numpy | 380 passed, 5 skipped |
| jax | 366 passed, 10 skipped, 2 xfailed, 7 xpassed (pre-existing combiner/image_collection xpasses, unrelated) |
| dask | 370 passed, 15 skipped |
| dask + `CCDPROC_ENFORCE_ESCAPE_BASELINE=1` | 370 passed, 15 skipped |

`ccdproc/tests/test_ccdproc.py` under array-api-strict: before 32 failed / 31 passed / 10 xfailed; after 28 failed / 35 passed / 10 xfailed. The four `test_subtract_dark[...scale=True]` variants go from failing to passing; no `backend_xfail` marker was present on them.

Fixes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA
