### PR TITLE
Upload coverage from the jax and dask CI jobs

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -40,12 +40,17 @@ jobs:
             os: ubuntu-latest
             python: '3.12'
             tox_env: 'py312-test-alldeps-cov'
+            codecov_flags: 'numpy'
 
-          # Test non-numpy array libraries
+          # Test non-numpy array libraries. These also upload coverage:
+          # the array-API-only code paths (wrapper classes, spec-only
+          # fallbacks) are never executed by the numpy coverage job above,
+          # so without these uploads codecov reports them as uncovered.
           - name: 'ubuntu-py313-jax'
             os: ubuntu-latest
             python: '3.13'
-            tox_env: 'py313-jax'
+            tox_env: 'py313-jax-cov'
+            codecov_flags: 'jax'
 
           # Move bottleneck test a test without coverage
           - name: 'ubuntu-py312-bottleneck'
@@ -71,7 +76,8 @@ jobs:
           - name: 'ubuntu-py312-dask-escape-baseline'
             os: ubuntu-latest
             python: '3.12'
-            tox_env: 'py312-alldeps-dask-enforce'
+            tox_env: 'py312-alldeps-dask-enforce-cov'
+            codecov_flags: 'dask'
 
           - name: 'windows-py312'
             os: windows-latest
@@ -123,6 +129,8 @@ jobs:
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+      with:
+        flags: ${{ matrix.codecov_flags }}
 
   # The strict array-API job is in its own matrix so that its failures --
   # expected until the remaining array-API bugs are fixed -- stay visible


### PR DESCRIPTION
Coverage is currently uploaded only from `ubuntu-py312-coverage`, which runs with numpy. Code that executes only under a non-numpy array namespace — the `CCDData` wrapper classes in `_ccddata_wrapper_for_array_api.py`, spec-only fallbacks like the one in #978 — is therefore never seen by codecov, and `codecov/patch` fails on every array-API PR (#975, #978, #980 are red only for this reason).

This adds the existing `cov` tox factor to the jax job (`py313-jax-cov`) and the dask escape-baseline job (`py312-alldeps-dask-enforce-cov`) and uploads from those as well. Uploads are tagged with codecov flags (`numpy`, `jax`, `dask`) so the per-backend reports can be told apart; codecov merges them per commit.

Verified locally: `tox -e py313-jax-cov` runs the full suite (377 passed, 40 skipped, 9 xfailed) and writes `coverage.xml` with `_ccddata_wrapper_for_array_api.py` at 85% line coverage — that file is ~0% on the numpy job.

Intended to merge before #975 / #978 / #980 so they can be rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQMJZUaaxfqGDk41GLSaFK
