### PR TITLE
Make combiner internals array-API compatible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,13 +39,9 @@ Bug Fixes
   the array API standard and use them in ``Combiner.average_combine`` and
   ``Combiner.sum_combine`` when the selected array namespace has no
   ``nansum``/``nanmean``/``nanstd``, instead of raising ``RuntimeError``. [#986]
-- Make the ``Combiner`` combination internals array-API compatible: masked
-  entries are detected and counted with ``xp.any``/``xp.count_nonzero``
-  instead of numpy-only array methods, image counts no longer rely on arrays
-  implementing ``len()`` and are promoted to floating point before entering
-  the uncertainty calculation, mask dtypes use the namespace's ``bool``, and
-  ``combine()`` sizes images for ``mem_limit`` from the element count and
-  dtype width instead of the non-standard ``nbytes``. [#988]
+- Make the ``Combiner`` combination internals array-API compatible and size
+  images for ``mem_limit`` from the element count and dtype width instead of
+  the non-standard ``nbytes``. [#988]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Build the ``Combiner`` data and mask arrays with ``xp.stack`` instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,13 @@ Bug Fixes
   the array API standard and use them in ``Combiner.average_combine`` and
   ``Combiner.sum_combine`` when the selected array namespace has no
   ``nansum``/``nanmean``/``nanstd``, instead of raising ``RuntimeError``. [#986]
+- Make the ``Combiner`` combination internals array-API compatible: masked
+  entries are detected and counted with ``xp.any``/``xp.count_nonzero``
+  instead of numpy-only array methods, image counts no longer rely on arrays
+  implementing ``len()`` and are promoted to floating point before entering
+  the uncertainty calculation, mask dtypes use the namespace's ``bool``, and
+  ``combine()`` sizes images for ``mem_limit`` from the element count and
+  dtype width instead of the non-standard ``nbytes``. [#988]
 - Make ``flat_correct`` and ``ccdmask`` use functional array updates so they
   support immutable array-API backends. [#956]
 - Build the ``Combiner`` data and mask arrays with ``xp.stack`` instead of

--- a/ccdproc/_ccddata_wrapper_for_array_api.py
+++ b/ccdproc/_ccddata_wrapper_for_array_api.py
@@ -21,7 +21,7 @@ class _NDDataArray(NDDataArray):
         xp = array_api_compat.array_namespace(self.data)
         # Check that value is not either type of null mask.
         if (value is not None) and (value is not np.ma.nomask):
-            mask = xp.asarray(value, dtype=bool)
+            mask = xp.asarray(value, dtype=xp.bool)
             if mask.shape != self.data.shape:
                 raise ValueError(
                     f"dimensions of mask {mask.shape} and data "
@@ -163,7 +163,7 @@ class _CCDDataWrapperForArrayAPI(CCDData):
         xp = array_api_compat.array_namespace(self.data)
         # Check that value is not either type of null mask.
         if (value is not None) and (value is not np.ma.nomask):
-            mask = xp.asarray(value, dtype=bool)
+            mask = xp.asarray(value, dtype=xp.bool)
             if mask.shape != self.data.shape:
                 raise ValueError(
                     f"dimensions of mask {mask.shape} and data "

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -514,7 +514,7 @@ class Combiner:
         xp = self._xp
 
         # Get the data as an unmasked array with masked values filled as NaN
-        if self._data_arr_mask.any():
+        if xp.any(self._data_arr_mask):
             # Use array_api_extra so that we can use at with all array libraries
             data = xpx.at(data)[self._data_arr_mask].set(xp.nan)
         else:
@@ -533,9 +533,9 @@ class Combiner:
             combo_func = default_func
             # Subtitute NaN for masked entries
             data = self._get_nan_substituted_data(data)
-            masked_values = xp.isnan(data).sum(axis=0)
+            masked_values = xp.count_nonzero(xp.isnan(data), axis=0)
         else:
-            masked_values = self._data_arr_mask.sum(axis=0)
+            masked_values = xp.count_nonzero(self._data_arr_mask, axis=0)
             combo_func = user_func
 
         return data, masked_values, combo_func
@@ -589,7 +589,7 @@ class Combiner:
         medianed = median_func(data, axis=0)
 
         # set the mask
-        mask = masked_values == len(self._data_arr)
+        mask = masked_values == self._data_arr.shape[0]
 
         # set the uncertainty
 
@@ -608,7 +608,9 @@ class Combiner:
         # in the data.
         uncertainty = xp.asarray(uncertainty)
         # Divide uncertainty by the number of pixel (#309)
-        uncertainty = uncertainty / xp.sqrt(len(self._data_arr) - masked_values)
+        uncertainty = uncertainty / xp.sqrt(
+            xp.astype(self._data_arr.shape[0] - masked_values, xp.float64)
+        )
 
         # create the combined image with a dtype matching the combiner
         combined_image = CCDData(
@@ -619,7 +621,7 @@ class Combiner:
         )
 
         # update the meta data
-        combined_image.meta["NCOMBINE"] = len(self._data_arr)
+        combined_image.meta["NCOMBINE"] = self._data_arr.shape[0]
 
         # return the combined image
         return combined_image
@@ -632,7 +634,7 @@ class Combiner:
         xp = xp or array_api_compat.array_namespace(data)
         if self.weights.shape != data.shape:
             # Add extra axes to the weights for broadcasting
-            weights = xp.reshape(self.weights, [len(self.weights), 1, 1])
+            weights = xp.reshape(self.weights, (self.weights.shape[0], 1, 1))
         else:
             weights = self.weights
 
@@ -709,12 +711,14 @@ class Combiner:
 
         # calculate the mask
 
-        mask = masked_values == len(self._data_arr)
+        mask = masked_values == self._data_arr.shape[0]
 
         # set up the deviation
         uncertainty = uncertainty_func(data, axis=0)
         # Divide uncertainty by the number of pixel (#309)
-        uncertainty = uncertainty / xp.sqrt(len(data) - masked_values)
+        uncertainty = uncertainty / xp.sqrt(
+            xp.astype(data.shape[0] - masked_values, xp.float64)
+        )
         # Make sure the uncertainty is an array in the combiner's namespace
         uncertainty = xp.asarray(uncertainty)
 
@@ -727,7 +731,7 @@ class Combiner:
         )
 
         # update the meta data
-        combined_image.meta["NCOMBINE"] = len(data)
+        combined_image.meta["NCOMBINE"] = data.shape[0]
 
         # return the combined image
         return combined_image
@@ -783,16 +787,18 @@ class Combiner:
             summed = sum_func(data, axis=0)
 
         # set up the mask
-        mask = masked_values == len(self._data_arr)
+        mask = masked_values == self._data_arr.shape[0]
 
         # set up the deviation
         uncertainty = uncertainty_func(data, axis=0)
         # Divide uncertainty by the number of pixel (#309)
-        uncertainty = uncertainty / xp.sqrt(len(data) - masked_values)
+        uncertainty = uncertainty / xp.sqrt(
+            xp.astype(data.shape[0] - masked_values, xp.float64)
+        )
         # Make sure the uncertainty is an array in the combiner's namespace
         uncertainty = xp.asarray(uncertainty)
         # Multiply uncertainty by square root of the number of images
-        uncertainty = uncertainty * (len(data) - masked_values)
+        uncertainty = uncertainty * xp.astype(data.shape[0] - masked_values, xp.float64)
 
         # create the combined image with a dtype that matches the combiner
         combined_image = CCDData(
@@ -803,7 +809,7 @@ class Combiner:
         )
 
         # update the meta data
-        combined_image.meta["NCOMBINE"] = len(self._data_arr)
+        combined_image.meta["NCOMBINE"] = self._data_arr.shape[0]
 
         # return the combined image
         return combined_image
@@ -836,28 +842,45 @@ def _calculate_step_sizes(x_size, y_size, num_chunks):
     return xstep, ystep
 
 
+def _array_size_in_bytes(arr):
+    # ``nbytes`` is not part of the array API standard, so get the size from
+    # the element count and the dtype's bit width instead. ``finfo``/``iinfo``
+    # report the bit width of a single component, so complex dtypes need a
+    # factor of two.
+    xp = array_api_compat.array_namespace(arr)
+    dtype = arr.dtype
+    if xp.isdtype(dtype, "bool"):
+        bits = 8
+    elif xp.isdtype(dtype, "integral"):
+        bits = xp.iinfo(dtype).bits
+    elif xp.isdtype(dtype, "complex floating"):
+        bits = 2 * xp.finfo(dtype).bits
+    else:
+        bits = xp.finfo(dtype).bits
+    return array_api_compat.size(arr) * bits // 8
+
+
 def _calculate_size_of_image(ccd):
     # If uncertainty_func is given for combine this will create an uncertainty
     # even if the originals did not have one. In that case we need to create
     # an empty placeholder.
 
-    size_of_an_img = ccd.data.nbytes
+    size_of_an_img = _array_size_in_bytes(ccd.data)
     try:
-        size_of_an_img += ccd.uncertainty.array.nbytes
+        size_of_an_img += _array_size_in_bytes(ccd.uncertainty.array)
     # In case uncertainty is None it has no "array" and in case the "array" is
-    # not a numpy array:
-    except AttributeError:
+    # not an array at all:
+    except (AttributeError, TypeError):
         pass
-    # Mask is enforced to be a numpy.array across astropy versions
     if ccd.mask is not None:
-        size_of_an_img += ccd.mask.nbytes
-    # flags is not necessarily a numpy array so do not fail with an
-    # AttributeError in case something was set!
+        size_of_an_img += _array_size_in_bytes(ccd.mask)
+    # flags is not necessarily an array so do not fail in case something
+    # was set!
     # TODO: Flags are not taken into account in Combiner. This number is added
     #       nevertheless for future compatibility.
     try:
-        size_of_an_img += ccd.flags.nbytes
-    except AttributeError:
+        size_of_an_img += _array_size_in_bytes(ccd.flags)
+    except (AttributeError, TypeError):
         pass
 
     return size_of_an_img

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -867,14 +867,22 @@ def test_combine_average_ccddata():
 
 # combine() sizes images without ``.nbytes``, which not every array library
 # provides; check the count against the known element sizes.
-def test_calculate_size_of_image():
+@pytest.mark.parametrize(
+    "dtype,element_size",
+    [
+        (xp.float32, 4),
+        (xp.complex64, 8),
+        (xp.complex128, 16),
+    ],
+)
+def test_calculate_size_of_image(dtype, element_size):
     ccd = CCDData(
-        xp.zeros((7, 5), dtype=xp.float32),
+        xp.zeros((7, 5), dtype=dtype),
         unit=u.adu,
         mask=xp.zeros((7, 5), dtype=xp.bool),
     )
-    # float32 data (4 bytes) plus bool mask (1 byte)
-    assert _calculate_size_of_image(ccd) == 7 * 5 * (4 + 1)
+    # data (element_size bytes) plus bool mask (1 byte)
+    assert _calculate_size_of_image(ccd) == 7 * 5 * (element_size + 1)
 
 
 # test combiner convenience function reads fits file and

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -17,6 +17,7 @@ from ccdproc import create_deviation
 from ccdproc._nanfuncs import nanmean, nanmedian, nanstd, nansum
 from ccdproc.combiner import (
     Combiner,
+    _calculate_size_of_image,
     _calculate_step_sizes,
     _default_average,
     _default_median,
@@ -269,18 +270,11 @@ def test_combiner_stacks_arrays_on_input_device():
     assert float(xp.max(xp.abs(c.scaling - (1.0 + 1 / 16)))) < 1e-6
 
 
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="combine() sizes the image with .nbytes, which array-api-strict "
-    "does not provide",
-)
 def test_combine_scale_callable_returning_backend_scalar():
     # Added in #976: ``combine(scale=<callable>)`` must accept a callable that
     # returns a 0-d array of the backend. Only array-api-strict rejects the
-    # previous ``xp.asarray([0-d array, ...])``, and on that backend
-    # ``combine()`` currently fails earlier on ``ccd.data.nbytes``, so this
-    # test cannot yet fail because of the scaling path on any backend; it
-    # will start guarding it once ``combine()`` stops using ``.nbytes``.
+    # previous ``xp.asarray([0-d array, ...])``, so this test guards the
+    # scaling path on that backend.
     ccds = [
         CCDData(xp.full((4, 4), float(i), dtype=xp.float64), unit=u.adu)
         for i in (1, 2, 4)
@@ -445,7 +439,7 @@ def test_combiner_weighted_average_preserves_custom_scale_func():
     "ignore:invalid value encountered in divide:RuntimeWarning",
 )
 def test_combiner_weighted_average_fully_masked():
-    mask = xp.ones((1, 1), dtype=bool)
+    mask = xp.ones((1, 1), dtype=xp.bool)
     ccd_list = [
         CCDData(xp.ones((1, 1)), unit=u.adu, mask=mask),
         CCDData(xp.ones((1, 1)), unit=u.adu, mask=mask),
@@ -814,7 +808,7 @@ def test_combiner_image_file_collection_input(tmp_path):
     for a_ccd in ccds:
         a_ccd.data = xp.asarray(a_ccd.data, dtype=xp.float64)
         if a_ccd.mask is not None:
-            a_ccd.mask = xp.asarray(a_ccd.mask, dtype=bool)
+            a_ccd.mask = xp.asarray(a_ccd.mask, dtype=xp.bool)
         if a_ccd.uncertainty is not None:
             a_ccd.uncertainty.array = xp.asarray(
                 a_ccd.uncertainty.array, dtype=xp.float64
@@ -869,6 +863,18 @@ def test_combine_average_ccddata():
     avgccd = combine(ccd_list, output_file=None, method="average", unit=u.adu)
     # averaging same ccdData should give back same images
     assert xp.all(xpx.isclose(avgccd.data, ccd_by_combiner.data))
+
+
+# combine() sizes images without ``.nbytes``, which not every array library
+# provides; check the count against the known element sizes.
+def test_calculate_size_of_image():
+    ccd = CCDData(
+        xp.zeros((7, 5), dtype=xp.float32),
+        unit=u.adu,
+        mask=xp.zeros((7, 5), dtype=xp.bool),
+    )
+    # float32 data (4 bytes) plus bool mask (1 byte)
+    assert _calculate_size_of_image(ccd) == 7 * 5 * (4 + 1)
 
 
 # test combiner convenience function reads fits file and
@@ -966,7 +972,7 @@ def test_combine_ccd_with_uncertainty_and_mask_from_fits(scale, tmp_path):
     ccd_data = CCDData.read(fitsfile, unit=u.adu)
     ccd_data.data = xp.asarray(ccd_data.data, dtype=xp.float64)
     # Set ._mask instead of .mask to avoid conversion to numpy array
-    ccd_data._mask = xp.zeros_like(ccd_data.data, dtype=bool)
+    ccd_data._mask = xp.zeros_like(ccd_data.data, dtype=xp.bool)
     if scale == "function":
         scale_by_mean = _make_mean_scaler(ccd_data)
     else:
@@ -1099,7 +1105,7 @@ def test_combiner_uncertainty_average():
 
 # test resulting uncertainty is corrected for the number of images (with mask)
 def test_combiner_uncertainty_average_mask():
-    mask = xp.zeros((10, 10), dtype=bool)
+    mask = xp.zeros((10, 10), dtype=xp.bool)
     mask = xpx.at(mask)[5, 5].set(True)
     ccd_with_mask = CCDData(xp.ones((10, 10)), unit=u.adu, mask=mask)
     ccd_list = [
@@ -1122,7 +1128,7 @@ def test_combiner_uncertainty_average_mask():
 # test resulting uncertainty is corrected for the number of images (with mask)
 def test_combiner_uncertainty_median_mask():
     mad_to_sigma = 1.482602218505602
-    mask = xp.zeros((10, 10), dtype=bool)
+    mask = xp.zeros((10, 10), dtype=xp.bool)
     mask = xpx.at(mask)[5, 5].set(True)
     ccd_with_mask = CCDData(xp.ones((10, 10)), unit=u.adu, mask=mask)
     ccd_list = [
@@ -1147,7 +1153,7 @@ def test_combiner_uncertainty_median_mask():
 
 # test resulting uncertainty is corrected for the number of images (with mask)
 def test_combiner_uncertainty_sum_mask():
-    mask = xp.zeros((10, 10), dtype=bool)
+    mask = xp.zeros((10, 10), dtype=xp.bool)
     mask = xpx.at(mask)[5, 5].set(True)
     ccd_with_mask = CCDData(xp.ones((10, 10)), unit=u.adu, mask=mask)
     ccd_list = [


### PR DESCRIPTION
Part of #971. This addresses three unnumbered checklist items from the array-API tracker, all in the combiner internals, plus the immediately adjacent numpy-isms those fixes exposed in the same code paths.

### The fixes

1. **`Combiner._get_nan_substituted_data` used `mask.any()`** — a numpy-only array method. Now `xp.any(...)` in the combiner's namespace. Fixing this exposed the next layer in the same functions, which is also fixed here: `.sum(axis=0)` method calls (now `xp.count_nonzero`, since the array API also disallows summing booleans), `len(<array>)` (now `.shape[0]`; `__len__` is not required by the standard), a list passed to `xp.reshape` (now a tuple), and integer counts fed to `xp.sqrt`/uncertainty scaling (now cast to `float64`, matching the promotion numpy does implicitly).
2. **Builtin `bool` passed as a dtype** in the `_CCDDataWrapperForArrayAPI` mask setters and in test bodies that build masks in the testing namespace — strict namespaces only accept their own dtype objects. Now `xp.bool`.
3. **`combine()` memory sizing used `.nbytes`**, which is not in the array API standard. A new `_array_size_in_bytes()` helper computes size from `array_api_compat.size(arr)` and the dtype bit width from `xp.finfo`/`xp.iinfo` (booleans counted as 1 byte, complex as two components). The stale `backend_xfail` on `test_combine_scale_callable_returning_backend_scalar` is removed and a direct unit test of `_calculate_size_of_image` is added.

### Strict suite: 99 failed / 348 passed → 85 failed / 364 passed

(`CCDPROC_ARRAY_LIBRARY=array-api-strict`, on top of #987.)

Causes eliminated: the 28 `.any()` failures, the 9 builtin-`bool` dtype failures, the 2 `.nbytes` failures, and the intermediate layers behind them (`.sum` method, `len()`, list reshape, int→float promotion). One previously xfailed test now passes and its marker is removed; three `test_cosmicray` parametrizations now xpass as a side effect of the wrapper mask-setter fix (their marker still guards other parametrizations, so it stays).

Remaining failures are known separate issues, left for follow-up: device handling (#946, now the largest bucket at 31 since more tests reach the device checks), `xp.median` in `core.py` (4), fancy-index `__setitem__` in `clip_extrema` (4), sigma clipping via `astropy.stats` (#929), `combine()` file-input handling, CCDData arithmetic converting arrays inside `astropy.nddata` (the "Could not convert Array" bucket, hit by the scaling tests), and numpy-isms in test bodies (`.mean()` method calls, mixed int/float test arithmetic, dtype comparisons).

`test_combiner.py` passes fully on numpy (89 passed) and dask (93 passed); the full numpy suite is green (501 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQMJZUaaxfqGDk41GLSaFK
