### PR TITLE
Compute Combiner.clip_extrema mask with rank comparison instead of scatter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,7 +104,7 @@ Bug Fixes
   non-NumPy array namespace in ``combine`` and ``ImageFileCollection``. [#995]
 - Compute the ``Combiner.clip_extrema`` mask with a rank comparison instead
   of scattering into the mask through per-pixel integer indices, which the
-  array API standard does not support. [#NNN]
+  array API standard does not support. [#994]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Bug Fixes
   cast the mask in ``transform_image`` to the data dtype before transforming
   it, and convert FITS data to native byte order before handing it to a
   non-NumPy array namespace in ``combine`` and ``ImageFileCollection``. [#995]
+- Compute the ``Combiner.clip_extrema`` mask with a rank comparison instead
+  of scattering into the mask through per-pixel integer indices, which the
+  array API standard does not support. [#NNN]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -18,7 +18,6 @@ from astropy import log
 from astropy.nddata import CCDData, StdDevUncertainty
 from astropy.stats import sigma_clip
 from astropy.utils import deprecated_renamed_argument
-from numpy import mgrid as np_mgrid
 
 from ._nanfuncs import nanmean, nanmedian, nanstd, nansum
 from .core import _native_numpy, sigma_func
@@ -358,6 +357,9 @@ class Combiner:
         will count the masking of that pixel toward the count of nhigh masked
         pixels.
 
+        If ``nlow`` or ``nhigh`` is at least the number of images, every pixel
+        is masked.
+
         Here is a copy of the relevant IRAF help text [0]_:
 
         nlow = 1, nhigh = (minmax)
@@ -379,33 +381,17 @@ class Combiner:
         if nhigh is None:
             nhigh = 0
 
+        n_images = self._data_arr.shape[0]
+        # argsorted[i, ...] is, per pixel, the index of the image whose value
+        # has rank i (0 = lowest, n_images - 1 = highest). Sorting those
+        # indices again inverts the permutation: ranks[k, ...] is the rank of
+        # image k's value at each pixel. Comparing ranks avoids scattering
+        # into the mask with per-pixel indices, which the array API standard
+        # does not support.
         argsorted = xp.argsort(self._data_arr, axis=0)
-        # Not every array package has mgrid, so make it in numpy and convert it to the
-        # array package used for the data.
-        mg = xp.asarray(
-            np_mgrid[
-                [slice(ndim) for i, ndim in enumerate(self._data_arr.shape) if i > 0]
-            ],
-            device=array_api_compat.device(self._data_arr),
-        )
-        for i in range(-1 * nhigh, nlow):
-            coordinates = [xp.reshape(argsorted[(i, ...)], (-1,))]
-            coordinates.extend(
-                xp.reshape(mg[(axis, ...)], (-1,)) for axis in range(mg.shape[0])
-            )
-            # Some array libraries don't support indexing with arrays in multiple
-            # dimensions, so we need to flatten the mask array, set the mask
-            # values for a flattened array, and then reshape it back to the
-            # original shape.
-            flat_index = coordinates[0]
-            for coordinate, dimension in zip(
-                coordinates[1:], self._data_arr.shape[1:], strict=True
-            ):
-                flat_index = flat_index * dimension + coordinate
-            self._data_arr_mask = xp.reshape(
-                xpx.at(xp.reshape(self._data_arr_mask, (-1,)))[flat_index].set(True),
-                self._data_arr.shape,
-            )
+        ranks = xp.argsort(argsorted, axis=0)
+        clip = (ranks < nlow) | (ranks >= n_images - nhigh)
+        self._data_arr_mask = self._data_arr_mask | clip
 
     # set up min/max clipping algorithms
     def minmax_clipping(self, min_clip=None, max_clip=None):

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1226,21 +1226,6 @@ def test_3d_combiner_with_scaling():
     assert avg_ccd.shape == ccd_data.shape
 
 
-def _clip_extrema_combiner(data):
-    if xp.__name__ == "array_api_strict":
-        # Bypass Combiner.__init__ only for array-api-strict, which cannot stack
-        # a list of arrays. This isolates clip_extrema from that separate limit.
-        combiner = object.__new__(Combiner)
-        combiner._xp = xp
-        combiner._data_arr = xp.asarray(data, device=xp_device)
-        combiner._data_arr_mask = xp.zeros(
-            combiner._data_arr.shape, dtype=xp.bool, device=xp_device
-        )
-    else:
-        combiner = Combiner([CCDData(xp.asarray(image), unit=u.adu) for image in data])
-    return combiner
-
-
 def test_clip_extrema_stays_in_array_namespace_and_device():
     data = [
         [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
@@ -1248,7 +1233,9 @@ def test_clip_extrema_stays_in_array_namespace_and_device():
         [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
     ]
 
-    c = _clip_extrema_combiner(data)
+    c = Combiner(
+        [CCDData(xp.asarray(image, device=xp_device), unit=u.adu) for image in data]
+    )
     c.clip_extrema(nlow=1, nhigh=1)
 
     expected_mask = xp.asarray(
@@ -1270,7 +1257,9 @@ def test_clip_extrema_masks_expected_indices():
     # identical to the pre-rewrite behavior for this input.
     data = [[[5.0, 1.0]], [[5.0, 4.0]], [[3.0, 2.0]], [[5.0, 3.0]]]
 
-    c = _clip_extrema_combiner(data)
+    c = Combiner(
+        [CCDData(xp.asarray(image, device=xp_device), unit=u.adu) for image in data]
+    )
     c.clip_extrema(nlow=1, nhigh=1)
 
     expected_mask = xp.asarray(

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -1226,13 +1226,7 @@ def test_3d_combiner_with_scaling():
     assert avg_ccd.shape == ccd_data.shape
 
 
-def test_clip_extrema_keeps_indices_in_array_namespace(monkeypatch):
-    data = [
-        [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
-        [[3.0, 6.0, 5.0], [9.0, 2.0, 8.0]],
-        [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
-    ]
-
+def _clip_extrema_combiner(data):
     if xp.__name__ == "array_api_strict":
         # Bypass Combiner.__init__ only for array-api-strict, which cannot stack
         # a list of arrays. This isolates clip_extrema from that separate limit.
@@ -1244,38 +1238,18 @@ def test_clip_extrema_keeps_indices_in_array_namespace(monkeypatch):
         )
     else:
         combiner = Combiner([CCDData(xp.asarray(image), unit=u.adu) for image in data])
+    return combiner
 
-    captured_indices = []
-    if xp.__name__ == "array_api_strict":
-        # array-api-strict deliberately implements only standard indexing, which
-        # excludes the integer-array assignment performed by xpx.at. Replace that
-        # final update only, so this backend can exercise and inspect the index
-        # calculation on a non-default device.
-        class AtSpy:
-            def __init__(self, array):
-                self.array = array
 
-            def __getitem__(self, index):
-                self.index = index
-                captured_indices.append(index)
-                return self
+def test_clip_extrema_stays_in_array_namespace_and_device():
+    data = [
+        [[9.0, 2.0, 7.0], [4.0, 8.0, 1.0]],
+        [[3.0, 6.0, 5.0], [9.0, 2.0, 8.0]],
+        [[6.0, 1.0, 4.0], [2.0, 7.0, 3.0]],
+    ]
 
-            def set(self, value):
-                device = array_api_compat.device(self.array)
-                positions = xp.arange(self.array.shape[0], device=device)
-                selected = xp.any(
-                    xp.reshape(positions, (-1, 1)) == xp.reshape(self.index, (1, -1)),
-                    axis=1,
-                )
-                return xp.where(
-                    selected,
-                    xp.asarray(value, dtype=self.array.dtype, device=device),
-                    self.array,
-                )
-
-        monkeypatch.setattr("ccdproc.combiner.xpx.at", AtSpy)
-
-    combiner.clip_extrema(nlow=1, nhigh=1)
+    c = _clip_extrema_combiner(data)
+    c.clip_extrema(nlow=1, nhigh=1)
 
     expected_mask = xp.asarray(
         [
@@ -1285,21 +1259,30 @@ def test_clip_extrema_keeps_indices_in_array_namespace(monkeypatch):
         ],
         device=xp_device,
     )
-    assert xp.all(combiner.mask == expected_mask)
-    assert array_api_compat.device(combiner.mask) == array_api_compat.device(
-        combiner.data
+    assert array_api_compat.array_namespace(c._data_arr_mask) is xp
+    assert array_api_compat.device(c.mask) == array_api_compat.device(c.data)
+    assert xp.all(c.mask == expected_mask)
+
+
+def test_clip_extrema_masks_expected_indices():
+    # pixel [0, 0] is a 3-way tie at 5.0; with the standard's stable=True
+    # argsort the last tied image (index 3) is the one nhigh masks --
+    # identical to the pre-rewrite behavior for this input.
+    data = [[[5.0, 1.0]], [[5.0, 4.0]], [[3.0, 2.0]], [[5.0, 3.0]]]
+
+    c = _clip_extrema_combiner(data)
+    c.clip_extrema(nlow=1, nhigh=1)
+
+    expected_mask = xp.asarray(
+        [
+            [[False, True]],
+            [[False, True]],
+            [[True, False]],
+            [[True, False]],
+        ],
+        device=xp_device,
     )
-    if captured_indices:
-        expected_indices = (
-            xp.asarray([0, 7, 2, 9, 4, 11], device=xp_device),
-            xp.asarray([6, 13, 14, 15, 10, 5], device=xp_device),
-        )
-        assert len(captured_indices) == len(expected_indices)
-        for actual, expected in zip(captured_indices, expected_indices, strict=True):
-            assert xp.all(actual == expected)
-            assert array_api_compat.device(actual) == array_api_compat.device(
-                combiner.data
-            )
+    assert xp.all(c.mask == expected_mask)
 
 
 def test_clip_extrema_3d():


### PR DESCRIPTION
Part of #971 (the clip_extrema bucket).

`array_api_strict` strict test run on top of `main` (711bb26): **41 failed → 37 failed**, no new failures on any of the four backends (numpy, jax, dask, strict). The failure list after this change is identical to `main`'s minus the four `clip_extrema` tests.

`Combiner.clip_extrema` masked the `nlow` lowest and `nhigh` highest per-pixel values by building flat integer indices by hand and scattering into the mask with `xpx.at(...)[flat_index].set(True)` -- the only integer-array `xpx.at(...).set` call anywhere in the codebase. `array_api_strict` rejects fancy-indexed `__setitem__`, and there is no `put_along_axis` in the array API standard, so this raised `IndexError` on strict.

A second `argsort` along axis 0 inverts the first: `ranks[k, ...]` is the rank of image k value at each pixel, so comparing ranks against `nlow`/`nhigh` produces the identical mask without any scatter. Both `argsort` calls default to `stable=True`, so tie-breaking is unchanged from the old code -- verified against a hand-written reference implementation across 8400 random trials (with ties and NaNs, several shapes) run against the new code path, 0 mismatches. This also let the `numpy.mgrid`-based coordinate construction and the now-unused `from numpy import mgrid as np_mgrid` import be deleted.

`test_clip_extrema_keeps_indices_in_array_namespace`, which existed to spy on the removed scatter indices via a monkeypatched `xpx.at`, no longer has anything to spy on. It is replaced with two tests: one checking the resulting mask namespace/device (reusing the same tied `(3, 2, 3)` fixture data and expected mask), and one checking the mask content directly against a documented 3-way tie.

The four target strict failures (`test_clip_extrema_3d`, `_alone`, `_via_combine`, `_with_other_rejection`) all pass; numpy, jax (`JAX_ENABLE_X64=True`), and dask are unaffected (same pass/skip/xfail counts as `main`, no failures). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME
