### PR TITLE
Use array-API astype and device in rebin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Bug Fixes
 
 - Use Bottleneck combination functions only with NumPy arrays, preserving the
   selected Array API namespace for other backends. [#904, #959]
+- Make ``rebin`` build its index array with ``xp.astype`` on the input array's
+  device instead of the NumPy-only ``.astype`` method, so it works with
+  array-API backends such as ``array-api-strict``. [#967]
 - Keep ``Combiner.clip_extrema`` index arithmetic in the selected array
   namespace so GPU-backed arrays do not require an implicit conversion to
   NumPy. [#954]

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -1474,8 +1474,8 @@ def rebin(ccd, newshape):
         # Not every array package has mgrid, so we do the mgrid with
         # numpy and convert to the array package used by ccd.data.
 
-        coordinates = xp.asarray(np_mgrid[slices])
-        indices = coordinates.astype("i")
+        coordinates = xp.asarray(np_mgrid[slices], device=array_api_compat.device(ccd))
+        indices = xp.astype(coordinates, xp.int32)
 
         try:
             result = ccd[tuple(indices)]

--- a/ccdproc/tests/test_rebin.py
+++ b/ccdproc/tests/test_rebin.py
@@ -98,3 +98,27 @@ def test_rebin_does_not_change_input():
 
     np.testing.assert_allclose(original.data, ccd_data.data)
     assert original.unit == ccd_data.unit
+
+
+def test_rebin_keeps_array_namespace():
+    # Regression test for #967: rebin used the numpy-only ``.astype`` method
+    # on the index array, which fails for array-API backends that do not
+    # provide it (e.g. array-api-strict).
+    import array_api_compat
+
+    from ccdproc.conftest import testing_array_device as xp_device
+    from ccdproc.conftest import testing_array_library as xp
+
+    a = xp.asarray(np.arange(16.0).reshape(4, 4), device=xp_device)
+    with pytest.warns(AstropyDeprecationWarning):
+        try:
+            b = rebin(a, (8, 8))
+        except TypeError as e:
+            if "does not support this method of rebinning" in str(e):
+                pytest.skip("Rebinning not supported for this data type")
+
+    assert array_api_compat.array_namespace(b) is array_api_compat.array_namespace(a)
+    assert array_api_compat.device(b) == array_api_compat.device(a)
+    assert b.shape == (8, 8)
+    # Every input pixel is replicated into a 2x2 block of the output.
+    assert bool(xp.all(b[::2, ::2] == a))


### PR DESCRIPTION
`rebin` built its index array with the NumPy-only `.astype("i")` method and created the coordinate grid without a device, so it raised `AttributeError` for array-API backends such as array-api-strict. This switches to `xp.astype(coordinates, xp.int32)` and creates the grid with `device=array_api_compat.device(ccd)`.

A backend-generic regression test (`test_rebin_keeps_array_namespace`) checks that the result stays in the input's namespace and on its device. Under backends that don't support integer-array indexing (dask, array-api-strict) it takes the file's existing "not supported" skip path.

### Test matrix (full `pytest ccdproc`)

| backend | result |
|---|---|
| numpy | 381 passed, 5 skipped |
| jax | 367 passed, 10 skipped, 2 xfailed, 7 xpassed (pre-existing xpasses) |
| dask | 370 passed, 16 skipped |
| dask + `CCDPROC_LOG_ARRAY_ESCAPES=1 CCDPROC_ENFORCE_ESCAPE_BASELINE=1` | 370 passed, 16 skipped |

`ccdproc/tests/test_rebin.py` under array-api-strict: before 5 failed / 3 passed (all `.astype` AttributeError); after 1 failed / 3 passed / 5 skipped. The remaining failure is `test_rebin_ccddata[True-True]`, which fails in the test's own setup (`np.zeros_like(ccd_data)` on a strict-device array) before `rebin` is called — that is #970, not this issue.

Fixes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA
