### PR TITLE
Fix pre-commit (black 26) failure on main

### DIFF
--- a/ccdproc/__init__.py
+++ b/ccdproc/__init__.py
@@ -4,6 +4,7 @@ The ccdproc package is a collection of code that will be helpful in basic CCD
 processing. These steps will allow reduction of basic CCD data as either a
 stand-alone processing or as part of a pipeline.
 """
+
 try:
     from ._version import version as __version__
 except ImportError:


### PR DESCRIPTION
pre-commit.ci has been red on \`main\` since the black 26.5.1 autoupdate in #919: black now wants a blank line after the module docstring in \`ccdproc/__init__.py\`. This is the only change it asks for; \`pre-commit run --all-files\` is clean with it.

The same one-line commit has been cherry-picked onto the open array-API PRs (#972–#980) so they pass pre-commit.ci independently; the hunks are identical so they merge cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTN9DnPnLKK2u7knnMJ2gA