### PR TITLE
Fix numpy-isms in strict-backend test bodies (test hygiene)

### DIFF
--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -172,8 +172,8 @@ def test_subtract_overscan(median, transpose, data_rectangle):
 
     # Since some array libraries do not support in-place operations, we
     # work on the science and overscan regions separately.
-    science_data = ccd_data.data[science_region].copy()
-    overscan_data = 0 * ccd_data.data[oscan_region].copy() + oscan
+    science_data = xp.asarray(ccd_data.data[science_region], copy=True)
+    overscan_data = 0 * xp.asarray(ccd_data.data[oscan_region], copy=True) + oscan
 
     # Add a fake sky background so the "science" part of the image has a
     # different average than the "overscan" part.
@@ -201,7 +201,7 @@ def test_subtract_overscan(median, transpose, data_rectangle):
         )
     )
     # Is the overscan region zero?
-    assert (ccd_data_overscan.data[oscan_region] == 0).all()
+    assert xp.all(ccd_data_overscan.data[oscan_region] == 0)
 
     # Now do what should be the same subtraction, with the overscan specified
     # with the fits_section
@@ -222,7 +222,7 @@ def test_subtract_overscan(median, transpose, data_rectangle):
         )
     )
     # Is the overscan region zero?
-    assert (ccd_data_fits_section.data[oscan_region] == 0).all()
+    assert xp.all(ccd_data_fits_section.data[oscan_region] == 0)
 
     # Do both ways of subtracting overscan give exactly the same result?
     assert xp.all(
@@ -353,7 +353,7 @@ def test_subtract_overscan_fails():
         subtract_overscan(xp.zeros((10, 10)), 3, median=False, model=None)
     # Do we get an error if we specify both overscan and fits_section?
     with pytest.raises(TypeError):
-        subtract_overscan(ccd_data, overscan=ccd_data[0:10], fits_section="[1:10]")
+        subtract_overscan(ccd_data, overscan=ccd_data[0:10, ...], fits_section="[1:10]")
     # Do we raise an error if we specify neither overscan nor fits_section?
     with pytest.raises(TypeError):
         subtract_overscan(ccd_data)
@@ -402,7 +402,7 @@ def test_trim_with_wcs_alters_wcs():
     ccd_data = ccd_data_func()
     # WCS construction example pulled form astropy.wcs docs
     wcs = WCS(naxis=2)
-    wcs.wcs.crpix = xp.asarray(ccd_data.shape) / 2
+    wcs.wcs.crpix = xp.asarray(ccd_data.shape, dtype=xp.float64) / 2
     wcs.wcs.cdelt = xp.asarray([-0.066667, 0.066667])
     wcs.wcs.crval = [0, -90]
     wcs.wcs.ctype = ["RA---AIR", "DEC--AIR"]
@@ -951,7 +951,7 @@ def test__overscan_schange():
     ccd_data = ccd_data_func()
     old_data = ccd_data.copy()
     new_data = subtract_overscan(ccd_data, overscan=ccd_data[:, 1], overscan_axis=0)
-    assert not xp.allclose(old_data.data, new_data.data)
+    assert not xp.all(xpx.isclose(old_data.data, new_data.data))
     assert xp.all(xpx.isclose(old_data.data, ccd_data.data))
 
 

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -5,6 +5,7 @@ import pytest
 from astropy.nddata import CCDData
 
 from ccdproc import Keyword, create_deviation, subtract_bias, trim_image
+from ccdproc.conftest import testing_array_library as xp
 from ccdproc.core import _short_names
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
@@ -72,7 +73,7 @@ def test_implicit_logging():
     # should happen:
     # + A key named func.__name__ is created, with
     # + value that is the list of arguments the function was called with.
-    bias = CCDData(np.zeros_like(ccd_data.data), unit="adu")
+    bias = CCDData(xp.zeros_like(ccd_data.data), unit="adu")
     result = subtract_bias(ccd_data, bias)
     assert "subtract_bias" in result.header
     assert result.header["subtract_bias"] == (

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -358,9 +358,7 @@ def test_pixelwise_weights():
     ]
     combo = Combiner(ccd_list)
     combo.weights = xp.ones_like(combo._data_arr)
-    combo.weights = xpx.at(combo.weights)[:, 5, 5].set(
-        xp.asarray([1, 5, 10], dtype=xp.float64)
-    )
+    combo.weights = xpx.at(combo.weights)[:, 5, 5].set(xp.asarray([1.0, 5.0, 10.0]))
     ccd = combo.average_combine()
     assert xp.all(xpx.isclose(ccd.data[5, 5], 312.5))
     assert xp.all(xpx.isclose(ccd.data[0, 0], 0))
@@ -583,10 +581,10 @@ def test_combiner_sum():
 
 # test weighted sum
 def test_combiner_sum_weighted():
-    ccd_data = CCDData(data=xp.asarray([[0, 1], [2, 3]], dtype=xp.float64), unit="adu")
+    ccd_data = CCDData(data=xp.asarray([[0.0, 1.0], [2.0, 3.0]]), unit="adu")
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
-    c.weights = xp.asarray([1, 2, 3], dtype=xp.float64)
+    c.weights = xp.asarray([1.0, 2.0, 3.0])
     ccd = c.sum_combine()
     expected_result = sum(w * d.data for w, d in zip(c.weights, ccd_list, strict=True))
     assert xp.all(xpx.isclose(ccd.data, expected_result))
@@ -598,10 +596,10 @@ def test_combiner_sum_weighted_by_pixel():
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     # Weights below are chosen so that every entry in
-    weights_pixel = [[8, 4], [2, 1]]
-    c.weights = xp.asarray([weights_pixel] * 3, dtype=xp.float64)
+    weights_pixel = [[8.0, 4.0], [2.0, 1.0]]
+    c.weights = xp.asarray([weights_pixel] * 3)
     ccd = c.sum_combine()
-    expected_result = xp.asarray([[24, 24], [24, 24]], dtype=xp.float64)
+    expected_result = xp.asarray([[24.0, 24.0], [24.0, 24.0]])
     assert xp.all(xpx.isclose(ccd.data, expected_result))
 
 
@@ -612,11 +610,11 @@ def test_combiner_sum_weighted_with_mask():
         CCDData(xp.asarray([[10, 20]]), unit=u.adu),
     ]
     combiner = Combiner(ccd_list)
-    combiner.weights = xp.asarray([1, 3], dtype=xp.float64)
+    combiner.weights = xp.asarray([1.0, 3.0])
 
     combined = combiner.sum_combine()
 
-    expected = xp.asarray([[30, 62]], dtype=xp.float64)
+    expected = xp.asarray([[30.0, 62.0]])
     assert xp.all(xpx.isclose(combined.data, expected))
 
 
@@ -1126,13 +1124,11 @@ def test_combiner_uncertainty_average_mask():
     c = Combiner(ccd_list)
     ccd = c.average_combine()
     # Just the standard deviation of ccd data.
-    ref_uncertainty = xp.ones((10, 10)) * xp.std(
-        xp.asarray([1, 2, 3], dtype=xp.float64)
-    )
+    ref_uncertainty = xp.ones((10, 10)) * xp.std(xp.asarray([1.0, 2.0, 3.0]))
     # Correction because we combined two images.
     ref_uncertainty /= xp.sqrt(xp.asarray(3.0))
     ref_uncertainty = xpx.at(ref_uncertainty)[5, 5].set(
-        xp.std(xp.asarray([2, 3], dtype=xp.float64)) / xp.sqrt(xp.asarray(2.0))
+        xp.std(xp.asarray([2.0, 3.0])) / xp.sqrt(xp.asarray(2.0))
     )
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 
@@ -1176,12 +1172,10 @@ def test_combiner_uncertainty_sum_mask():
     c = Combiner(ccd_list)
     ccd = c.sum_combine()
     # Just the standard deviation of ccd data.
-    ref_uncertainty = xp.ones((10, 10)) * xp.std(
-        xp.asarray([1, 2, 3], dtype=xp.float64)
-    )
+    ref_uncertainty = xp.ones((10, 10)) * xp.std(xp.asarray([1.0, 2.0, 3.0]))
     ref_uncertainty *= xp.sqrt(xp.asarray(3.0))
     ref_uncertainty = xpx.at(ref_uncertainty)[5, 5].set(
-        xp.std(xp.asarray([2, 3], dtype=xp.float64)) * xp.sqrt(xp.asarray(2.0))
+        xp.std(xp.asarray([2.0, 3.0])) * xp.sqrt(xp.asarray(2.0))
     )
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -358,7 +358,9 @@ def test_pixelwise_weights():
     ]
     combo = Combiner(ccd_list)
     combo.weights = xp.ones_like(combo._data_arr)
-    combo.weights = xpx.at(combo.weights)[:, 5, 5].set(xp.asarray([1, 5, 10]))
+    combo.weights = xpx.at(combo.weights)[:, 5, 5].set(
+        xp.asarray([1, 5, 10], dtype=xp.float64)
+    )
     ccd = combo.average_combine()
     assert xp.all(xpx.isclose(ccd.data[5, 5], 312.5))
     assert xp.all(xpx.isclose(ccd.data[0, 0], 0))
@@ -463,7 +465,7 @@ def test_combiner_minmax():
     c = Combiner(ccd_list)
     c.minmax_clipping(min_clip=-500, max_clip=500)
     ccd = c.median_combine()
-    assert ccd.data.mean() == 0
+    assert xp.mean(ccd.data) == 0
 
 
 def test_combiner_minmax_max():
@@ -475,7 +477,7 @@ def test_combiner_minmax_max():
 
     c = Combiner(ccd_list)
     c.minmax_clipping(min_clip=None, max_clip=500)
-    assert c._data_arr_mask[2].all()
+    assert xp.all(c._data_arr_mask[2, ...])
 
 
 def test_combiner_minmax_min():
@@ -487,7 +489,7 @@ def test_combiner_minmax_min():
 
     c = Combiner(ccd_list)
     c.minmax_clipping(min_clip=-500, max_clip=None)
-    assert c._data_arr_mask[1].all()
+    assert xp.all(c._data_arr_mask[1, ...])
 
 
 def test_combiner_sigmaclip_high():
@@ -581,10 +583,10 @@ def test_combiner_sum():
 
 # test weighted sum
 def test_combiner_sum_weighted():
-    ccd_data = CCDData(data=xp.asarray([[0, 1], [2, 3]]), unit="adu")
+    ccd_data = CCDData(data=xp.asarray([[0, 1], [2, 3]], dtype=xp.float64), unit="adu")
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
-    c.weights = xp.asarray([1, 2, 3])
+    c.weights = xp.asarray([1, 2, 3], dtype=xp.float64)
     ccd = c.sum_combine()
     expected_result = sum(w * d.data for w, d in zip(c.weights, ccd_list, strict=True))
     assert xp.all(xpx.isclose(ccd.data, expected_result))
@@ -597,9 +599,9 @@ def test_combiner_sum_weighted_by_pixel():
     c = Combiner(ccd_list)
     # Weights below are chosen so that every entry in
     weights_pixel = [[8, 4], [2, 1]]
-    c.weights = xp.asarray([weights_pixel] * 3)
+    c.weights = xp.asarray([weights_pixel] * 3, dtype=xp.float64)
     ccd = c.sum_combine()
-    expected_result = xp.asarray([[24, 24], [24, 24]])
+    expected_result = xp.asarray([[24, 24], [24, 24]], dtype=xp.float64)
     assert xp.all(xpx.isclose(ccd.data, expected_result))
 
 
@@ -610,11 +612,11 @@ def test_combiner_sum_weighted_with_mask():
         CCDData(xp.asarray([[10, 20]]), unit=u.adu),
     ]
     combiner = Combiner(ccd_list)
-    combiner.weights = xp.asarray([1, 3])
+    combiner.weights = xp.asarray([1, 3], dtype=xp.float64)
 
     combined = combiner.sum_combine()
 
-    expected = xp.asarray([[30, 62]])
+    expected = xp.asarray([[30, 62]], dtype=xp.float64)
     assert xp.all(xpx.isclose(combined.data, expected))
 
 
@@ -1107,7 +1109,7 @@ def test_combiner_uncertainty_average():
     # Just the standard deviation of ccd data.
     ref_uncertainty = xp.ones((10, 10)) / 2
     # Correction because we combined two images.
-    ref_uncertainty /= xp.sqrt(2)
+    ref_uncertainty /= xp.sqrt(xp.asarray(2.0))
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 
 
@@ -1124,11 +1126,13 @@ def test_combiner_uncertainty_average_mask():
     c = Combiner(ccd_list)
     ccd = c.average_combine()
     # Just the standard deviation of ccd data.
-    ref_uncertainty = xp.ones((10, 10)) * xp.std(xp.asarray([1, 2, 3]))
+    ref_uncertainty = xp.ones((10, 10)) * xp.std(
+        xp.asarray([1, 2, 3], dtype=xp.float64)
+    )
     # Correction because we combined two images.
-    ref_uncertainty /= xp.sqrt(3)
+    ref_uncertainty /= xp.sqrt(xp.asarray(3.0))
     ref_uncertainty = xpx.at(ref_uncertainty)[5, 5].set(
-        xp.std(xp.asarray([2, 3])) / xp.sqrt(2)
+        xp.std(xp.asarray([2, 3], dtype=xp.float64)) / xp.sqrt(xp.asarray(2.0))
     )
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 
@@ -1147,14 +1151,14 @@ def test_combiner_uncertainty_median_mask():
     c = Combiner(ccd_list)
     ccd = c.median_combine()
     # Just the standard deviation of ccd data.
-    ref_uncertainty = xp.ones((10, 10)) * mad_to_sigma * mad([1, 2, 3])
-    # Correction because we combined two images.
-    ref_uncertainty /= xp.sqrt(3)  # 0.855980789955
     # It turns out that the expression below evaluates to a np.float64, which
     # introduces numpy into the array namespace, which raises an error
     # when arrat_api_compat tries to figure out the namespace. Casting
     # it to a regular float fixes that.
-    med_value = float(mad_to_sigma * mad([2, 3]) / xp.sqrt(2))
+    ref_uncertainty = xp.ones((10, 10)) * float(mad_to_sigma * mad([1, 2, 3]))
+    # Correction because we combined two images.
+    ref_uncertainty /= xp.sqrt(xp.asarray(3.0))  # 0.855980789955
+    med_value = float(mad_to_sigma * mad([2, 3])) / float(xp.sqrt(xp.asarray(2.0)))
     ref_uncertainty = xpx.at(ref_uncertainty)[5, 5].set(med_value)  # 0.524179041254
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 
@@ -1172,10 +1176,12 @@ def test_combiner_uncertainty_sum_mask():
     c = Combiner(ccd_list)
     ccd = c.sum_combine()
     # Just the standard deviation of ccd data.
-    ref_uncertainty = xp.ones((10, 10)) * xp.std(xp.asarray([1, 2, 3]))
-    ref_uncertainty *= xp.sqrt(3)
+    ref_uncertainty = xp.ones((10, 10)) * xp.std(
+        xp.asarray([1, 2, 3], dtype=xp.float64)
+    )
+    ref_uncertainty *= xp.sqrt(xp.asarray(3.0))
     ref_uncertainty = xpx.at(ref_uncertainty)[5, 5].set(
-        xp.std(xp.asarray([2, 3])) * xp.sqrt(2)
+        xp.std(xp.asarray([2, 3], dtype=xp.float64)) * xp.sqrt(xp.asarray(2.0))
     )
     assert xp.all(xpx.isclose(ccd.uncertainty.array, ref_uncertainty))
 
@@ -1517,12 +1523,16 @@ def test_user_supplied_combine_func_that_relies_on_masks(comb_func):
             xp = array_api_compat.array_namespace(data)
             new_data = []
             for i in range(data.shape[0]):
-                if mask[i] is not None:
-                    new_data.append(data[i] * ~mask[i])
+                if mask[i, ...] is not None:
+                    new_data.append(
+                        xp.where(
+                            mask[i, ...], xp.zeros_like(data[i, ...]), data[i, ...]
+                        )
+                    )
                 else:
-                    new_data.append(xp.zeros_like(data[i]))
+                    new_data.append(xp.zeros_like(data[i, ...]))
 
-            new_data = xp.asarray(new_data)
+            new_data = xp.stack(new_data)
 
             def sum_func(_, axis=axis):
                 return xp.sum(new_data, axis=axis)

--- a/ccdproc/tests/test_rebin.py
+++ b/ccdproc/tests/test_rebin.py
@@ -7,6 +7,7 @@ import pytest
 from astropy.nddata import StdDevUncertainty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
+from ccdproc.conftest import testing_array_library as xp
 from ccdproc.core import rebin
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
@@ -67,7 +68,7 @@ def test_rebin_smaller():
 def test_rebin_ccddata(mask_data, uncertainty):
     ccd_data = ccd_data_func(data_size=10)
     if mask_data:
-        ccd_data.mask = np.zeros_like(ccd_data)
+        ccd_data.mask = xp.zeros_like(ccd_data.data)
     if uncertainty:
         err = np.random.default_rng().normal(size=ccd_data.shape)
         ccd_data.uncertainty = StdDevUncertainty(err)


### PR DESCRIPTION
## Summary

Test-only hygiene batch for the array-API migration (#971). Many
`array-api-strict` test failures were caused by numpy-only idioms in the
**test bodies**, not by bugs in ccdproc source. This PR fixes only files
under `ccdproc/tests/`.

**Strict suite: 85 failed, 366 passed → 65 failed, 386 passed** (36
skipped / 46 xfailed / 5 xpassed unchanged). Numpy backend stays at 0
failed (503 passed); dask backend on the four changed test files also
stays at 0 failed.

No CHANGES.rst entry — this is a test-only change.

## Fixed causes (itemized)

1. **#969** — `.copy()` is not an array-API method. Replaced
   `arr.copy()` with `xp.asarray(arr, copy=True)` in
   `test_ccdproc.py::test_subtract_overscan`. Closes all 6 parametrized
   failures for that test as numpy-isms; two of the six
   (`[True-False-False]`, `[True-False-True]`, the `median=True` cases)
   still fail afterward because they hit the separate, already-tracked
   `xp.median` gap at `core.py:629` (another agent is fixing that on a
   different branch) — the `.copy()` fix itself is still correct and is
   kept per the issue's scope.
2. **#970** — raw `np.zeros_like` mixed with backend arrays.
   `test_ccdproc_logging.py::test_implicit_logging` now builds its bias
   frame with `xp.zeros_like` (now passes). `test_rebin.py::test_rebin_ccddata[True-True]`
   was updated the same way, but it still fails afterward: astropy's
   `CCDData.mask` setter (`astropy/nddata/compat.py`) forces
   `np.asarray(value, dtype=np.bool_)`, which can't convert an array on
   a non-default strict device. That's an astropy-internals limitation
   outside a test-only fix, so it's kept per the issue's scope and noted
   as a residual failure.
3. `test__overscan_schange` used `xp.allclose`, which isn't in the
   array-API standard. Replaced with `xp.all(xpx.isclose(...))`.
4. `test_combiner.py` numpy-only method calls (`.mean()`, `.all()`) on
   backend arrays, replaced with `xp.mean(...)` / `xp.all(...)`:
   `test_combiner_minmax`, `test_combiner_minmax_max`,
   `test_combiner_minmax_min`.
5. Broader numpy-isms diagnosed from actual strict tracebacks:
   - Single-axis indexing (`arr[i]`) on arrays with `ndim > 1`, which
     the array-API standard requires an explicit ellipsis for
     (`arr[i, ...]`): `test_subtract_overscan_fails`,
     `test_user_supplied_combine_func_that_relies_on_masks[sum_combine]`.
   - int/float mixed arithmetic that strict's dtype promotion rejects:
     `test_trim_with_wcs_alters_wcs` (`xp.asarray(shape) / 2` on an int
     array), `test_pixelwise_weights`, `test_combiner_sum_weighted`,
     `test_combiner_sum_weighted_by_pixel`,
     `test_combiner_sum_weighted_with_mask`,
     `test_combiner_uncertainty_average`,
     `test_combiner_uncertainty_average_mask`,
     `test_combiner_uncertainty_median_mask`,
     `test_combiner_uncertainty_sum_mask` (int-literal arrays passed to
     `xp.std`/`xp.sqrt`, and an unwrapped `np.float64` from
     `astropy.stats.median_absolute_deviation` multiplied against a
     strict `Array`, following the existing `float(...)` cast pattern
     already used elsewhere in that file).
   - `xp.asarray(list_of_arrays)` ("Nested Arrays are not allowed"),
     replaced with `xp.stack(...)`:
     `test_user_supplied_combine_func_that_relies_on_masks[sum_combine]`.

## Failures examined and deliberately left (with why)

- `test_ccd_process[*]`, `test_ccd_process_gain_corrected`,
  `test_subtract_overscan[True-False-*]` (median path) — the known,
  already-tracked `xp.median` gap at `core.py:629`; another agent is
  fixing this on a separate branch, explicitly out of scope here.
- `test_flat_correct*`, `test_gain_correct*`, `test_gain.py::*` — source
  bugs in `gain_correct`/`flat_correct` (`core.py:934`, `core.py:1023`,
  `core.py:1037`): `xp.asarray(...)` called without `device=`, causing
  "Arrays from two different devices" errors from ccdproc source, not
  the test body.
- `test_flat_correct_data_uncertainty` — intentionally uses a raw numpy
  array as uncertainty; the test's own comment documents this as a
  regression test for astropy's `NDUncertainty` explicitly checking for
  `numpy.ndarray`, to be removed once that's fixed upstream.
- `test_flat_correct_deviation`, `test_sigma_func_for_ccddata`,
  `test_combiner_median`/`average`/`sum`/`dtype`,
  `test_average_combine_uncertainty`, `test_median_combine_uncertainty`,
  `test_sum_combine_uncertainty`, `test_combine_result_uncertainty_and_mask[*]` —
  fail inside `astropy.stats.median_absolute_deviation` or
  `CCDData.mask`/`Quantity` construction forcing numpy conversion of a
  non-default-device strict array; astropy-internals, not test-body.
- `test_combiner_sigmaclip_high/low/single_pix` — the test intentionally
  passes `astropy.stats.median_absolute_deviation` as `dev_func`, which
  forces a numpy conversion inside `combiner.py`'s `sigma_clipping`;
  same astropy-internals limitation.
- `test_combine_average_fitsimages`, `test_combine_numpyndarray`,
  `test_combiner_image_file_collection_input`,
  `test_combine_image_file_collection_input`,
  `test_combine_average_ccddata`, `test_combine_limitedmem_fitsimages`,
  `test_combine_limitedmem_scale_fitsimages`,
  `test_combine_ccd_with_uncertainty_and_mask_from_fits[*]` — explicitly
  out of scope per the task brief (`combine()` file-input handling
  returns plain numpy arrays).
- `test_clip_extrema_3d/alone/via_combine/with_other_rejection` —
  explicitly out of scope per the task brief (clip_extrema fancy
  indexing).
- `test_combiner_with_scaling`, `test_combiner_result_dtype`,
  `test_combine_overwrite_output`, `test_combiner_with_scaling_uncertainty[*]` —
  astropy `ndarithmetic`'s `np.result_type(ref, operand)` can't convert
  a strict `Array`'s dtype; astropy-internals ("Could not convert Array"
  pattern named as out of scope in the task brief).
- `test_writeable_after_combine[*]` — `CCDData.write`/mask conversion
  forcing numpy on a non-default device; source/astropy-internals.
- `test_3d_combiner_with_scaling`, `test_combiner_with_scaling` (helper
  `scale_by_mean`) — tried fixing the `.mean()` numpy-ism, but it then
  exposed a genuine ccdproc source bug: `Combiner.scaling`'s setter
  (`combiner.py:327`) calls `xp.asarray(list_of_arrays)` on a list of
  strict `Array`s ("Nested Arrays are not allowed. Use `stack` instead."),
  and for `test_combiner_with_scaling` the test is blocked even earlier
  by the astropy `ndarithmetic` issue above. Per the task's revert
  policy for non-numbered items, these test-body changes were reverted
  back to the pre-existing (still-numpy) form and left failing.
- `test_transform_image[True-True]` — the test's user-supplied `tran =
  lambda arr: 10 * arr` is applied generically to data, uncertainty, and
  mask by `transform_image`; ccdproc's array-API wrapper coerces the
  mask to `bool` before this call, so `10 * bool_array` hits strict's
  "Only numeric dtypes are allowed in `__rmul__`". Making the test's
  transform function dtype-aware would change what the test exercises
  rather than being a simple hygiene fix, so left as-is.
- `test_unit_mismatch_behaves_as_expected` — fails inside astropy's
  `Quantity.__new__` forcing a numpy conversion via
  `_arithmetic_data`/`_prepare_then_do_arithmetic`; astropy-internals.
- `test_image_collection.py::test_generator_ccds_without_unit` — fails
  only when run as part of the full suite (passes in isolation),
  indicating cross-test state leakage unrelated to array-API numpy-isms;
  left as a pre-existing, order-dependent issue outside this batch's
  scope.

## Test plan

- [x] `CCDPROC_ARRAY_LIBRARY=array-api-strict tox -e strict` (from the
      main checkout's tox env): 85 failed, 366 passed → 65 failed, 386
      passed.
- [x] `CCDPROC_ARRAY_LIBRARY=numpy` full suite: 503 passed, 0 failed (no
      regression).
- [x] `CCDPROC_ARRAY_LIBRARY=dask` on the four changed test files: 181
      passed, 0 failed.
- [x] `ruff check` / `ruff format --check` clean on changed files.

Part of #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQMJZUaaxfqGDk41GLSaFK
