### PR TITLE
Add a spec-only nanmedian fallback for Combiner.median_combine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug Fixes
   excluded from the noise estimate when ``error_image`` is not given.
   Previously the mask of a masked array was silently dropped by the array
   conversion. [#932]
+- Add a NaN-aware median written purely in terms of the array API standard
+  and use it in ``Combiner.median_combine`` when the selected array namespace
+  has no ``nanmedian``, instead of raising ``RuntimeError``. [#906]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Build the ``Combiner`` data and mask arrays with ``xp.stack`` instead of

--- a/ccdproc/_nanmedian.py
+++ b/ccdproc/_nanmedian.py
@@ -80,6 +80,10 @@ def nanmedian(x, /, *, axis=0, xp=None):
 
     # Number of non-NaN values along the axis, kept broadcastable.
     n = xp.sum(xp.astype(~xp.isnan(x), xp.int32), axis=axis, keepdims=True)
+    # For odd ``n`` these collapse to the same index, so the middle entry is
+    # picked twice and averaged with itself -- exact, bar overflow when the
+    # value exceeds half the dtype's maximum (numpy.nanmedian overflows there
+    # too). For ``n == 0`` ``lo`` is -1, which matches no index; see below.
     lo = (n - 1) // 2
     hi = n // 2
 
@@ -93,5 +97,10 @@ def nanmedian(x, /, *, axis=0, xp=None):
     hi_val = xp.sum(xp.where(idx == hi, s, zero), axis=axis)
     result = (lo_val + hi_val) / 2
 
+    # This guard is load-bearing, not defensive: for an all-NaN slice ``n`` is
+    # 0, so ``lo`` is -1 and matches no index (``lo_val`` sums to zero) while
+    # ``hi`` is 0 and picks s[0], which is one of the +inf sentinels above.
+    # ``result`` is therefore +inf rather than NaN, and only this ``where``
+    # makes an all-NaN slice yield NaN. Do not remove it as redundant.
     nan = xp.asarray(xp.nan, dtype=s.dtype, device=device)
     return xp.where(xp.squeeze(n, axis=axis) == 0, nan, result)

--- a/ccdproc/_nanmedian.py
+++ b/ccdproc/_nanmedian.py
@@ -1,0 +1,82 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+A NaN-aware median written only in terms of the array API standard.
+
+``median``/``nanmedian`` are not part of the array API standard, so this
+module provides a fallback that works on any conforming namespace
+(``array-api-strict``, ``jax``, ``dask``, ``numpy``, ...). It is used by
+`ccdproc.combiner.Combiner.median_combine` when the selected namespace
+does not provide ``nanmedian``.
+"""
+
+import array_api_compat
+
+__all__ = ["nanmedian"]
+
+
+def nanmedian(x, /, *, axis=0, xp=None):
+    """
+    Median along an axis, ignoring NaNs, using only array-API functions.
+
+    The input is sorted along ``axis`` (NaNs sort to the end per the array
+    API specification), the number of non-NaN entries ``n`` is counted, and
+    the elements at positions ``(n - 1) // 2`` and ``n // 2`` are gathered
+    and averaged. Slices that are entirely NaN yield NaN.
+
+    Parameters
+    ----------
+    x : array
+        Input array. Integer inputs are promoted to ``float64``.
+    axis : int, optional
+        Axis along which to compute the median. Default is 0.
+        ``None`` and tuples of axes are not supported.
+    xp : array namespace, optional
+        Namespace to use. Defaults to ``array_api_compat.array_namespace(x)``.
+
+    Returns
+    -------
+    array
+        Median of ``x`` along ``axis``, with that axis removed.
+
+    Notes
+    -----
+    The implementation relies on a full sort so its cost is O(n log n) along
+    ``axis``, compared with the O(n) selection used by ``numpy.nanmedian``
+    or ``bottleneck.nanmedian``. Prefer a native ``nanmedian`` when the
+    namespace offers one.
+    """
+    if axis is None or not isinstance(axis, int):
+        raise NotImplementedError(
+            "nanmedian fallback supports only a single integer axis."
+        )
+
+    xp = xp or array_api_compat.array_namespace(x)
+
+    if not xp.isdtype(x.dtype, "real floating"):
+        x = xp.astype(x, xp.float64)
+
+    ndim = x.ndim
+    if not -ndim <= axis < ndim:
+        raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    axis = axis % ndim
+
+    device = array_api_compat.device(x)
+    s = xp.sort(x, axis=axis)
+
+    # Number of non-NaN values along the axis, kept broadcastable.
+    n = xp.sum(xp.astype(~xp.isnan(x), xp.int64), axis=axis, keepdims=True)
+    lo = (n - 1) // 2
+    hi = n // 2
+
+    # Index along ``axis``, shaped to broadcast against ``s``.
+    shape = [1] * ndim
+    shape[axis] = x.shape[axis]
+    idx = xp.reshape(xp.arange(x.shape[axis], device=device), tuple(shape))
+
+    zero = xp.asarray(0, dtype=s.dtype, device=device)
+    lo_val = xp.sum(xp.where(idx == lo, s, zero), axis=axis)
+    hi_val = xp.sum(xp.where(idx == hi, s, zero), axis=axis)
+    result = (lo_val + hi_val) / 2
+
+    nan = xp.asarray(xp.nan, dtype=s.dtype, device=device)
+    return xp.where(xp.squeeze(n, axis=axis) == 0, nan, result)

--- a/ccdproc/_nanmedian.py
+++ b/ccdproc/_nanmedian.py
@@ -18,15 +18,18 @@ def nanmedian(x, /, *, axis=0, xp=None):
     """
     Median along an axis, ignoring NaNs, using only array-API functions.
 
-    The input is sorted along ``axis`` (NaNs sort to the end per the array
-    API specification), the number of non-NaN entries ``n`` is counted, and
-    the elements at positions ``(n - 1) // 2`` and ``n // 2`` are gathered
-    and averaged. Slices that are entirely NaN yield NaN.
+    NaNs are replaced by ``+inf`` and the result is sorted along ``axis``,
+    so that the first ``n`` positions hold the non-NaN values in order no
+    matter where the namespace's ``sort`` places NaNs (the standard leaves
+    that implementation-defined). The number of non-NaN entries ``n`` is
+    counted, and the elements at positions ``(n - 1) // 2`` and ``n // 2``
+    are gathered and averaged. Slices that are entirely NaN yield NaN.
 
     Parameters
     ----------
     x : array
-        Input array. Integer inputs are promoted to ``float64``.
+        Input array. Integer and boolean inputs are promoted to the
+        namespace's default real floating dtype.
     axis : int, optional
         Axis along which to compute the median. Default is 0.
         ``None`` and tuples of axes are not supported.
@@ -50,10 +53,8 @@ def nanmedian(x, /, *, axis=0, xp=None):
             "nanmedian fallback supports only a single integer axis."
         )
 
-    xp = xp or array_api_compat.array_namespace(x)
-
-    if not xp.isdtype(x.dtype, "real floating"):
-        x = xp.astype(x, xp.float64)
+    if xp is None:
+        xp = array_api_compat.array_namespace(x)
 
     ndim = x.ndim
     if not -ndim <= axis < ndim:
@@ -61,10 +62,24 @@ def nanmedian(x, /, *, axis=0, xp=None):
     axis = axis % ndim
 
     device = array_api_compat.device(x)
-    s = xp.sort(x, axis=axis)
+
+    if not xp.isdtype(x.dtype, "real floating"):
+        # Promote to the namespace's default real dtype rather than hardcoding
+        # float64: jax without JAX_ENABLE_X64 has no float64 and warns when one
+        # is requested, which pytest's filterwarnings turns into an error.
+        info = xp.__array_namespace_info__()
+        x = xp.astype(x, info.default_dtypes(device=device)["real floating"])
+
+    # Replacing NaNs with +inf keeps them past every real value regardless of
+    # how the namespace orders NaNs in ``sort``. Genuine +inf entries compare
+    # equal to the sentinels, so positions below ``n`` are unaffected.
+    s = xp.sort(
+        xp.where(xp.isnan(x), xp.asarray(xp.inf, dtype=x.dtype, device=device), x),
+        axis=axis,
+    )
 
     # Number of non-NaN values along the axis, kept broadcastable.
-    n = xp.sum(xp.astype(~xp.isnan(x), xp.int64), axis=axis, keepdims=True)
+    n = xp.sum(xp.astype(~xp.isnan(x), xp.int32), axis=axis, keepdims=True)
     lo = (n - 1) // 2
     hi = n // 2
 

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -3,6 +3,7 @@
 """This module implements the combiner class."""
 
 from copy import deepcopy
+from functools import partial
 
 try:  # pragma: no cover
     import bottleneck as bn
@@ -19,6 +20,7 @@ from astropy.stats import sigma_clip
 from astropy.utils import deprecated_renamed_argument
 from numpy import mgrid as np_mgrid
 
+from ._nanmedian import nanmedian
 from .core import sigma_func
 
 __all__ = ["Combiner", "combine"]
@@ -33,10 +35,10 @@ def _default_median(xp=None):
     # No bottleneck, but we have a namespace.
     try:
         return xp.nanmedian
-    except AttributeError as e:
-        raise RuntimeError(
-            "No NaN-aware median function available. Please install bottleneck."
-        ) from e
+    except AttributeError:
+        # nanmedian is not part of the array API standard; fall back to a
+        # (slower, sort-based) implementation written purely in terms of it.
+        return partial(nanmedian, xp=xp)
 
 
 def _default_average(xp=None):

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import types
 from functools import partial
 
 import array_api_compat
@@ -133,6 +134,19 @@ def test_bottleneck_defaults_respect_array_namespace(default_func, function_name
     else:
         pytest.skip(f"{xp.__name__} has no {function_name}")
     assert default is expected
+
+
+def test_default_median_falls_back_without_nanmedian():
+    # A namespace with no nanmedian (it is not in the array API standard)
+    # gets the spec-only fallback, bound to that namespace. Use a stand-in
+    # namespace so this is exercised regardless of which backend is under
+    # test; every backend in CI happens to provide nanmedian.
+    fake_xp = types.ModuleType("not_a_real_array_namespace")
+    default = _default_median(xp=fake_xp)
+
+    assert isinstance(default, partial)
+    assert default.func is nanmedian
+    assert default.keywords == {"xp": fake_xp}
 
 
 @pytest.mark.parametrize(

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -124,15 +124,15 @@ def test_bottleneck_defaults_respect_array_namespace(default_func, function_name
         expected = getattr(bottleneck, function_name)
     elif hasattr(xp, function_name):
         expected = getattr(xp, function_name)
-    elif function_name == "nanmedian":
-        # No nanmedian in the namespace: the spec-only fallback is used,
-        # bound to this namespace.
+    else:
+        # The namespace has no such function -- array-api-strict has no
+        # nanmedian, for one. Only the median has a spec-only fallback; the
+        # others raise RuntimeError inside default_func above, so in practice
+        # only nanmedian reaches here.
         assert isinstance(default, partial)
         assert default.func is nanmedian
         assert default.keywords == {"xp": xp}
         return
-    else:
-        pytest.skip(f"{xp.__name__} has no {function_name}")
     assert default is expected
 
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from functools import partial
+
 import array_api_compat
 import array_api_extra as xpx
 import astropy.units as u
@@ -8,10 +10,10 @@ import pytest
 from astropy.nddata import CCDData
 from astropy.stats import median_absolute_deviation as mad
 from astropy.utils.data import get_pkg_data_filename
-from numpy import median as np_median
 from numpy.testing import assert_allclose
 
 from ccdproc import create_deviation
+from ccdproc._nanmedian import nanmedian
 from ccdproc.combiner import (
     Combiner,
     _calculate_step_sizes,
@@ -35,6 +37,11 @@ from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 pytestmark = pytest.mark.filterwarnings(
     "ignore:All-NaN slice encountered:RuntimeWarning"
 )
+
+
+def _overall_median(arr):
+    """NaN-aware median of every element of ``arr``, staying in ``xp``."""
+    return nanmedian(xp.reshape(arr, (-1,)), axis=0, xp=xp)
 
 
 def _make_mean_scaler(ccd_data):
@@ -114,8 +121,17 @@ def test_bottleneck_defaults_respect_array_namespace(default_func, function_name
 
     if array_api_compat.is_numpy_namespace(xp):
         expected = getattr(bottleneck, function_name)
-    else:
+    elif hasattr(xp, function_name):
         expected = getattr(xp, function_name)
+    elif function_name == "nanmedian":
+        # No nanmedian in the namespace: the spec-only fallback is used,
+        # bound to this namespace.
+        assert isinstance(default, partial)
+        assert default.func is nanmedian
+        assert default.keywords == {"xp": xp}
+        return
+    else:
+        pytest.skip(f"{xp.__name__} has no {function_name}")
     assert default is expected
 
 
@@ -634,23 +650,9 @@ def test_combiner_with_scaling():
     assert avg_ccd.shape == ccd_data.shape
     median_ccd = combiner.median_combine()
     # Does median also scale to the correct value?
-    # Some array libraries do not have a median, and median is not part of the
-    # standard array API, so we use numpy's median here.
-    # Odd; for dask, which does not have a full median, even falling back to numpy does
-    # not work. For some reason the call to np_median fails. I suppose this is maybe
-    # because dask just adds a median to its task list/compute graph thingy
-    # and then tries to evaluate it itself?
-
-    med_ccd = median_ccd.data
-    med_inp_data = ccd_data.data
-    # Try doing a compute on the data first, and if that fails it is no big deal
-    try:
-        med_ccd = med_ccd.compute()
-        med_inp_data = med_inp_data.compute()
-    except AttributeError:
-        pass
-
-    assert xp.all(xpx.isclose(np_median(med_ccd), np_median(med_inp_data)))
+    assert xp.all(
+        xpx.isclose(_overall_median(median_ccd.data), _overall_median(ccd_data.data))
+    )
 
     # Set the scaling manually...
     combiner.scaling = [scale_by_mean(combiner._data_arr[i]) for i in range(3)]
@@ -1176,16 +1178,9 @@ def test_3d_combiner_with_scaling():
     assert avg_ccd.shape == ccd_data.shape
     median_ccd = combiner.median_combine()
     # Does median also scale to the correct value?
-    # Once again, use numpy to find the median
-    med_ccd = median_ccd.data
-    med_inp_data = ccd_data.data
-    try:
-        med_ccd = med_ccd.compute()
-        med_inp_data = med_inp_data.compute()
-    except AttributeError:
-        pass
-
-    assert xp.all(xpx.isclose(np_median(med_ccd), np_median(med_inp_data)))
+    assert xp.all(
+        xpx.isclose(_overall_median(median_ccd.data), _overall_median(ccd_data.data))
+    )
 
     # Set the scaling manually...
     combiner.scaling = [scale_by_mean(combiner._data_arr[i]) for i in range(3)]
@@ -1503,11 +1498,7 @@ def test_user_supplied_combine_func_that_relies_on_masks(comb_func):
         actual_result = c.average_combine(scale_func=xp.mean)
     elif comb_func == "median_combine":
         expected_result = data
-        if not hasattr(xp, "median"):
-            # If the array API does not have a median function, we
-            # cannot test this.
-            pytest.skip("The array library does not support median")
-        actual_result = c.median_combine(median_func=xp.median)
+        actual_result = c.median_combine(median_func=partial(nanmedian, xp=xp))
 
     # Two of the three values are masked, so no matter what the combination
     # method is the result in this pixel should be 2.

--- a/ccdproc/tests/test_nanmedian.py
+++ b/ccdproc/tests/test_nanmedian.py
@@ -1,0 +1,78 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import array_api_extra as xpx
+import numpy as np
+import pytest
+
+from ccdproc._nanmedian import nanmedian
+from ccdproc.conftest import testing_array_device as xp_device
+from ccdproc.conftest import testing_array_library as xp
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:All-NaN slice encountered:RuntimeWarning"
+)
+
+
+def _check(np_data, axis=0):
+    """Compare the array-API nanmedian with numpy's, without leaving ``xp``."""
+    arr = xp.asarray(np_data, device=xp_device)
+    result = nanmedian(arr, axis=axis)
+    expected = xp.asarray(np.nanmedian(np_data, axis=axis), device=xp_device)
+    assert result.shape == expected.shape
+    assert xp.isdtype(result.dtype, "real floating")
+    assert xp.all(xpx.isclose(result, expected, equal_nan=True))
+
+
+@pytest.mark.parametrize("length", [1, 2, 3, 4, 5, 6])
+def test_nanmedian_odd_and_even_lengths(length):
+    rng = np.random.default_rng(length)
+    _check(rng.normal(size=(length, 7)))
+
+
+def test_nanmedian_1d():
+    _check(np.array([3.0, 1.0, 2.0, 4.0]))
+
+
+def test_nanmedian_3d():
+    rng = np.random.default_rng(3)
+    _check(rng.normal(size=(5, 4, 3)))
+
+
+def test_nanmedian_some_nan():
+    data = np.array(
+        [
+            [1.0, np.nan, 5.0],
+            [2.0, 4.0, np.nan],
+            [np.nan, 3.0, 1.0],
+            [4.0, 2.0, np.nan],
+        ]
+    )
+    _check(data)
+
+
+def test_nanmedian_all_nan_column():
+    data = np.array([[1.0, np.nan], [2.0, np.nan], [3.0, np.nan]])
+    arr = xp.asarray(data, device=xp_device)
+    result = nanmedian(arr, axis=0)
+    assert float(result[0]) == 2.0
+    assert bool(xp.isnan(result[1]))
+
+
+def test_nanmedian_integer_input():
+    data = np.array([[1, 4], [2, 3], [5, 6], [4, 1]])
+    _check(data)
+
+
+def test_nanmedian_axis_1():
+    rng = np.random.default_rng(11)
+    data = rng.normal(size=(3, 6))
+    data[1, 2] = np.nan
+    _check(data, axis=1)
+    _check(data, axis=-1)
+
+
+def test_nanmedian_unsupported_axis():
+    arr = xp.asarray(np.ones((2, 2)), device=xp_device)
+    with pytest.raises(NotImplementedError):
+        nanmedian(arr, axis=None)
+    with pytest.raises(NotImplementedError):
+        nanmedian(arr, axis=(0, 1))

--- a/ccdproc/tests/test_nanmedian.py
+++ b/ccdproc/tests/test_nanmedian.py
@@ -76,3 +76,10 @@ def test_nanmedian_unsupported_axis():
         nanmedian(arr, axis=None)
     with pytest.raises(NotImplementedError):
         nanmedian(arr, axis=(0, 1))
+
+
+@pytest.mark.parametrize("axis", [2, -3])
+def test_nanmedian_axis_out_of_bounds(axis):
+    arr = xp.asarray(np.ones((2, 2)), device=xp_device)
+    with pytest.raises(ValueError, match="out of bounds"):
+        nanmedian(arr, axis=axis)

--- a/ccdproc/tests/test_nanmedian.py
+++ b/ccdproc/tests/test_nanmedian.py
@@ -7,79 +7,44 @@ from ccdproc._nanmedian import nanmedian
 from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:All-NaN slice encountered:RuntimeWarning"
+_rng = np.random.default_rng(906)
+_some_nan = _rng.normal(size=(4, 3))
+_some_nan[[0, 1, 2, 3], [1, 2, 0, 2]] = np.nan
+
+
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
+@pytest.mark.parametrize(
+    ("data", "axis"),
+    [
+        *[(_rng.normal(size=(n, 7)), 0) for n in range(1, 7)],  # odd/even lengths
+        (np.array([3.0, 1.0, 2.0, 4.0]), 0),  # 1-D
+        (_rng.normal(size=(5, 4, 3)), 0),  # 3-D
+        (_some_nan, 0),  # NaNs scattered through the reduced axis
+        (_some_nan, 1),  # a non-zero axis
+        (_some_nan, -1),  # a negative axis
+        (np.array([[1.0, np.nan], [2.0, np.nan], [3.0, np.nan]]), 0),  # all-NaN column
+        (np.array([[1, 4], [2, 3], [5, 6], [4, 1]]), 0),  # integer input
+    ],
 )
-
-
-def _check(np_data, axis=0):
-    """Compare the array-API nanmedian with numpy's, without leaving ``xp``."""
-    arr = xp.asarray(np_data, device=xp_device)
-    result = nanmedian(arr, axis=axis)
-    expected = xp.asarray(np.nanmedian(np_data, axis=axis), device=xp_device)
+def test_nanmedian_matches_numpy(data, axis):
+    """The fallback reproduces ``numpy.nanmedian``, in shape, dtype and value."""
+    result = nanmedian(xp.asarray(data, device=xp_device), axis=axis)
+    expected = xp.asarray(np.nanmedian(data, axis=axis), device=xp_device)
     assert result.shape == expected.shape
     assert xp.isdtype(result.dtype, "real floating")
     assert xp.all(xpx.isclose(result, expected, equal_nan=True))
 
 
-@pytest.mark.parametrize("length", [1, 2, 3, 4, 5, 6])
-def test_nanmedian_odd_and_even_lengths(length):
-    rng = np.random.default_rng(length)
-    _check(rng.normal(size=(length, 7)))
-
-
-def test_nanmedian_1d():
-    _check(np.array([3.0, 1.0, 2.0, 4.0]))
-
-
-def test_nanmedian_3d():
-    rng = np.random.default_rng(3)
-    _check(rng.normal(size=(5, 4, 3)))
-
-
-def test_nanmedian_some_nan():
-    data = np.array(
-        [
-            [1.0, np.nan, 5.0],
-            [2.0, 4.0, np.nan],
-            [np.nan, 3.0, 1.0],
-            [4.0, 2.0, np.nan],
-        ]
-    )
-    _check(data)
-
-
-def test_nanmedian_all_nan_column():
-    data = np.array([[1.0, np.nan], [2.0, np.nan], [3.0, np.nan]])
-    arr = xp.asarray(data, device=xp_device)
-    result = nanmedian(arr, axis=0)
-    assert float(result[0]) == 2.0
-    assert bool(xp.isnan(result[1]))
-
-
-def test_nanmedian_integer_input():
-    data = np.array([[1, 4], [2, 3], [5, 6], [4, 1]])
-    _check(data)
-
-
-def test_nanmedian_axis_1():
-    rng = np.random.default_rng(11)
-    data = rng.normal(size=(3, 6))
-    data[1, 2] = np.nan
-    _check(data, axis=1)
-    _check(data, axis=-1)
-
-
-def test_nanmedian_unsupported_axis():
-    arr = xp.asarray(np.ones((2, 2)), device=xp_device)
-    with pytest.raises(NotImplementedError):
-        nanmedian(arr, axis=None)
-    with pytest.raises(NotImplementedError):
-        nanmedian(arr, axis=(0, 1))
-
-
-@pytest.mark.parametrize("axis", [2, -3])
-def test_nanmedian_axis_out_of_bounds(axis):
-    arr = xp.asarray(np.ones((2, 2)), device=xp_device)
-    with pytest.raises(ValueError, match="out of bounds"):
-        nanmedian(arr, axis=axis)
+@pytest.mark.parametrize(
+    ("axis", "error"),
+    [
+        (None, NotImplementedError),
+        ((0, 1), NotImplementedError),
+        (2, ValueError),
+        (-3, ValueError),
+    ],
+)
+def test_nanmedian_bad_axis(axis, error):
+    """Axes the fallback cannot handle are rejected instead of silently wrong."""
+    with pytest.raises(error):
+        nanmedian(xp.asarray(np.ones((2, 2)), device=xp_device), axis=axis)

--- a/docs/array_api.rst
+++ b/docs/array_api.rst
@@ -150,9 +150,13 @@ What limitations should I be aware of?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 + The ``median`` function is not part of the array API, but most array libraries
-  do provide a ``median``. If the array library you choose does not have a ``median``
-  function then `ccdproc`_ will automatically fall back to using a ``median`` function from
-  `bottleneck`_, if that is installed, or to `numpy`_.
+  do provide a NaN-aware ``nanmedian``. When combining images, `ccdproc`_ uses
+  ``nanmedian`` from `bottleneck`_ for `numpy`_ arrays if `bottleneck`_ is
+  installed; otherwise it uses the ``nanmedian`` of the selected array library.
+  If that library has no ``nanmedian`` (for example ``array-api-strict``),
+  `ccdproc`_ falls back to a sort-based implementation written purely in terms
+  of the array API standard. That fallback is correct but slower
+  (O(n log n) along the combination axis rather than O(n)).
 
 Which array library should I use?
 ---------------------------------


### PR DESCRIPTION
Adds `ccdproc/_nanmedian.py`, a NaN-aware median written only in terms of array-API-standard functions (replace NaNs with `+inf`, sort the axis, count non-NaN entries, gather and average the two middle elements; all-NaN slices give NaN; integer input is promoted to the namespace's default real floating dtype). `Combiner._default_median` now returns this fallback (bound to the namespace via `functools.partial`) when the namespace has no `nanmedian`, instead of raising `RuntimeError`. The fallback is O(n log n) along the combination axis; native `nanmedian` / bottleneck are still preferred when available.

Also:
- `docs/array_api.rst`: replace the claim of a bottleneck -> numpy fallback (which did not exist) with the real chain (bottleneck for numpy -> `xp.nanmedian` -> spec-only fallback).
- `test_combiner.py`: drop the numpy-median/`.compute()` workarounds and the `pytest.skip` for namespaces without `median`; `test_bottleneck_defaults_respect_array_namespace` now checks the fallback is returned when `nanmedian` is absent.
- New `ccdproc/tests/test_nanmedian.py`, two parametrized tests covering odd/even lengths, 1-D/2-D/3-D, partial and all-NaN columns, integer input, axis=1/-1, and rejected axes.

### Review follow-ups

- **NaN ordering in `sort` is implementation-defined.** The first version relied on NaNs sorting last, which the standard does not guarantee — it only worked because numpy/strict/jax/dask all happen to agree. NaNs are now replaced by `+inf` before sorting, so the first `n` positions hold the non-NaN values whatever the backend does. Genuine `+inf` entries compare equal to the sentinels and are still counted in `n`, so the result is unchanged for them. Verified against a namespace whose `sort` deliberately places NaNs first: the old code returned `[1., 2., nan]` where the answer is `[2., 3., 3.]`; the new code is correct.
- **No hardcoded 64-bit dtypes.** The non-NaN count is `int32` rather than `int64`, and integer input is promoted via `xp.__array_namespace_info__().default_dtypes(device=device)["real floating"]` rather than `xp.float64`. Both tripped jax's x64-truncation `UserWarning`, which `filterwarnings = ["error"]` turns into a failure: with `JAX_ENABLE_X64` unset, `test_nanmedian.py` was 12 failed / 3 passed and is now 17 passed. On jax without x64 an integer input therefore yields `float32` rather than numpy's `float64`; every backend that has `float64` is unchanged.

### Test matrix

| backend | result |
| --- | --- |
| numpy, `pytest ccdproc` | 410 passed, 5 skipped |
| jax (`JAX_ENABLE_X64=True`), `pytest ccdproc` | 396 passed, 10 skipped, 2 xfailed, 7 xpassed |
| jax, `JAX_ENABLE_X64` unset, `test_nanmedian.py` | 17 passed |
| dask (`CCDPROC_LOG_ARRAY_ESCAPES=1 CCDPROC_ENFORCE_ESCAPE_BASELINE=1`) | 399 passed, 16 skipped; no escapes outside the baseline |
| array-api-strict, `test_nanmedian.py` | 17 passed |
| array-api-strict, `test_combiner.py` | 68 failed, 23 passed, 1 xfailed (92 collected) — `main` is 75 failed, 12 passed (87 collected) |

The 7 jax XPASS are identical on upstream/main (astropy/jax `DeprecationWarning` markers, unrelated).

The remaining strict `test_combiner.py` failures are pre-existing and tracked in #971; they hit the `Combiner` constructor ("Nested Arrays are not allowed", being fixed in #976) or other known strict bugs, not the median. This PR takes strict from 12 passed to 23 passed. An earlier revision of this description quoted "75 failed / 12 passed before -> 74 failed / 13 passed after"; the "before" figure is right (that is `main`) but the "after" figure was measured at an earlier commit and understates the result — the branch is 68 failed / 23 passed / 1 xfailed.

Fixes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA
