### PR TITLE
Fix background_deviation_box discarding the xpx.at result on immutable backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Bug Fixes
 - Keep ``Combiner.clip_extrema`` index arithmetic in the selected array
   namespace so GPU-backed arrays do not require an implicit conversion to
   NumPy. [#954]
+- Fix ``background_deviation_box`` discarding the result of the functional
+  array update, which left the output at the global standard deviation on
+  immutable array-API backends such as JAX. [#963]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -1343,7 +1343,7 @@ def background_deviation_box(data, bbox, xp=None):
     for i in range(int(0.5 * bbox), xlen, bbox):
         for j in range(int(0.5 * bbox), ylen, bbox):
             x1, x2, y1, y2 = setbox(i, j, bbox, xlen, ylen)
-            xpx.at(barr)[y1:y2, x1:x2].set(float(sigma_func(data[y1:y2, x1:x2])))
+            barr = xpx.at(barr)[y1:y2, x1:x2].set(float(sigma_func(data[y1:y2, x1:x2])))
 
     return barr
 

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -2,6 +2,7 @@
 
 import array_api_compat
 import array_api_extra as xpx
+import numpy as np
 import pytest
 from astropy import units as u
 from astropy.nddata import (
@@ -518,7 +519,30 @@ def test_background_deviation_box():
     scale = 5.3
     cd = xp.asarray(default_rng(seed=123).normal(loc=0, size=(100, 100), scale=scale))
     bd = background_deviation_box(cd, 25)
-    assert abs(bd.mean() - scale) < 0.10
+    assert abs(float(xp.mean(bd)) - scale) < 0.10
+
+
+def test_background_deviation_box_per_box_values():
+    # Regression test for #963: the per-box deviation must actually be
+    # written into the result. A pure-mean check passes even if every box is
+    # silently left at the global standard deviation.
+    rng = default_rng(seed=123)
+    left = rng.normal(loc=0, size=(100, 50), scale=1.0)
+    right = rng.normal(loc=0, size=(100, 50), scale=10.0)
+    cd = xp.asarray(np.hstack([left, right]))
+    bd = background_deviation_box(cd, 50)
+    global_std = float(xp.std(cd))
+    left_val = float(bd[25, 25])
+    right_val = float(bd[25, 75])
+    assert abs(left_val - 1.0) < 0.1
+    assert abs(right_val - 10.0) < 1.0
+    assert left_val != right_val
+    assert abs(left_val - global_std) > 1.0
+    assert abs(right_val - global_std) > 1.0
+    # every pixel within a box shares that box's value (the top-left and
+    # top-right boxes cover rows 0-50 and columns 0-50 / 50-99)
+    assert bool(xp.all(bd[:50, :50] == bd[0, 0]))
+    assert bool(xp.all(bd[:50, 50:99] == bd[0, 50]))
 
 
 def test_background_deviation_box_fail():

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -534,13 +534,19 @@ def test_background_deviation_box_per_box_values():
     global_std = float(xp.std(cd))
     left_val = float(bd[25, 25])
     right_val = float(bd[25, 75])
-    assert abs(left_val - 1.0) < 0.1
-    assert abs(right_val - 10.0) < 1.0
+    # The sample standard deviation of a 50x50 box scatters by roughly
+    # sigma / sqrt(2 * 2500) ~ 0.014 * sigma, so with a fixed seed these
+    # bounds are comfortably above the noise while still far tighter than the
+    # gap to the global standard deviation (~7).
+    assert abs(left_val - 1.0) < 0.05
+    assert abs(right_val - 10.0) < 0.5
     assert left_val != right_val
     assert abs(left_val - global_std) > 1.0
     assert abs(right_val - global_std) > 1.0
-    # every pixel within a box shares that box's value (the top-left and
-    # top-right boxes cover rows 0-50 and columns 0-50 / 50-99)
+    # every pixel within a box shares that box's value. setbox clamps the
+    # upper edge to len - 1, so the last row and column of the image are never
+    # filled (they keep the global standard deviation) and are deliberately
+    # excluded from the comparison.
     assert bool(xp.all(bd[:50, :50] == bd[0, 0]))
     assert bool(xp.all(bd[:50, 50:99] == bd[0, 50]))
 


### PR DESCRIPTION
`background_deviation_box` called `xpx.at(barr)[y1:y2, x1:x2].set(...)` without rebinding the result. `xpx.at(...).set()` returns a new array, so on immutable backends (JAX, array-api-strict) every box was silently left at the global standard deviation. This rebinds the result.

The existing `test_background_deviation_box` only checked the mean of the output, which happens to pass on JAX even when the per-box values are never written. A new regression test (`test_background_deviation_box_per_box_values`) uses different noise scales in different boxes and checks the per-box values; it fails on JAX before the fix and passes after. The existing test now uses `xp.mean()` so it also runs on array-api-strict.

Test matrix (full suite unless noted):

| backend | result |
| --- | --- |
| numpy | 381 passed, 5 skipped |
| jax | 367 passed, 10 skipped, 2 xfailed, 7 xpassed (all 7 XPASS are pre-existing combiner / image_collection entries) |
| dask | 371 passed, 15 skipped |
| array-api-strict, `test_cosmicray.py` only | before: 1 failed, 7 passed, 33 xfailed; after: 9 passed, 33 xfailed |

Fixes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA