### PR TITLE
Keep Variance/InverseVariance uncertainty propagation in the array namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Bug Fixes
   provide ``percentile``. [#957]
 - Cast the boolean mask to the data dtype in ``create_deviation`` so that
   ``disregard_nan=True`` works with strict array-API backends. [#968]
+- Keep ``VarianceUncertainty`` and ``InverseVariance`` propagation in the
+  array namespace of the data instead of converting to NumPy. [#962]
 - Make array-API escape logging thread-safe so concurrent worker escapes are
   not missed. [#955]
 - Create the dark scale factor in ``subtract_dark(scale=True)`` on the same

--- a/ccdproc/_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/_ccddata_wrapper_for_array_api.py
@@ -263,64 +263,113 @@ class _CupyOperationNamesMixin:
         return self.__class__(array=result, copy=False)
 
 
-class _StdDevUncertaintyWrapper(_CupyOperationNamesMixin, StdDevUncertainty):
+class _ArrayAPIPropagationMixin:
+    """
+    Override the operation propagate methods so that the variance conversions
+    happen in the array namespace of the uncertainty arrays.
+
+    Astropy's ``_VariancePropagationMixin`` does the propagation arithmetic in
+    terms of variances, using ``to_variance``/``from_variance`` hooks to convert
+    to and from the uncertainty type. Subclasses provide ``_variance_hooks``
+    to build those hooks from the array namespace ``xp``.
+    """
+
+    @staticmethod
+    def _variance_hooks(xp):
+        raise NotImplementedError
+
+    def _propagate_add(self, other_uncert, result_data, correlation):
+        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
+        to_variance, from_variance = self._variance_hooks(xp)
+        return super()._propagate_add_sub(
+            other_uncert,
+            result_data,
+            correlation,
+            subtract=False,
+            to_variance=to_variance,
+            from_variance=from_variance,
+        )
+
+    def _propagate_subtract(self, other_uncert, result_data, correlation):
+        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
+        to_variance, from_variance = self._variance_hooks(xp)
+        return super()._propagate_add_sub(
+            other_uncert,
+            result_data,
+            correlation,
+            subtract=True,
+            to_variance=to_variance,
+            from_variance=from_variance,
+        )
+
+    def _propagate_multiply(self, other_uncert, result_data, correlation):
+        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
+        to_variance, from_variance = self._variance_hooks(xp)
+        return super()._propagate_multiply_divide(
+            other_uncert,
+            result_data,
+            correlation,
+            divide=False,
+            to_variance=to_variance,
+            from_variance=from_variance,
+        )
+
+    def _propagate_divide(self, other_uncert, result_data, correlation):
+        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
+        to_variance, from_variance = self._variance_hooks(xp)
+        return super()._propagate_multiply_divide(
+            other_uncert,
+            result_data,
+            correlation,
+            divide=True,
+            to_variance=to_variance,
+            from_variance=from_variance,
+        )
+
+
+class _StdDevUncertaintyWrapper(
+    _CupyOperationNamesMixin, _ArrayAPIPropagationMixin, StdDevUncertainty
+):
     """
     Override operation propagate methods to make sure they use the array API.
 
     Override overall propagate method to allow cupy_-prefixed operation names.
     """
 
-    def _propagate_add(self, other_uncert, result_data, correlation):
-        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
-        return super()._propagate_add_sub(
-            other_uncert,
-            result_data,
-            correlation,
-            subtract=False,
-            to_variance=xp.square,
-            from_variance=xp.sqrt,
-        )
-
-    def _propagate_subtract(self, other_uncert, result_data, correlation):
-        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
-        return super()._propagate_add_sub(
-            other_uncert,
-            result_data,
-            correlation,
-            subtract=True,
-            to_variance=xp.square,
-            from_variance=xp.sqrt,
-        )
-
-    def _propagate_multiply(self, other_uncert, result_data, correlation):
-        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
-        return super()._propagate_multiply_divide(
-            other_uncert,
-            result_data,
-            correlation,
-            divide=False,
-            to_variance=xp.square,
-            from_variance=xp.sqrt,
-        )
-
-    def _propagate_divide(self, other_uncert, result_data, correlation):
-        xp = array_api_compat.array_namespace(self.array, other_uncert.array)
-        return super()._propagate_multiply_divide(
-            other_uncert,
-            result_data,
-            correlation,
-            divide=True,
-            to_variance=xp.square,
-            from_variance=xp.sqrt,
-        )
+    @staticmethod
+    def _variance_hooks(xp):
+        return xp.square, xp.sqrt
 
 
-class _VarianceUncertaintyWrapper(_CupyOperationNamesMixin, VarianceUncertainty):
-    """This subclass is needed to allow CuPy operation names"""
+class _VarianceUncertaintyWrapper(
+    _CupyOperationNamesMixin, _ArrayAPIPropagationMixin, VarianceUncertainty
+):
+    """
+    Override operation propagate methods to make sure they use the array API.
+
+    Override overall propagate method to allow cupy_-prefixed operation names.
+    """
+
+    @staticmethod
+    def _variance_hooks(xp):
+        # Astropy also applies ``to_variance`` to units, so it must accept
+        # non-array inputs; ``xp.asarray`` keeps the result in the namespace
+        # (and on the device) of the input arrays.
+        return (lambda x: x), xp.asarray
 
 
-class _InverseVarianceWrapper(_CupyOperationNamesMixin, InverseVariance):
-    """This subclass is needed to allow CuPy operation names"""
+class _InverseVarianceWrapper(
+    _CupyOperationNamesMixin, _ArrayAPIPropagationMixin, InverseVariance
+):
+    """
+    Override operation propagate methods to make sure they use the array API.
+
+    Override overall propagate method to allow cupy_-prefixed operation names.
+    """
+
+    @staticmethod
+    def _variance_hooks(xp):
+        return (lambda x: 1 / x), (lambda x: 1 / xp.asarray(x))
 
 
 def _wrap_uncertainty(unc):

--- a/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import array_api_compat
 import array_api_extra as xpx
 import astropy.units as u
+import numpy as np
 import pytest
 from astropy.nddata import (
     CCDData,
@@ -136,3 +138,53 @@ def test_unwrap_rejects_non_ccddata():
         match="Input must be a CCDData or _CCDDataWrapperForArrayAPI instance",
     ):
         _unwrap_ccddata_for_array_api(object())
+
+
+_STRICT_STDDEV_MULDIV_XFAIL = pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="astropy's _propagate_multiply_divide applies np.sqrt/np.abs to the "
+    "std-dev result, which fails on a non-default strict device (see #940)",
+)
+
+
+@pytest.mark.parametrize(
+    ("uncertainty_type", "operation"),
+    [
+        pytest.param(
+            unc,
+            op,
+            marks=(
+                [_STRICT_STDDEV_MULDIV_XFAIL]
+                if unc is StdDevUncertainty and op in ("multiply", "divide")
+                else []
+            ),
+        )
+        for unc in (StdDevUncertainty, VarianceUncertainty, InverseVariance)
+        for op in ("add", "subtract", "multiply", "divide")
+    ],
+)
+def test_wrapped_arithmetic_keeps_uncertainty_in_namespace(uncertainty_type, operation):
+    data1 = [[1.0, 2.0], [3.0, 4.0]]
+    data2 = [[2.0, 2.0], [4.0, 8.0]]
+    unc1 = [[0.1, 0.2], [0.3, 0.4]]
+    unc2 = [[0.2, 0.1], [0.4, 0.3]]
+
+    def make(data, unc, asarray):
+        return CCDData(
+            asarray(data), unit=u.adu, uncertainty=uncertainty_type(asarray(unc))
+        )
+
+    ccd1 = _wrap_ccddata_for_array_api(make(data1, unc1, xp.asarray))
+    ccd2 = _wrap_ccddata_for_array_api(make(data2, unc2, xp.asarray))
+    result = getattr(ccd1, operation)(ccd2)
+
+    # Reference: astropy's own propagation on plain numpy CCDData.
+    ref1 = make(data1, unc1, np.asarray)
+    ref2 = make(data2, unc2, np.asarray)
+    expected = getattr(ref1, operation)(ref2)
+
+    assert array_api_compat.array_namespace(result.uncertainty.array) is xp
+    assert isinstance(result.uncertainty, uncertainty_type)
+    assert xp.all(
+        xpx.isclose(result.uncertainty.array, xp.asarray(expected.uncertainty.array))
+    )

--- a/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/tests/test_ccddata_wrapper_for_array_api.py
@@ -15,6 +15,7 @@ from astropy.wcs import WCS
 
 from ccdproc import flat_correct, trim_image
 from ccdproc._ccddata_wrapper_for_array_api import (
+    _ArrayAPIPropagationMixin,
     _CCDDataWrapperForArrayAPI,
     _InverseVarianceWrapper,
     _StdDevUncertaintyWrapper,
@@ -145,6 +146,13 @@ _STRICT_STDDEV_MULDIV_XFAIL = pytest.mark.backend_xfail(
     reason="astropy's _propagate_multiply_divide applies np.sqrt/np.abs to the "
     "std-dev result, which fails on a non-default strict device (see #940)",
 )
+
+
+def test_propagation_mixin_requires_variance_hooks():
+    """The mixin is abstract: a subclass that forgets ``_variance_hooks`` fails
+    loudly rather than silently propagating with the wrong conversions."""
+    with pytest.raises(NotImplementedError):
+        _ArrayAPIPropagationMixin._variance_hooks(xp)
 
 
 @pytest.mark.parametrize(

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -263,26 +263,8 @@ def _run_cosmicray_gain_correct_uncertainty(
     ("uncertainty_type", "gain_power", "gain_apply"),
     [
         (StdDevUncertainty, 1, True),
-        pytest.param(
-            VarianceUncertainty,
-            2,
-            True,
-            marks=pytest.mark.backend_xfail(
-                "jax",
-                reason="Astropy uncertainty propagation converts JAX variance "
-                "arrays to NumPy",
-            ),
-        ),
-        pytest.param(
-            InverseVariance,
-            -2,
-            True,
-            marks=pytest.mark.backend_xfail(
-                "jax",
-                reason="Astropy uncertainty propagation converts JAX inverse "
-                "variance arrays to NumPy",
-            ),
-        ),
+        (VarianceUncertainty, 2, True),
+        (InverseVariance, -2, True),
         (StdDevUncertainty, 1, False),
         (VarianceUncertainty, 2, False),
         (InverseVariance, -2, False),


### PR DESCRIPTION
`_VarianceUncertaintyWrapper` and `_InverseVarianceWrapper` in `ccdproc/_ccddata_wrapper_for_array_api.py` were bare subclasses, so arithmetic on a `CCDData` carrying a `VarianceUncertainty` / `InverseVariance` went through astropy's default `to_variance` / `from_variance` hooks and the propagated uncertainty escaped to NumPy on JAX (and other non-NumPy backends).

This PR factors the four `_propagate_add/subtract/multiply/divide` overrides that `_StdDevUncertaintyWrapper` already had into a small `_ArrayAPIPropagationMixin`; each wrapper supplies namespace-aware hooks via `_variance_hooks(xp)`:

- StdDev: `xp.square` / `xp.sqrt` (unchanged behaviour)
- Variance: identity / `xp.asarray`
- InverseVariance: `1/x` / `1/xp.asarray(x)`

The two jax `backend_xfail` params on `test_cosmicray_gain_correct` (VarianceUncertainty and InverseVariance with `gain_apply=True`) are removed; under jax they go XPASS -> PASS.

Note: intermediates may still round-trip through NumPy inside astropy's `_VariancePropagationMixin` itself (it calls `np.sqrt` / `np.abs` and checks `isinstance(correlation, np.ndarray)`); that is upstream and tracked in #940. This PR only fixes the ccdproc-side wrapper so the *result* stays in the data's namespace.

### Test matrix

| backend | `pytest ccdproc` |
|---|---|
| numpy | 380 passed, 5 skipped |
| jax (`JAX_ENABLE_X64=True`) | 368 passed, 10 skipped, 7 xpassed (same 7 XPASS as on main; 2 fewer xfails — the two removed here) |
| dask | 370 passed, 15 skipped |
| dask + `CCDPROC_ENFORCE_ESCAPE_BASELINE=1` | 370 passed, 15 skipped |

`ccdproc/tests/test_cosmicray.py` under array-api-strict: 1 failed, 7 passed, 33 xfailed both before and after (pre-existing failure, unrelated).

Fixes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA
