### PR TITLE
Keep combine result masks in the array namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,13 @@ Bug Fixes
   standard, built on the existing NaN-aware ``nanmedian``, and use it in
   ``subtract_overscan`` when the selected array namespace has no ``median``,
   instead of raising ``AttributeError``. [#989]
+- Keep the mask of the result of ``Combiner.average_combine``,
+  ``median_combine`` and ``sum_combine`` and of ``combine`` in the array
+  namespace and on the device of the data, instead of letting the
+  ``CCDData.mask`` setter convert it to NumPy, which fails for arrays that
+  cannot be converted (for example on a non-default device). ``combine``
+  now also coerces a NumPy mask on the template image into the data's
+  namespace and device. [#992]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,12 +92,8 @@ Bug Fixes
   ``subtract_overscan`` when the selected array namespace has no ``median``,
   instead of raising ``AttributeError``. [#989]
 - Keep the mask of the result of ``Combiner.average_combine``,
-  ``median_combine`` and ``sum_combine`` and of ``combine`` in the array
-  namespace and on the device of the data, instead of letting the
-  ``CCDData.mask`` setter convert it to NumPy, which fails for arrays that
-  cannot be converted (for example on a non-default device). ``combine``
-  now also coerces a NumPy mask on the template image into the data's
-  namespace and device. [#992]
+  ``median_combine``, ``sum_combine`` and ``combine`` in the array namespace
+  and on the device of the data instead of converting it to NumPy. [#992]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -615,10 +615,13 @@ class Combiner:
         # create the combined image with a dtype matching the combiner
         combined_image = CCDData(
             xp.asarray(medianed, dtype=self.dtype),
-            mask=mask,
             unit=self.unit,
             uncertainty=StdDevUncertainty(uncertainty),
         )
+        # TODO: the private _mask attribute is set here to avoid the
+        # CCDData.mask setter, which converts the mask to a numpy array.
+        # This can be removed when CCDData supports array namespaces.
+        combined_image._mask = mask
 
         # update the meta data
         combined_image.meta["NCOMBINE"] = self._data_arr.shape[0]
@@ -725,10 +728,13 @@ class Combiner:
         # create the combined image with a dtype that matches the combiner
         combined_image = CCDData(
             xp.asarray(mean, dtype=self.dtype),
-            mask=mask,
             unit=self.unit,
             uncertainty=StdDevUncertainty(uncertainty),
         )
+        # TODO: the private _mask attribute is set here to avoid the
+        # CCDData.mask setter, which converts the mask to a numpy array.
+        # This can be removed when CCDData supports array namespaces.
+        combined_image._mask = mask
 
         # update the meta data
         combined_image.meta["NCOMBINE"] = data.shape[0]
@@ -803,10 +809,13 @@ class Combiner:
         # create the combined image with a dtype that matches the combiner
         combined_image = CCDData(
             xp.asarray(summed, dtype=self.dtype),
-            mask=mask,
             unit=self.unit,
             uncertainty=StdDevUncertainty(uncertainty),
         )
+        # TODO: the private _mask attribute is set here to avoid the
+        # CCDData.mask setter, which converts the mask to a numpy array.
+        # This can be removed when CCDData supports array namespaces.
+        combined_image._mask = mask
 
         # update the meta data
         combined_image.meta["NCOMBINE"] = self._data_arr.shape[0]
@@ -1084,8 +1093,7 @@ def combine(
                 ccd.uncertainty.array = xp.asarray(
                     ccd.uncertainty.array, dtype=ccd.uncertainty.array.dtype.type
                 )
-            if ccd.mask is not None:
-                ccd.mask = xp.asarray(ccd.mask, dtype=xp.bool)
+            # The mask is converted below, once the namespace is known.
 
     # Get the array namespace; if array_package was not None and files were read in,
     # then xp the ccd.data will be the same as the array_package.
@@ -1110,9 +1118,18 @@ def combine(
         ccd.uncertainty = StdDevUncertainty(xp.zeros_like(ccd.data))
 
     # If the template doesn't have a mask, add one, because the result may have
-    # a mask
+    # a mask. If it does have one, it may be a numpy array even when the data
+    # is not (the CCDData.mask setter converts to numpy), so coerce it into the
+    # data's namespace and onto the data's device: the combined tiles are
+    # written into it below.
+    # TODO: the private _mask attribute is set here to avoid the CCDData.mask
+    # setter. This can be removed when CCDData supports array namespaces.
     if ccd.mask is None:
-        ccd.mask = xp.zeros_like(ccd.data, dtype=xp.bool)
+        ccd._mask = xp.zeros_like(ccd.data, dtype=xp.bool)
+    else:
+        ccd._mask = xp.asarray(
+            ccd.mask, dtype=xp.bool, device=array_api_compat.device(ccd.data)
+        )
 
     size_of_an_img = _calculate_size_of_image(ccd)
 
@@ -1165,7 +1182,7 @@ def combine(
                                 imgccd.uncertainty.array, dtype=dtype
                             )
                         if imgccd.mask is not None:
-                            imgccd.mask = xp.asarray(imgccd.mask, dtype=xp.bool)
+                            imgccd._mask = xp.asarray(imgccd.mask, dtype=xp.bool)
 
                 scalevalues.append(scale(imgccd.data))
 
@@ -1213,7 +1230,7 @@ def combine(
                                 imgccd.uncertainty.array, dtype=dtype
                             )
                         if imgccd.mask is not None:
-                            imgccd.mask = xp.asarray(imgccd.mask, dtype=xp.bool)
+                            imgccd._mask = xp.asarray(imgccd.mask, dtype=xp.bool)
 
                 # Trim image and copy
                 # The copy is *essential* to avoid having a bunch
@@ -1243,10 +1260,12 @@ def combine(
             ccd.data = xpx.at(ccd.data)[x:xend, y:yend].set(comb_tile.data)
 
             if ccd.mask is not None:
-                # Maybe temporary workaround for the mask not being writeable...
-                ccd.mask = ccd.mask.copy()
-                # Handle immutable arrays with array_api_extra
-                ccd.mask = xpx.at(ccd.mask)[x:xend, y:yend].set(comb_tile.mask)
+                # Handle immutable arrays with array_api_extra; copy=True
+                # also covers a read-only mask. The private attribute is set
+                # to avoid the CCDData.mask setter (see above).
+                ccd._mask = xpx.at(ccd.mask)[x:xend, y:yend].set(
+                    comb_tile.mask, copy=True
+                )
 
             if ccd.uncertainty is not None:
                 # Handle immutable arrays with array_api_extra

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import math
 import types
 from functools import partial
 
@@ -933,7 +934,7 @@ def test_average_combine_uncertainty():
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.average_combine(uncertainty_func=xp.sum)
-    uncert_ref = xp.sum(c._data_arr, 0) / xp.sqrt(3)
+    uncert_ref = xp.sum(c._data_arr, axis=0) / math.sqrt(3)
     assert xp.all(xpx.isclose(ccd.uncertainty.array, uncert_ref))
 
     # Compare this also to the "combine" call
@@ -948,7 +949,7 @@ def test_median_combine_uncertainty():
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.median_combine(uncertainty_func=xp.sum)
-    uncert_ref = xp.sum(c._data_arr, 0) / xp.sqrt(3)
+    uncert_ref = xp.sum(c._data_arr, axis=0) / math.sqrt(3)
     assert xp.all(xpx.isclose(ccd.uncertainty.array, uncert_ref))
 
     # Compare this also to the "combine" call
@@ -963,7 +964,7 @@ def test_sum_combine_uncertainty():
     ccd_list = [ccd_data, ccd_data, ccd_data]
     c = Combiner(ccd_list)
     ccd = c.sum_combine(uncertainty_func=xp.sum)
-    uncert_ref = xp.sum(c._data_arr, 0) * xp.sqrt(3)
+    uncert_ref = xp.sum(c._data_arr, axis=0) * math.sqrt(3)
     assert xp.all(xpx.isclose(ccd.uncertainty.array, uncert_ref))
 
     # Compare this also to the "combine" call
@@ -1054,9 +1055,9 @@ def test_combine_result_uncertainty_and_mask(comb_func, mask_point):
     # Check that the right point is masked, and only one point is
     # masked
     assert expected_result.mask[0, 0] == mask_point
-    assert expected_result.mask.sum() == mask_point
+    assert int(xp.count_nonzero(expected_result.mask)) == int(mask_point)
     assert ccd_comb.mask[0, 0] == mask_point
-    assert ccd_comb.mask.sum() == mask_point
+    assert int(xp.count_nonzero(ccd_comb.mask)) == int(mask_point)
 
 
 @pytest.mark.backend_xfail(


### PR DESCRIPTION
Part of #971 (section 1, "combine methods pass `mask=` to `CCDData(...)`" — the largest remaining bucket on the strict job).

`Combiner.average_combine`, `median_combine` and `sum_combine` built their result with `CCDData(..., mask=mask)`, and `combine()` assigned `ccd.mask = ...` at several points, so astropy's `CCDData.mask` setter (`np.asarray(value, dtype=np.bool_)`) ran on every result. On backends whose arrays cannot be converted to NumPy (a non-default `array-api-strict` device, a GPU) that raises; on jax/dask it silently handed back a NumPy mask on non-NumPy data.

### Changes

- The three `*_combine` methods assign `combined_image._mask = mask` after construction, the same workaround `ccd_process` already uses (`core.py:381`), with the same TODO.
- `combine()` does the same at its own mask sites, and coerces the template image's mask into the data's namespace and onto its device the way `Combiner.__init__` does — a `CCDData` that received its mask through the setter always carries a NumPy mask, so without this the tile loop fails with "Multiple namespaces for array inputs" once the tiles' masks are no longer NumPy.
- The tile loop's `ccd.mask.copy()` (NumPy-only; it only worked because the mask was always NumPy) is replaced by `xpx.at(...).set(..., copy=True)`.
- Test bodies that were previously never reached on strict are made array-API clean: positional `axis`, `xp.sqrt(3)` → `math.sqrt(3)`, `mask.sum()` → `xp.count_nonzero`.

### Results

- Strict job locally (`tox -e strict`): **63 → 54 failed**, 418 → 427 passed, no new failures.
- numpy full suite, and dask / jax (`JAX_ENABLE_X64=1`) `test_combiner.py`: all green.
- The rest of the original 12-test bucket now stops at the next layer: `median_combine` uses the default `sigma_func` → `astropy.stats.median_absolute_deviation` (#929, section 3), and `test_writeable_after_combine` writes a `device1` array to FITS, which belongs with the section-2 "write a NumPy copy" tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME
