### PR TITLE
Honor the input mask in cosmicray_median

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,10 +20,11 @@ Bug Fixes
 - Exclude masked and clipped pixels, and their weights, when computing weighted
   average combinations. [#952]
 - ``cosmicray_median`` now honors the mask of a ``CCDData`` or masked-array
-  input: masked pixels are never flagged as cosmic rays, are returned
-  unchanged, and are excluded from the noise estimate when ``error_image``
-  is not given. Previously the mask of a masked array was silently dropped
-  by the array conversion. [#932]
+  input: masked pixels are never flagged as cosmic rays, no longer seed
+  ``gbox`` growth into their neighbors, are returned unchanged, and are
+  excluded from the noise estimate when ``error_image`` is not given.
+  Previously the mask of a masked array was silently dropped by the array
+  conversion. [#932]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Build the ``Combiner`` data and mask arrays with ``xp.stack`` instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,9 +19,9 @@ Bug Fixes
 
 - Exclude masked and clipped pixels, and their weights, when computing weighted
   average combinations. [#952]
-- ``cosmicray_median`` now honours the mask of a masked-array input: masked
+- ``cosmicray_median`` now honors the mask of a ``CCDData`` or masked-array input: masked
   pixels are never flagged as cosmic rays and are excluded from the median
-  filter, so they do not bias the detection in neighbouring pixels.
+  filter, so they do not bias the detection in neighboring pixels.
   Previously the input mask was silently ignored. [#932]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Bug Fixes
 
 - Exclude masked and clipped pixels, and their weights, when computing weighted
   average combinations. [#952]
+- ``cosmicray_median`` now honours the mask of a masked-array input: masked
+  pixels are never flagged as cosmic rays and do not contaminate the median
+  filter. Previously the input mask was silently ignored. [#932]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Fix the fallback percentile calculation for array namespaces that do not

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,9 @@ Bug Fixes
 - Exclude masked and clipped pixels, and their weights, when computing weighted
   average combinations. [#952]
 - ``cosmicray_median`` now honours the mask of a masked-array input: masked
-  pixels are never flagged as cosmic rays and do not contaminate the median
-  filter. Previously the input mask was silently ignored. [#932]
+  pixels are never flagged as cosmic rays and are excluded from the median
+  filter, so they do not bias the detection in neighbouring pixels.
+  Previously the input mask was silently ignored. [#932]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Fix the fallback percentile calculation for array namespaces that do not

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,10 +19,11 @@ Bug Fixes
 
 - Exclude masked and clipped pixels, and their weights, when computing weighted
   average combinations. [#952]
-- ``cosmicray_median`` now honors the mask of a ``CCDData`` or masked-array input: masked
-  pixels are never flagged as cosmic rays and are excluded from the median
-  filter, so they do not bias the detection in neighboring pixels.
-  Previously the input mask was silently ignored. [#932]
+- ``cosmicray_median`` now honors the mask of a ``CCDData`` or masked-array
+  input: masked pixels are never flagged as cosmic rays, are returned
+  unchanged, and are excluded from the noise estimate when ``error_image``
+  is not given. Previously the mask of a masked array was silently dropped
+  by the array conversion. [#932]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Build the ``Combiner`` data and mask arrays with ``xp.stack`` instead of

--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -20,6 +20,7 @@ from astropy.units.quantity import Quantity
 from astropy.utils import deprecated, deprecated_renamed_argument
 from astropy.wcs.utils import proj_plane_pixel_area
 from numpy import mgrid as np_mgrid
+from numpy.ma import nomask as np_ma_nomask
 from packaging import version as pkgversion
 from scipy import ndimage
 
@@ -1981,7 +1982,9 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     Parameters
     ----------
     ccd : `~astropy.nddata.CCDData`, `numpy.ndarray` or other array_like
-        Data to have cosmic ray cleaned.
+        Data to have cosmic ray cleaned. If a `numpy.ma.MaskedArray` (or an
+        array with a ``mask`` attribute) is given, masked pixels are never
+        flagged as cosmic rays and do not affect the detection; see Notes.
 
     thresh : float, optional
         Threshold for detecting cosmic rays.
@@ -2013,6 +2016,13 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     Notes
     -----
     Similar implementation to crmedian in iraf.imred.crutil.crmedian.
+
+    If ``ccd`` is a `numpy.ma.MaskedArray` (or any array with a non-empty
+    ``mask`` attribute), the masked pixels are never flagged as cosmic rays.
+    For the purposes of detection and replacement they are treated as if they
+    had the local median value, so they do not affect the detection of cosmic
+    rays in neighbouring pixels. The masked pixels are returned unchanged in
+    the output data array, and the returned cosmic-ray mask is ``False`` there.
 
     Returns
     -------
@@ -2052,13 +2062,19 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     if _is_array(ccd):
         xp = xp or array_api_compat.array_namespace(ccd)
 
-        # Masked data is not part of the array API so remove mask if present.
-        # Only look at the data array, guessing that if there is a .mask then
-        # there is also a .data.
-        if hasattr(ccd, "mask"):
-            data = ccd.data
-
-        data = xp.asarray(ccd)
+        # Masked arrays are not part of the array API, so split the input
+        # into a plain data array and a boolean mask (if any). Note that
+        # ``xp.asarray`` on a ``numpy.ma.MaskedArray`` silently drops the mask,
+        # so the mask must be extracted before converting.
+        in_mask = getattr(ccd, "mask", None)
+        if in_mask is None or in_mask is np_ma_nomask:
+            in_mask = None
+            data = xp.asarray(ccd)
+        else:
+            data = xp.asarray(ccd.data)
+            in_mask = xp.asarray(
+                in_mask, dtype=xp.bool, device=array_api_compat.device(data)
+            )
 
         if error_image is None:
             error_image = xp.std(data)
@@ -2067,29 +2083,37 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
                 raise TypeError("error_image is not a float or ndarray.")
 
         # create the median image
-        marr = ndimage.median_filter(data, size=(mbox, mbox))
+        marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
+
+        # Masked input pixels are replaced by the local median for the
+        # purposes of detection and replacement so that they do not
+        # contaminate the filters; the original values are kept in the output.
+        filt_data = data if in_mask is None else xp.where(in_mask, marr, data)
 
         # Find the residual image
-        rarr = (data - marr) / error_image
+        rarr = (filt_data - marr) / error_image
 
         # identify all sources
         crarr = rarr > thresh
 
         # grow the pixels
         if gbox > 0:
-            crarr = ndimage.maximum_filter(crarr, gbox)
+            crarr = xp.asarray(ndimage.maximum_filter(crarr, gbox))
+
+        if in_mask is not None:
+            # Masked input pixels are never flagged as cosmic rays.
+            crarr = crarr & ~in_mask
 
         # replace bad pixels in the image
-        ndata = data.copy()
+        ndata = xp.asarray(data, copy=True)
         if rbox > 0:
             # Fun fact: scipy.ndimage ignores the mask, so may as well not
             # bother with it.
             # data = np.ma.masked_array(data, (crarr == 1))
 
             # make sure that mdata is the same type as data
-            mdata = xp.asarray(ndimage.median_filter(data, rbox))
-            ndata = xp.where(crarr == 1, mdata, data)
-            # ndata = xpx.at(ndata)[crarr == 1].set(mdata[crarr == 1])
+            mdata = xp.asarray(ndimage.median_filter(filt_data, rbox))
+            ndata = xp.where(crarr, mdata, data)
 
         return ndata, crarr
     elif isinstance(ccd, CCDData):

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -1988,8 +1988,7 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     ccd : `~astropy.nddata.CCDData`, `numpy.ndarray` or other array_like
         Data to have cosmic ray cleaned. If the input has a mask (the ``mask``
         of a `~astropy.nddata.CCDData`, or a `numpy.ma.MaskedArray`), masked
-        pixels are never flagged as cosmic rays and do not affect the
-        detection; see Notes.
+        pixels are never flagged as cosmic rays; see Notes.
 
     thresh : float, optional
         Threshold for detecting cosmic rays.
@@ -2023,13 +2022,13 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     Similar implementation to crmedian in iraf.imred.crutil.crmedian.
 
     If ``ccd`` is a `~astropy.nddata.CCDData` with a mask, or a
-    `numpy.ma.MaskedArray` (or any array with a non-empty ``mask``
-    attribute), the masked pixels are never flagged as cosmic rays.
-    For the purposes of detection and replacement they are treated as if they
-    had the local median value of the unmasked data, so they do not affect
-    the detection of cosmic rays in neighboring pixels. The masked pixels are
-    returned unchanged in the output data array, and the returned cosmic-ray
-    mask is ``False`` there.
+    `numpy.ma.MaskedArray`, the masked pixels are never flagged as cosmic
+    rays (including by the ``gbox`` growth step), they are returned unchanged
+    in the output data, and, when ``error_image`` is `None`, they are excluded
+    from the noise estimate. They are *not* excluded from the median filter
+    itself, so very bright masked pixels can still influence the local median
+    of their unmasked neighbors. For a `~astropy.nddata.CCDData` the returned
+    mask is the union of the input mask and the detected cosmic rays.
 
     Returns
     -------
@@ -2122,47 +2121,43 @@ def _cosmicray_median_array(data, in_mask, error_image, thresh, mbox, gbox, rbox
             in_mask, dtype=xp.bool, device=array_api_compat.device(data)
         )
 
+    if in_mask is not None and not bool(xp.any(~in_mask)):
+        # Everything is masked, so nothing can be a cosmic ray.
+        return xp.asarray(data, copy=True), xp.zeros_like(in_mask)
+
     if error_image is None:
-        error_image = xp.std(data)
+        # Estimate the noise from the unmasked pixels only, so that bright
+        # masked pixels (e.g. a saturated column) do not inflate the
+        # detection threshold.
+        if in_mask is None:
+            error_image = xp.std(data)
+        else:
+            error_image = xp.std(data[~in_mask])
     elif not isinstance(error_image, float):
         if not _is_array(error_image):
             raise TypeError("error_image is not a float or ndarray.")
 
-    if in_mask is None:
-        filt_data = data
-        marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
-    else:
-        # Masked input pixels must not contaminate the median filter, so
-        # they are replaced before filtering. The replacement cannot depend
-        # on the masked values themselves (a masked region wider than the
-        # filter box would otherwise just reproduce them), so start from
-        # the mean of the unmasked data, compute the local median, and then
-        # refine once by replacing the masked pixels with that local
-        # median. The original values are kept in the output.
-        keep = ~in_mask
-        n_keep = xp.sum(xp.astype(keep, data.dtype))
-        if float(n_keep) == 0:
-            # Everything is masked, so nothing can be a cosmic ray.
-            return xp.asarray(data, copy=True), xp.zeros_like(in_mask)
-        fill = xp.sum(xp.where(keep, data, 0)) / n_keep
-        filt_data = xp.where(in_mask, fill, data)
-        marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
-        filt_data = xp.where(in_mask, marr, data)
-        marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
+    # create the median image. Note that scipy.ndimage knows nothing about
+    # masks, so masked pixels are included in the median like any other.
+    marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
 
     # Find the residual image
-    rarr = (filt_data - marr) / error_image
+    rarr = (data - marr) / error_image
 
     # identify all sources
     crarr = rarr > thresh
 
+    if in_mask is not None:
+        # Masked input pixels are never flagged as cosmic rays, and must not
+        # seed the growth step below.
+        crarr = crarr & ~in_mask
+
     # grow the pixels
     if gbox > 0:
         crarr = xp.asarray(ndimage.maximum_filter(crarr, gbox))
-
-    if in_mask is not None:
-        # Masked input pixels are never flagged as cosmic rays.
-        crarr = crarr & ~in_mask
+        if in_mask is not None:
+            # Growth must not extend into masked pixels either.
+            crarr = crarr & ~in_mask
 
     # replace bad pixels in the image
     ndata = xp.asarray(data, copy=True)
@@ -2172,7 +2167,7 @@ def _cosmicray_median_array(data, in_mask, error_image, thresh, mbox, gbox, rbox
         # data = np.ma.masked_array(data, (crarr == 1))
 
         # make sure that mdata is the same type as data
-        mdata = xp.asarray(ndimage.median_filter(filt_data, rbox))
+        mdata = xp.asarray(ndimage.median_filter(data, rbox))
         ndata = xp.where(crarr, mdata, data)
 
     return ndata, crarr

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -2020,9 +2020,10 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     If ``ccd`` is a `numpy.ma.MaskedArray` (or any array with a non-empty
     ``mask`` attribute), the masked pixels are never flagged as cosmic rays.
     For the purposes of detection and replacement they are treated as if they
-    had the local median value, so they do not affect the detection of cosmic
-    rays in neighbouring pixels. The masked pixels are returned unchanged in
-    the output data array, and the returned cosmic-ray mask is ``False`` there.
+    had the local median value of the unmasked data, so they do not affect
+    the detection of cosmic rays in neighbouring pixels. The masked pixels are
+    returned unchanged in the output data array, and the returned cosmic-ray
+    mask is ``False`` there.
 
     Returns
     -------
@@ -2082,13 +2083,23 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
             if not _is_array(error_image):
                 raise TypeError("error_image is not a float or ndarray.")
 
-        # create the median image
-        marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
-
-        # Masked input pixels are replaced by the local median for the
-        # purposes of detection and replacement so that they do not
-        # contaminate the filters; the original values are kept in the output.
-        filt_data = data if in_mask is None else xp.where(in_mask, marr, data)
+        if in_mask is None:
+            filt_data = data
+            marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
+        else:
+            # Masked input pixels must not contaminate the median filter, so
+            # they are replaced before filtering. The replacement cannot depend
+            # on the masked values themselves (a masked region wider than the
+            # filter box would otherwise just reproduce them), so start from
+            # the mean of the unmasked data, compute the local median, and then
+            # refine once by replacing the masked pixels with that local
+            # median. The original values are kept in the output.
+            keep = ~in_mask
+            fill = xp.sum(xp.where(keep, data, 0)) / xp.sum(xp.astype(keep, data.dtype))
+            filt_data = xp.where(in_mask, fill, data)
+            marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
+            filt_data = xp.where(in_mask, marr, data)
+            marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
 
         # Find the residual image
         rarr = (filt_data - marr) / error_image

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -2120,6 +2120,8 @@ def _cosmicray_median_array(data, in_mask, error_image, thresh, mbox, gbox, rbox
         in_mask = xp.asarray(
             in_mask, dtype=xp.bool, device=array_api_compat.device(data)
         )
+        if in_mask.shape != data.shape:
+            raise ValueError("mask is not the same shape as data.")
 
     if in_mask is not None and not bool(xp.any(~in_mask)):
         # Everything is masked, so nothing can be a cosmic ray.
@@ -2162,10 +2164,6 @@ def _cosmicray_median_array(data, in_mask, error_image, thresh, mbox, gbox, rbox
     # replace bad pixels in the image
     ndata = xp.asarray(data, copy=True)
     if rbox > 0:
-        # Fun fact: scipy.ndimage ignores the mask, so may as well not
-        # bother with it.
-        # data = np.ma.masked_array(data, (crarr == 1))
-
         # make sure that mdata is the same type as data
         mdata = xp.asarray(ndimage.median_filter(data, rbox))
         ndata = xp.where(crarr, mdata, data)

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -1982,9 +1982,10 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     Parameters
     ----------
     ccd : `~astropy.nddata.CCDData`, `numpy.ndarray` or other array_like
-        Data to have cosmic ray cleaned. If a `numpy.ma.MaskedArray` (or an
-        array with a ``mask`` attribute) is given, masked pixels are never
-        flagged as cosmic rays and do not affect the detection; see Notes.
+        Data to have cosmic ray cleaned. If the input has a mask (the ``mask``
+        of a `~astropy.nddata.CCDData`, or a `numpy.ma.MaskedArray`), masked
+        pixels are never flagged as cosmic rays and do not affect the
+        detection; see Notes.
 
     thresh : float, optional
         Threshold for detecting cosmic rays.
@@ -2017,11 +2018,12 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
     -----
     Similar implementation to crmedian in iraf.imred.crutil.crmedian.
 
-    If ``ccd`` is a `numpy.ma.MaskedArray` (or any array with a non-empty
-    ``mask`` attribute), the masked pixels are never flagged as cosmic rays.
+    If ``ccd`` is a `~astropy.nddata.CCDData` with a mask, or a
+    `numpy.ma.MaskedArray` (or any array with a non-empty ``mask``
+    attribute), the masked pixels are never flagged as cosmic rays.
     For the purposes of detection and replacement they are treated as if they
     had the local median value of the unmasked data, so they do not affect
-    the detection of cosmic rays in neighbouring pixels. The masked pixels are
+    the detection of cosmic rays in neighboring pixels. The masked pixels are
     returned unchanged in the output data array, and the returned cosmic-ray
     mask is ``False`` there.
 
@@ -2073,61 +2075,12 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
             data = xp.asarray(ccd)
         else:
             data = xp.asarray(ccd.data)
-            in_mask = xp.asarray(
-                in_mask, dtype=xp.bool, device=array_api_compat.device(data)
-            )
 
-        if error_image is None:
-            error_image = xp.std(data)
-        elif not isinstance(error_image, float):
-            if not _is_array(error_image):
-                raise TypeError("error_image is not a float or ndarray.")
-
-        if in_mask is None:
-            filt_data = data
-            marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
-        else:
-            # Masked input pixels must not contaminate the median filter, so
-            # they are replaced before filtering. The replacement cannot depend
-            # on the masked values themselves (a masked region wider than the
-            # filter box would otherwise just reproduce them), so start from
-            # the mean of the unmasked data, compute the local median, and then
-            # refine once by replacing the masked pixels with that local
-            # median. The original values are kept in the output.
-            keep = ~in_mask
-            fill = xp.sum(xp.where(keep, data, 0)) / xp.sum(xp.astype(keep, data.dtype))
-            filt_data = xp.where(in_mask, fill, data)
-            marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
-            filt_data = xp.where(in_mask, marr, data)
-            marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
-
-        # Find the residual image
-        rarr = (filt_data - marr) / error_image
-
-        # identify all sources
-        crarr = rarr > thresh
-
-        # grow the pixels
-        if gbox > 0:
-            crarr = xp.asarray(ndimage.maximum_filter(crarr, gbox))
-
-        if in_mask is not None:
-            # Masked input pixels are never flagged as cosmic rays.
-            crarr = crarr & ~in_mask
-
-        # replace bad pixels in the image
-        ndata = xp.asarray(data, copy=True)
-        if rbox > 0:
-            # Fun fact: scipy.ndimage ignores the mask, so may as well not
-            # bother with it.
-            # data = np.ma.masked_array(data, (crarr == 1))
-
-            # make sure that mdata is the same type as data
-            mdata = xp.asarray(ndimage.median_filter(filt_data, rbox))
-            ndata = xp.where(crarr, mdata, data)
-
-        return ndata, crarr
+        return _cosmicray_median_array(
+            data, in_mask, error_image, thresh, mbox, gbox, rbox, xp
+        )
     elif isinstance(ccd, CCDData):
+        xp = xp or array_api_compat.array_namespace(ccd.data)
 
         # set up the error image
         if error_image is None and ccd.uncertainty is not None:
@@ -2135,13 +2088,10 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
         if ccd.data.shape != error_image.shape:
             raise ValueError("error_image is not the same shape as data.")
 
-        data, crarr = cosmicray_median(
-            ccd.data,
-            error_image=error_image,
-            thresh=thresh,
-            mbox=mbox,
-            gbox=gbox,
-            rbox=rbox,
+        # Pass the CCDData mask along so that masked pixels are excluded from
+        # the detection rather than merely OR-ed into the output mask.
+        data, crarr = _cosmicray_median_array(
+            ccd.data, ccd.mask, error_image, thresh, mbox, gbox, rbox, xp
         )
 
         # create the new ccd data object
@@ -2150,11 +2100,78 @@ def cosmicray_median(ccd, error_image=None, thresh=5, mbox=11, gbox=0, rbox=0, x
         if nccd.mask is None:
             nccd.mask = crarr
         else:
-            nccd.mask = nccd.mask + crarr
+            nccd.mask = nccd.mask | crarr
         return nccd
 
     else:
         raise TypeError("ccd is not an numpy.ndarray or a CCDData object.")
+
+
+def _cosmicray_median_array(data, in_mask, error_image, thresh, mbox, gbox, rbox, xp):
+    """
+    Implementation of `cosmicray_median` for a plain data array plus an
+    optional boolean mask. See `cosmicray_median` for the meaning of the
+    arguments; ``in_mask`` may be `None`.
+    """
+    if in_mask is not None:
+        in_mask = xp.asarray(
+            in_mask, dtype=xp.bool, device=array_api_compat.device(data)
+        )
+
+    if error_image is None:
+        error_image = xp.std(data)
+    elif not isinstance(error_image, float):
+        if not _is_array(error_image):
+            raise TypeError("error_image is not a float or ndarray.")
+
+    if in_mask is None:
+        filt_data = data
+        marr = xp.asarray(ndimage.median_filter(data, size=(mbox, mbox)))
+    else:
+        # Masked input pixels must not contaminate the median filter, so
+        # they are replaced before filtering. The replacement cannot depend
+        # on the masked values themselves (a masked region wider than the
+        # filter box would otherwise just reproduce them), so start from
+        # the mean of the unmasked data, compute the local median, and then
+        # refine once by replacing the masked pixels with that local
+        # median. The original values are kept in the output.
+        keep = ~in_mask
+        n_keep = xp.sum(xp.astype(keep, data.dtype))
+        if float(n_keep) == 0:
+            # Everything is masked, so nothing can be a cosmic ray.
+            return xp.asarray(data, copy=True), xp.zeros_like(in_mask)
+        fill = xp.sum(xp.where(keep, data, 0)) / n_keep
+        filt_data = xp.where(in_mask, fill, data)
+        marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
+        filt_data = xp.where(in_mask, marr, data)
+        marr = xp.asarray(ndimage.median_filter(filt_data, size=(mbox, mbox)))
+
+    # Find the residual image
+    rarr = (filt_data - marr) / error_image
+
+    # identify all sources
+    crarr = rarr > thresh
+
+    # grow the pixels
+    if gbox > 0:
+        crarr = xp.asarray(ndimage.maximum_filter(crarr, gbox))
+
+    if in_mask is not None:
+        # Masked input pixels are never flagged as cosmic rays.
+        crarr = crarr & ~in_mask
+
+    # replace bad pixels in the image
+    ndata = xp.asarray(data, copy=True)
+    if rbox > 0:
+        # Fun fact: scipy.ndimage ignores the mask, so may as well not
+        # bother with it.
+        # data = np.ma.masked_array(data, (crarr == 1))
+
+        # make sure that mdata is the same type as data
+        mdata = xp.asarray(ndimage.median_filter(filt_data, rbox))
+        ndata = xp.where(crarr, mdata, data)
+
+    return ndata, crarr
 
 
 def ccdmask(

--- a/ccdproc/tests/array_escape_baseline.txt
+++ b/ccdproc/tests/array_escape_baseline.txt
@@ -20,6 +20,7 @@ core.py      block_average                numpy.asanyarray  BOUNDARY: astropy.nd
 core.py      block_reduce                 numpy.asanyarray  BOUNDARY: astropy.nddata.block_reduce is numpy-only
 core.py      block_replicate              numpy.asanyarray  BOUNDARY: astropy.nddata.block_replicate is numpy-only
 core.py      cosmicray_median             numpy.asarray     BOUNDARY: scipy.ndimage median_filter/maximum_filter are numpy-only
+core.py      _cosmicray_median_array      numpy.asarray     BOUNDARY: scipy.ndimage median_filter/maximum_filter are numpy-only
 core.py      create_deviation             numpy.asarray     BOUNDARY: astropy CCDData.copy()/StdDevUncertainty are numpy-backed
 core.py      sigma_func                   numpy.asanyarray  BOUNDARY: astropy.stats.median_absolute_deviation is numpy-only
 core.py      subtract_overscan            numpy.asanyarray  BOUNDARY: astropy.modeling fit/evaluation (model= path) is numpy-only

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -477,6 +477,33 @@ def test_cosmicray_median_masked():
     assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
 
 
+def test_cosmicray_median_masked_region_does_not_bias_neighbours():
+    # Regression test for #932: a masked region of very bright pixels must not
+    # raise the local median of the pixels next to it. The region is wider
+    # than the median box, so an adjacent pixel's box is almost half masked;
+    # if the masked values leaked into the median, a marginal cosmic ray next
+    # to the region would be missed.
+    rng = default_rng(seed=1)
+    sigma = 1.0
+    np_data = rng.normal(loc=0, scale=sigma, size=(100, 100))
+    np_mask = np_zeros(np_data.shape, dtype=bool)
+    np_mask[40:61, 40:54] = True
+    np_data[np_mask] = 1e4 * sigma
+    threshold = 5
+    cr_y, cr_x = 50, 54  # immediately to the right of the masked region
+    np_data[cr_y, cr_x] = 1.1 * threshold * sigma
+
+    masked = np_ma_array(np_data, mask=np_mask)
+    ndata, crarr = cosmicray_median(
+        masked, thresh=threshold, mbox=11, error_image=sigma
+    )
+    crarr = np_array(crarr)
+    assert crarr[cr_y, cr_x]
+    assert not crarr[np_mask].any()
+    # the masked pixels come back untouched
+    assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
+
+
 @pytest.mark.backend_xfail(
     "array-api-strict",
     reason="cosmicray_median uses scipy.ndimage.median_filter, which "

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -794,8 +794,11 @@ def test_cosmicray_median_mask_shape_mismatch():
     from ccdproc.core import _cosmicray_median_array
 
     np_data = default_rng(seed=4).normal(size=(20, 20))
+    # Use the compat namespace, as the public function does: plain numpy < 2
+    # has no ``bool`` attribute.
+    np_xp = array_api_compat.array_namespace(np_data)
 
     with pytest.raises(ValueError, match="mask is not the same shape"):
         _cosmicray_median_array(
-            np_data, np_zeros((10, 20), dtype=bool), 1.0, 5, 11, 0, 0, np
+            np_data, np_zeros((10, 20), dtype=bool), 1.0, 5, 11, 0, 0, np_xp
         )

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 import array_api_compat
 import array_api_extra as xpx
 import pytest
 from astropy import units as u
 from astropy.nddata import (
+    CCDData,
     InverseVariance,
     StdDevUncertainty,
     VarianceUncertainty,
@@ -477,7 +480,7 @@ def test_cosmicray_median_masked():
     assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
 
 
-def test_cosmicray_median_masked_region_does_not_bias_neighbours():
+def test_cosmicray_median_masked_region_does_not_bias_neighbors():
     # Regression test for #932: a masked region of very bright pixels must not
     # raise the local median of the pixels next to it. The region is wider
     # than the median box, so an adjacent pixel's box is almost half masked;
@@ -502,6 +505,59 @@ def test_cosmicray_median_masked_region_does_not_bias_neighbours():
     assert not crarr[np_mask].any()
     # the masked pixels come back untouched
     assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
+
+
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+    "requires numpy and fails on a non-default device",
+)
+def test_cosmicray_median_ccddata_masked_region_does_not_bias_neighbors():
+    # Same as the test above, but with the mask carried by a CCDData. The
+    # CCDData branch must forward its mask to the detection rather than only
+    # OR-ing it into the output mask.
+    rng = default_rng(seed=1)
+    sigma = 1.0
+    np_data = rng.normal(loc=0, scale=sigma, size=(100, 100))
+    np_mask = np_zeros(np_data.shape, dtype=bool)
+    np_mask[40:61, 40:54] = True
+    np_data[np_mask] = 1e4 * sigma
+    threshold = 5
+    cr_y, cr_x = 50, 54  # immediately to the right of the masked region
+    np_data[cr_y, cr_x] = 1.1 * threshold * sigma
+
+    ccd = CCDData(
+        xp.asarray(np_data),
+        unit="adu",
+        mask=xp.asarray(np_mask),
+        uncertainty=StdDevUncertainty(xp.asarray(np_data * 0.0 + sigma)),
+    )
+    nccd = cosmicray_median(ccd, thresh=threshold, mbox=11)
+    out_mask = np_array(nccd.mask)
+    assert out_mask[cr_y, cr_x]
+    assert out_mask[np_mask].all()
+    expected = np_mask.copy()
+    expected[cr_y, cr_x] = True
+    assert (out_mask == expected).all()
+    # the masked pixels come back untouched
+    assert_allclose(np_array(nccd.data)[np_mask], np_data[np_mask])
+
+
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+    "requires numpy and fails on a non-default device",
+)
+def test_cosmicray_median_all_masked():
+    # Every pixel masked: nothing is flagged, data are returned unchanged and
+    # no warning (e.g. from a 0/0 in the fill value) is emitted.
+    np_data = default_rng(seed=3).normal(size=(20, 20))
+    data = np_ma_array(np_data, mask=np_zeros(np_data.shape, dtype=bool) | True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=1.0)
+    assert not np_array(crarr).any()
+    assert_allclose(np_array(ndata), np_data)
 
 
 @pytest.mark.backend_xfail(

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -454,30 +454,34 @@ def test_cosmicray_median_ccddata():
     reason="cosmicray_median uses scipy.ndimage.median_filter, which "
     "requires numpy and fails on a non-default device",
 )
-def test_cosmicray_median_masked():
+@pytest.mark.parametrize("masked", ["none", "some", "all"])
+def test_cosmicray_median_masked(masked):
     # Regression test for #932: an input mask used to be silently ignored.
-    # Mask a subset of the injected cosmic-ray pixels; those must NOT be
-    # flagged, while the unmasked cosmic rays must still be detected.
+    # "none": a masked array with nomask behaves like a plain array.
+    # "some": mask a subset of the injected cosmic rays; those must NOT be
+    #         flagged while the rest are.
+    # "all":  nothing is flagged, and no warning (e.g. 0/0) is emitted.
     ccd_data = ccd_data_func(data_scale=DATA_SCALE)
-    threshold = 5
-    crrays = add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
-    n_masked = NCRAYS // 3
+    crrays = add_cosmicrays(ccd_data, DATA_SCALE, 5, ncrays=NCRAYS)
     np_data = np_array(ccd_data.data)
     np_mask = np_zeros(np_data.shape, dtype=bool)
-    for y, x in crrays[:n_masked]:
-        np_mask[y, x] = True
-    n_masked_unique = int(np_mask.sum())
+    if masked == "some":
+        for y, x in crrays[: NCRAYS // 3]:
+            np_mask[y, x] = True
+    elif masked == "all":
+        np_mask[:] = True
 
-    data = np_ma_array(np_data, mask=np_mask)
-    ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=DATA_SCALE)
+    data = np_ma_array(np_data, mask=np_mask if masked != "none" else np_ma_nomask)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=DATA_SCALE)
 
     crarr = np_array(crarr)
-    # no masked pixel is flagged as a cosmic ray...
+    # no masked pixel is flagged, every unmasked cosmic ray is, nothing else is
     assert not crarr[np_mask].any()
-    # ...and all of the unmasked cosmic rays are still detected
-    for y, x in crrays[n_masked:]:
-        assert crarr[y, x]
-    assert crarr.sum() == NCRAYS - n_masked_unique
+    for y, x in crrays:
+        assert crarr[y, x] == (not np_mask[y, x])
+    assert crarr.sum() == sum(not np_mask[y, x] for y, x in crrays)
     # masked pixels are returned unchanged
     assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
 
@@ -498,129 +502,56 @@ def _masked_column_image(seed=1, sigma=1.0):
     return np_data, np_mask, crays
 
 
-def test_cosmicray_median_masked_gbox_and_rbox():
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+    "requires numpy and fails on a non-default device",
+)
+# (The CCDData branch takes its error image from the uncertainty.)
+@pytest.mark.parametrize(
+    "kind,error_image",
+    [("masked_array", 1.0), ("masked_array", None), ("ccddata", None)],
+)
+def test_cosmicray_median_masked_column(kind, error_image):
     # Masked pixels are never flagged, not even by the gbox growth step,
-    # whether the growth would start from a masked pixel (the saturated
-    # column has an enormous residual) or spread into one from a cosmic ray
-    # next to the column; and with rbox > 0 masked pixels are returned
-    # unchanged while the cosmic rays are replaced.
+    # whether growth would start from a masked pixel (the saturated column
+    # has an enormous residual) or spread into one from the cosmic ray next
+    # to the column. With rbox > 0 the cosmic rays are replaced while masked
+    # pixels are returned unchanged. With error_image=None on a masked array
+    # the noise is estimated from the unmasked pixels only; if the saturated
+    # column were included nothing would be detected. For a CCDData the
+    # mask is forwarded to the detection and the output mask is the union of
+    # the input mask and the (grown) cosmic rays.
     np_data, np_mask, crays = _masked_column_image()
-    masked = np_ma_array(np_data, mask=np_mask)
-    ndata, crarr = cosmicray_median(
-        masked, thresh=5, mbox=11, gbox=3, rbox=5, error_image=1.0
+    if kind == "masked_array":
+        ccd = np_ma_array(np_data, mask=np_mask)
+    else:
+        ccd = CCDData(
+            xp.asarray(np_data, device=xp_device),
+            unit="adu",
+            mask=np_mask,
+            uncertainty=StdDevUncertainty(xp.ones_like(xp.asarray(np_data))),
+        )
+    result = cosmicray_median(
+        ccd, thresh=5, mbox=11, gbox=3, rbox=5, error_image=error_image
     )
+    if kind == "masked_array":
+        ndata, crarr = result
+    else:
+        out_mask = np_array(result.mask)
+        assert out_mask[np_mask].all()
+        ndata, crarr = result.data, out_mask & ~np_mask
     crarr = np_array(crarr)
+    ndata = np_array(ndata)
+
     assert not crarr[np_mask].any()
     for y, x in crays:
         assert crarr[y, x]
     # growth happened around the cosmic rays (3x3 minus the masked column)
     assert crarr.sum() == 9 + 6
-    ndata = np_array(ndata)
     assert_allclose(ndata[np_mask], np_data[np_mask])
     for y, x in crays:
         assert abs(ndata[y, x] - 100.0) < 5
-
-
-def test_cosmicray_median_masked_error_image_none():
-    # With error_image=None the noise is estimated from the unmasked pixels
-    # only; if the saturated column were included, the threshold would be
-    # thousands of sigma and nothing would be detected.
-    np_data, np_mask, crays = _masked_column_image()
-    masked = np_ma_array(np_data, mask=np_mask)
-    ndata, crarr = cosmicray_median(masked, thresh=5, mbox=11, error_image=None)
-    crarr = np_array(crarr)
-    for y, x in crays:
-        assert crarr[y, x]
-    assert not crarr[np_mask].any()
-
-
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
-    "requires numpy and fails on a non-default device",
-)
-def test_cosmicray_median_ccddata_masked_gbox():
-    # The CCDData branch forwards its mask to the detection: the masked
-    # column must not be flagged nor seed growth, and the output mask is the
-    # union of the input mask and the (grown) cosmic rays.
-    np_data, np_mask, crays = _masked_column_image()
-    ccd = CCDData(
-        xp.asarray(np_data, device=xp_device),
-        unit="adu",
-        mask=np_mask,
-        uncertainty=StdDevUncertainty(xp.ones_like(xp.asarray(np_data))),
-    )
-    nccd = cosmicray_median(ccd, thresh=5, mbox=11, gbox=3)
-    out_mask = np_array(nccd.mask)
-    assert out_mask[np_mask].all()
-    for y, x in crays:
-        assert out_mask[y, x]
-    assert out_mask.sum() == np_mask.sum() + 9 + 6
-    assert_allclose(np_array(nccd.data), np_data)
-
-
-def test_cosmicray_median_all_masked():
-    # Every pixel masked: nothing is flagged, data are returned unchanged and
-    # no warning (e.g. from a 0/0 in the fill value) is emitted.
-    np_data = default_rng(seed=3).normal(size=(20, 20))
-    data = np_ma_array(np_data, mask=np_zeros(np_data.shape, dtype=bool) | True)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=1.0)
-    assert not np_array(crarr).any()
-    assert_allclose(np_array(ndata), np_data)
-
-
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
-    "requires numpy and fails on a non-default device",
-)
-def test_cosmicray_median_masked_nomask():
-    # A masked array with no mask set behaves like a plain array.
-    ccd_data = ccd_data_func(data_scale=DATA_SCALE)
-    threshold = 5
-    add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
-    data = np_ma_array(np_array(ccd_data.data))
-    assert data.mask is np_ma_nomask
-    ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=DATA_SCALE)
-    assert crarr.sum() == NCRAYS
-
-
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
-    "requires numpy and fails on a non-default device",
-)
-def test_cosmicray_median_ccddata_masked():
-    # A CCDData input with a mask: the output mask is the union of the input
-    # mask and the detected cosmic rays. (This cannot distinguish a masked
-    # cosmic ray that is flagged from one that is not; see
-    # test_cosmicray_median_ccddata_masked_gbox for that.)
-    ccd_data = ccd_data_func(data_scale=DATA_SCALE)
-    threshold = 5
-    crrays = add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
-    np_mask = np_zeros(ccd_data.shape, dtype=bool)
-    # mask a few of the cosmic rays and a block of ordinary pixels
-    for y, x in crrays[:5]:
-        np_mask[y, x] = True
-    np_mask[2:6, 3:9] = True
-    ccd_data.mask = xp.asarray(np_mask)
-    ccd_data.uncertainty = StdDevUncertainty(ccd_data.data * 0.0 + DATA_SCALE)
-
-    nccd = cosmicray_median(ccd_data, thresh=5, mbox=11, error_image=None)
-
-    out_mask = np_array(nccd.mask)
-    # every input-masked pixel is still masked
-    assert out_mask[np_mask].all()
-    # every cosmic ray is masked
-    for y, x in crrays:
-        assert out_mask[y, x]
-    # and nothing else is
-    expected = np_mask.copy()
-    for y, x in crrays:
-        expected[y, x] = True
-    assert (out_mask == expected).all()
 
 
 @pytest.mark.backend_xfail(

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -10,7 +10,10 @@ from astropy.nddata import (
     VarianceUncertainty,
 )
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from numpy import array as np_array
+from numpy import zeros as np_zeros
 from numpy.ma import array as np_ma_array
+from numpy.ma import nomask as np_ma_nomask
 from numpy.random import default_rng
 from numpy.testing import assert_allclose
 
@@ -50,6 +53,7 @@ def add_cosmicrays(data, scale, threshold, ncrays=NCRAYS):
         y, x = crrays[i]
         data_as_np[y, x] = crflux[i]
     data.data = xp.asarray(data_as_np)
+    return crrays
 
 
 @pytest.mark.backend_xfail(
@@ -446,14 +450,81 @@ def test_cosmicray_median_ccddata():
     "requires numpy and fails on a non-default device",
 )
 def test_cosmicray_median_masked():
+    # Regression test for #932: an input mask used to be silently ignored.
+    # Mask a subset of the injected cosmic-ray pixels; those must NOT be
+    # flagged, while the unmasked cosmic rays must still be detected.
+    ccd_data = ccd_data_func(data_scale=DATA_SCALE)
+    threshold = 5
+    crrays = add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
+    n_masked = NCRAYS // 3
+    np_data = np_array(ccd_data.data)
+    np_mask = np_zeros(np_data.shape, dtype=bool)
+    for y, x in crrays[:n_masked]:
+        np_mask[y, x] = True
+    n_masked_unique = int(np_mask.sum())
+
+    data = np_ma_array(np_data, mask=np_mask)
+    ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=DATA_SCALE)
+
+    crarr = np_array(crarr)
+    # no masked pixel is flagged as a cosmic ray...
+    assert not crarr[np_mask].any()
+    # ...and all of the unmasked cosmic rays are still detected
+    for y, x in crrays[n_masked:]:
+        assert crarr[y, x]
+    assert crarr.sum() == NCRAYS - n_masked_unique
+    # masked pixels are returned unchanged
+    assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
+
+
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+    "requires numpy and fails on a non-default device",
+)
+def test_cosmicray_median_masked_nomask():
+    # A masked array with no mask set behaves like a plain array.
     ccd_data = ccd_data_func(data_scale=DATA_SCALE)
     threshold = 5
     add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
-    data = np_ma_array(ccd_data.data, mask=(ccd_data.data > -1e6))
+    data = np_ma_array(np_array(ccd_data.data))
+    assert data.mask is np_ma_nomask
     ndata, crarr = cosmicray_median(data, thresh=5, mbox=11, error_image=DATA_SCALE)
-
-    # check the number of cosmic rays detected
     assert crarr.sum() == NCRAYS
+
+
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+    "requires numpy and fails on a non-default device",
+)
+def test_cosmicray_median_ccddata_masked():
+    # A CCDData input with a mask: the output mask is the union of the input
+    # mask and the detected cosmic rays.
+    ccd_data = ccd_data_func(data_scale=DATA_SCALE)
+    threshold = 5
+    crrays = add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)
+    np_mask = np_zeros(ccd_data.shape, dtype=bool)
+    # mask a few of the cosmic rays and a block of ordinary pixels
+    for y, x in crrays[:5]:
+        np_mask[y, x] = True
+    np_mask[2:6, 3:9] = True
+    ccd_data.mask = xp.asarray(np_mask)
+    ccd_data.uncertainty = StdDevUncertainty(ccd_data.data * 0.0 + DATA_SCALE)
+
+    nccd = cosmicray_median(ccd_data, thresh=5, mbox=11, error_image=None)
+
+    out_mask = np_array(nccd.mask)
+    # every input-masked pixel is still masked
+    assert out_mask[np_mask].all()
+    # every cosmic ray is masked
+    for y, x in crrays:
+        assert out_mask[y, x]
+    # and nothing else is
+    expected = np_mask.copy()
+    for y, x in crrays:
+        expected[y, x] = True
+    assert (out_mask == expected).all()
 
 
 @pytest.mark.backend_xfail(

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -786,3 +786,16 @@ def test_cosmicray_lacosmic_pssl_does_not_fail():
     # Note that to get this to succeed reliably meant tuning
     # both sigclip and the threshold
     assert nccd_data.mask.sum() == NCRAYS
+
+
+def test_cosmicray_median_mask_shape_mismatch():
+    # CCDData and MaskedArray validate the mask shape themselves, so exercise
+    # the shared helper directly.
+    from ccdproc.core import _cosmicray_median_array
+
+    np_data = default_rng(seed=4).normal(size=(20, 20))
+
+    with pytest.raises(ValueError, match="mask is not the same shape"):
+        _cosmicray_median_array(
+            np_data, np_zeros((10, 20), dtype=bool), 1.0, 5, 11, 0, 0, np
+        )

--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -22,6 +22,7 @@ from numpy.random import default_rng
 from numpy.testing import assert_allclose
 
 # Set up the array library to be used in tests
+from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
 from ccdproc.core import (
     background_deviation_box,
@@ -481,31 +482,56 @@ def test_cosmicray_median_masked():
     assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
 
 
-def test_cosmicray_median_masked_region_does_not_bias_neighbors():
-    # Regression test for #932: a masked region of very bright pixels must not
-    # raise the local median of the pixels next to it. The region is wider
-    # than the median box, so an adjacent pixel's box is almost half masked;
-    # if the masked values leaked into the median, a marginal cosmic ray next
-    # to the region would be missed.
-    rng = default_rng(seed=1)
-    sigma = 1.0
-    np_data = rng.normal(loc=0, scale=sigma, size=(100, 100))
+def _masked_column_image(seed=1, sigma=1.0):
+    """
+    A flat noise image with a masked, saturated column and two cosmic rays:
+    one well away from the column and one immediately next to it.
+    """
+    rng = default_rng(seed=seed)
+    np_data = rng.normal(loc=100.0, scale=sigma, size=(60, 60))
     np_mask = np_zeros(np_data.shape, dtype=bool)
-    np_mask[40:61, 40:54] = True
-    np_data[np_mask] = 1e4 * sigma
-    threshold = 5
-    cr_y, cr_x = 50, 54  # immediately to the right of the masked region
-    np_data[cr_y, cr_x] = 1.1 * threshold * sigma
+    np_mask[:, 30] = True
+    np_data[np_mask] = 65535.0
+    crays = [(10, 10), (40, 31)]
+    for y, x in crays:
+        np_data[y, x] = 100.0 + 20 * sigma
+    return np_data, np_mask, crays
 
+
+def test_cosmicray_median_masked_gbox_and_rbox():
+    # Masked pixels are never flagged, not even by the gbox growth step,
+    # whether the growth would start from a masked pixel (the saturated
+    # column has an enormous residual) or spread into one from a cosmic ray
+    # next to the column; and with rbox > 0 masked pixels are returned
+    # unchanged while the cosmic rays are replaced.
+    np_data, np_mask, crays = _masked_column_image()
     masked = np_ma_array(np_data, mask=np_mask)
     ndata, crarr = cosmicray_median(
-        masked, thresh=threshold, mbox=11, error_image=sigma
+        masked, thresh=5, mbox=11, gbox=3, rbox=5, error_image=1.0
     )
     crarr = np_array(crarr)
-    assert crarr[cr_y, cr_x]
     assert not crarr[np_mask].any()
-    # the masked pixels come back untouched
-    assert_allclose(np_array(ndata)[np_mask], np_data[np_mask])
+    for y, x in crays:
+        assert crarr[y, x]
+    # growth happened around the cosmic rays (3x3 minus the masked column)
+    assert crarr.sum() == 9 + 6
+    ndata = np_array(ndata)
+    assert_allclose(ndata[np_mask], np_data[np_mask])
+    for y, x in crays:
+        assert abs(ndata[y, x] - 100.0) < 5
+
+
+def test_cosmicray_median_masked_error_image_none():
+    # With error_image=None the noise is estimated from the unmasked pixels
+    # only; if the saturated column were included, the threshold would be
+    # thousands of sigma and nothing would be detected.
+    np_data, np_mask, crays = _masked_column_image()
+    masked = np_ma_array(np_data, mask=np_mask)
+    ndata, crarr = cosmicray_median(masked, thresh=5, mbox=11, error_image=None)
+    crarr = np_array(crarr)
+    for y, x in crays:
+        assert crarr[y, x]
+    assert not crarr[np_mask].any()
 
 
 @pytest.mark.backend_xfail(
@@ -513,42 +539,26 @@ def test_cosmicray_median_masked_region_does_not_bias_neighbors():
     reason="cosmicray_median uses scipy.ndimage.median_filter, which "
     "requires numpy and fails on a non-default device",
 )
-def test_cosmicray_median_ccddata_masked_region_does_not_bias_neighbors():
-    # Same as the test above, but with the mask carried by a CCDData. The
-    # CCDData branch must forward its mask to the detection rather than only
-    # OR-ing it into the output mask.
-    rng = default_rng(seed=1)
-    sigma = 1.0
-    np_data = rng.normal(loc=0, scale=sigma, size=(100, 100))
-    np_mask = np_zeros(np_data.shape, dtype=bool)
-    np_mask[40:61, 40:54] = True
-    np_data[np_mask] = 1e4 * sigma
-    threshold = 5
-    cr_y, cr_x = 50, 54  # immediately to the right of the masked region
-    np_data[cr_y, cr_x] = 1.1 * threshold * sigma
-
+def test_cosmicray_median_ccddata_masked_gbox():
+    # The CCDData branch forwards its mask to the detection: the masked
+    # column must not be flagged nor seed growth, and the output mask is the
+    # union of the input mask and the (grown) cosmic rays.
+    np_data, np_mask, crays = _masked_column_image()
     ccd = CCDData(
-        xp.asarray(np_data),
+        xp.asarray(np_data, device=xp_device),
         unit="adu",
-        mask=xp.asarray(np_mask),
-        uncertainty=StdDevUncertainty(xp.asarray(np_data * 0.0 + sigma)),
+        mask=np_mask,
+        uncertainty=StdDevUncertainty(xp.ones_like(xp.asarray(np_data))),
     )
-    nccd = cosmicray_median(ccd, thresh=threshold, mbox=11)
+    nccd = cosmicray_median(ccd, thresh=5, mbox=11, gbox=3)
     out_mask = np_array(nccd.mask)
-    assert out_mask[cr_y, cr_x]
     assert out_mask[np_mask].all()
-    expected = np_mask.copy()
-    expected[cr_y, cr_x] = True
-    assert (out_mask == expected).all()
-    # the masked pixels come back untouched
-    assert_allclose(np_array(nccd.data)[np_mask], np_data[np_mask])
+    for y, x in crays:
+        assert out_mask[y, x]
+    assert out_mask.sum() == np_mask.sum() + 9 + 6
+    assert_allclose(np_array(nccd.data), np_data)
 
 
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
-    "requires numpy and fails on a non-default device",
-)
 def test_cosmicray_median_all_masked():
     # Every pixel masked: nothing is flagged, data are returned unchanged and
     # no warning (e.g. from a 0/0 in the fill value) is emitted.
@@ -584,7 +594,9 @@ def test_cosmicray_median_masked_nomask():
 )
 def test_cosmicray_median_ccddata_masked():
     # A CCDData input with a mask: the output mask is the union of the input
-    # mask and the detected cosmic rays.
+    # mask and the detected cosmic rays. (This cannot distinguish a masked
+    # cosmic ray that is flagged from one that is not; see
+    # test_cosmicray_median_ccddata_masked_gbox for that.)
     ccd_data = ccd_data_func(data_scale=DATA_SCALE)
     threshold = 5
     crrays = add_cosmicrays(ccd_data, DATA_SCALE, threshold, ncrays=NCRAYS)


### PR DESCRIPTION
`cosmicray_median` had dead code in its array branch: `if hasattr(ccd, "mask"): data = ccd.data` was immediately overwritten by `data = xp.asarray(ccd)`, which silently drops the mask of a `numpy.ma.MaskedArray` (backend-dependently), so an input mask was ignored.

This PR makes the mask handling deliberate and backend-independent, with intentionally narrow semantics:

- the mask is extracted *before* the array conversion (handling `numpy.ma.nomask`), and the `CCDData` branch passes `ccd.mask` straight through to a shared `_cosmicray_median_array` helper instead of round-tripping through the array branch;
- masked pixels are never flagged as cosmic rays — the mask is applied before the `gbox` growth step (so masked pixels cannot seed growth) and after it (so growth cannot extend into them);
- masked pixels are returned unchanged in the output data, including with `rbox > 0`;
- when `error_image` is `None`, the noise is estimated from the unmasked pixels only, so a masked saturated column cannot inflate the threshold and switch detection off;
- an all-masked input returns early (no 0/0 warnings);
- the `CCDData` output mask is built with `|` rather than `+`.

The median filter itself still runs on the data as-is: `scipy.ndimage` knows nothing about masks, so bright masked pixels can still influence the local median of their neighbors. That is documented in the Notes, and making the median mask-aware is #984 (an earlier revision of this branch attempted an approximate version and it was not good enough).

Tests: `test_cosmicray_median_masked` now masks a subset of the injected cosmic rays and asserts those are not flagged while the rest are (fails on `main`); new tests cover `gbox`/`rbox` with a mask (masked array and `CCDData`), `error_image=None` with a masked saturated column, all-masked input, `nomask`, and the `CCDData` union mask. Removing the mask guard or the masked noise estimate is caught by the tests.

Test matrix (branch merged with current `main`): numpy 392 passed; dask 381 passed, escape ratchet clean; jax (x64) `test_cosmicray.py` 46 passed / 2 xfailed; array-api-strict `test_cosmicray.py` 12 passed / 36 xfailed, no XPASS.

Fixes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA
