### PR TITLE
Fix array-namespace dtype handling in ccd_process, transform_image, combine, and ImageFileCollection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,7 +101,7 @@ Bug Fixes
 - Use the array namespace's ``bool`` for the ``ccd_process`` bad-pixel mask,
   cast the mask in ``transform_image`` to the data dtype before transforming
   it, and convert FITS data to native byte order before handing it to a
-  non-NumPy array namespace in ``combine`` and ``ImageFileCollection``. [#NNN]
+  non-NumPy array namespace in ``combine`` and ``ImageFileCollection``. [#995]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,10 @@ Bug Fixes
   device: put the gain and flat normalization on the device of the data, cast
   an integer gain to float, and keep the uncertainty propagation for
   multiplication and division out of NumPy. [#993]
+- Use the array namespace's ``bool`` for the ``ccd_process`` bad-pixel mask,
+  cast the mask in ``transform_image`` to the data dtype before transforming
+  it, and convert FITS data to native byte order before handing it to a
+  non-NumPy array namespace in ``combine`` and ``ImageFileCollection``. [#NNN]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -21,7 +21,7 @@ from astropy.utils import deprecated_renamed_argument
 from numpy import mgrid as np_mgrid
 
 from ._nanfuncs import nanmean, nanmedian, nanstd, nansum
-from .core import sigma_func
+from .core import _native_numpy, sigma_func
 
 __all__ = ["Combiner", "combine"]
 
@@ -1088,11 +1088,16 @@ def combine(
             except TypeError:
                 xp = array_package
 
-            ccd.data = xp.asarray(ccd.data, dtype=ccd.data.dtype.type)
+            # ccd.data (and its uncertainty, if any) were just read from a
+            # FITS file, so they are NumPy arrays, possibly in big-endian
+            # byte order. Convert to native byte order before handing them
+            # to a non-NumPy namespace: some namespaces reject non-native
+            # dtypes outright, and array_api_strict warns (which becomes an
+            # error under this project's warning filters) when a NumPy
+            # dtype object is compared against one of its own.
+            ccd.data = xp.asarray(_native_numpy(ccd.data))
             if ccd.uncertainty is not None:
-                ccd.uncertainty.array = xp.asarray(
-                    ccd.uncertainty.array, dtype=ccd.uncertainty.array.dtype.type
-                )
+                ccd.uncertainty.array = xp.asarray(_native_numpy(ccd.uncertainty.array))
             # The mask is converted below, once the namespace is known.
 
     # Get the array namespace; if array_package was not None and files were read in,

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -98,6 +98,32 @@ def _is_array(arr):
     return True
 
 
+def _native_numpy(arr):
+    """
+    Return a NumPy array with the same data in native byte order.
+
+    Data read from a FITS file is big-endian (e.g. dtype ``>f8``), a byte
+    order that only NumPy understands. Non-NumPy array namespaces (and
+    ``array_api_strict``) reject such a dtype outright, or, if the dtype
+    happens to be native-endian already, warn when it is compared against
+    their own dtype objects. Converting to native byte order first and
+    handing the resulting plain NumPy array to ``xp.asarray`` avoids both
+    problems.
+
+    Parameters
+    ----------
+    arr : `numpy.ndarray`
+        A NumPy array, possibly in non-native byte order.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        ``arr`` converted to its dtype's native scalar type. No copy is made
+        if one is not required.
+    """
+    return arr.astype(arr.dtype.type, copy=False)
+
+
 def _percentile_fallback(array, percentiles, xp=None):
     """
     Try calculating percentile using namespace, otherwise fall back to
@@ -380,7 +406,7 @@ def ccd_process(
         # TODO: the private _mask attribute is set here to avoid the
         # mask.setter than sets the mask to a numpy array. This can be
         # removed when CCDData supports array namespaces.
-        nccd._mask = xp.asarray(bad_pixel_mask, dtype=bool)
+        nccd._mask = xp.asarray(bad_pixel_mask, dtype=xp.bool)
     else:
         raise TypeError("bad_pixel_mask is not None or an array.")
 
@@ -1147,6 +1173,9 @@ def transform_image(ccd, transform_func, **kwargs):
     # make a copy of the object
     _nccd = _ccd.copy()
 
+    # Set array namespace
+    xp = array_api_compat.array_namespace(_nccd.data)
+
     # transform the image plane
     try:
         _nccd.data = transform_func(_nccd.data, **kwargs)
@@ -1161,7 +1190,11 @@ def transform_image(ccd, transform_func, **kwargs):
 
     # transform the mask plane
     if _nccd.mask is not None:
-        mask = transform_func(_nccd.mask, **kwargs)
+        # Cast the boolean mask to the data's dtype before transforming it;
+        # most transform functions (e.g. scipy.ndimage.shift) do not accept
+        # boolean input, so treat the mask as numeric and re-threshold the
+        # result below.
+        mask = transform_func(xp.astype(_nccd.mask, _nccd.data.dtype), **kwargs)
         _nccd.mask = mask > 0
 
     if _nccd.wcs is not None:

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -102,15 +102,6 @@ def _native_numpy(arr):
     """
     Return a NumPy array with the same data in native byte order.
 
-    Data read from a FITS file is big-endian (e.g. dtype ``>f8``), a byte
-    order that only NumPy understands; other array namespaces reject such
-    an array outright. Requesting ``dtype=arr.dtype.type`` from
-    ``xp.asarray`` works around that in NumPy and JAX but hands a NumPy
-    type object to the namespace, which ``array_api_strict`` warns about.
-    Converting to native byte order in NumPy first and handing the
-    resulting plain array to ``xp.asarray`` with no ``dtype`` avoids both
-    problems.
-
     Parameters
     ----------
     arr : `numpy.ndarray`
@@ -121,6 +112,17 @@ def _native_numpy(arr):
     `numpy.ndarray`
         ``arr`` converted to its dtype's native scalar type. No copy is made
         if one is not required.
+
+    Notes
+    -----
+    Data read from a FITS file is big-endian (e.g. dtype ``>f8``), a byte
+    order that only NumPy understands; other array namespaces reject such
+    an array outright. Requesting ``dtype=arr.dtype.type`` from
+    ``xp.asarray`` works around that in NumPy and JAX but hands a NumPy
+    type object to the namespace, which ``array_api_strict`` warns about.
+    Converting to native byte order in NumPy first and handing the
+    resulting plain array to ``xp.asarray`` with no ``dtype`` avoids both
+    problems.
     """
     return arr.astype(arr.dtype.type, copy=False)
 

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -103,11 +103,12 @@ def _native_numpy(arr):
     Return a NumPy array with the same data in native byte order.
 
     Data read from a FITS file is big-endian (e.g. dtype ``>f8``), a byte
-    order that only NumPy understands. Non-NumPy array namespaces (and
-    ``array_api_strict``) reject such a dtype outright, or, if the dtype
-    happens to be native-endian already, warn when it is compared against
-    their own dtype objects. Converting to native byte order first and
-    handing the resulting plain NumPy array to ``xp.asarray`` avoids both
+    order that only NumPy understands; other array namespaces reject such
+    an array outright. Requesting ``dtype=arr.dtype.type`` from
+    ``xp.asarray`` works around that in NumPy and JAX but hands a NumPy
+    type object to the namespace, which ``array_api_strict`` warns about.
+    Converting to native byte order in NumPy first and handing the
+    resulting plain array to ``xp.asarray`` with no ``dtype`` avoids both
     problems.
 
     Parameters

--- a/ccdproc/image_collection.py
+++ b/ccdproc/image_collection.py
@@ -15,6 +15,7 @@ from astropy.table import MaskedColumn, Table
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .ccddata import _recognized_fits_file_extensions, fits_ccddata_reader
+from .core import _native_numpy
 
 # ==> numpy comment <==
 # numpy is used internally to keep track of masking in the summary
@@ -954,25 +955,31 @@ class ImageFileCollection:
                 # By default we will get a numpy array, but if the user
                 # specified an array package, we will convert it to that type.
                 if xp is not None:
-                    return_thing = xp.asarray(
-                        # Turns out only numpy understands dtypes like ">f8" so use
-                        # .type
-                        return_thing,
-                        dtype=return_thing.dtype.type,
-                    )
+                    # return_thing was just read from a FITS file, so it is a
+                    # NumPy array, possibly in big-endian byte order.
+                    # Converting to native byte order first lets a non-NumPy
+                    # namespace accept it.
+                    return_thing = xp.asarray(_native_numpy(return_thing))
             elif return_type == "ccd":
                 return_thing = fits_ccddata_reader(full_path, hdu=ccd_hdu, **ccd_kwargs)
                 if xp is not None:
-                    return_thing.data = xp.asarray(
-                        return_thing.data, dtype=return_thing.data.dtype.type
-                    )
+                    # As above: convert to native byte order before handing
+                    # the FITS-derived data to a non-NumPy namespace.
+                    return_thing.data = xp.asarray(_native_numpy(return_thing.data))
                     if return_thing.uncertainty is not None:
                         return_thing.uncertainty.array = xp.asarray(
-                            return_thing.uncertainty.array,
-                            dtype=return_thing.uncertainty.array.dtype.type,
+                            _native_numpy(return_thing.uncertainty.array)
                         )
                     if return_thing.mask is not None:
-                        return_thing.mask = xp.asarray(return_thing.mask, dtype=bool)
+                        # Set the private _mask attribute directly: the
+                        # public mask setter (CCDData -> NDDataArray)
+                        # always converts its value to a NumPy array, which
+                        # would silently undo the namespace conversion here.
+                        # TODO: remove this workaround when CCDData supports
+                        # array namespaces.
+                        return_thing._mask = xp.asarray(
+                            return_thing.mask, dtype=xp.bool
+                        )
 
             elif return_type == "hdu":
                 with fits.open(full_path, **add_kwargs) as hdulist:

--- a/ccdproc/log_meta.py
+++ b/ccdproc/log_meta.py
@@ -139,11 +139,15 @@ def _replace_array_with_placeholder(value):
         try:
             length = len(value)
         except TypeError:
-            # Value has no length...
+            # Value has no length. This includes array API arrays that
+            # deliberately do not implement __len__ (e.g. array_api_strict,
+            # per the array API standard), not just NDData.
             try:
-                # ...but if it is NDData its .data will have a length
+                # ...but if it is NDData its .data will have a length. A
+                # bare array-API array has no .data attribute, hence the
+                # AttributeError below.
                 length = len(value.data)
-            except TypeError:
+            except (TypeError, AttributeError):
                 # No idea what this data is, assume length is not 1
                 length = 42
         return_type_not_value = length > 1

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -838,8 +838,10 @@ def test_transform_image(mask_data, uncertainty):
     if mask_data:
         # Set the _mask rather than .mask to avoid issues with array-api
         # TODO: Fix this when CCDData is array-api compliant
-        ccd_data._mask = xp.zeros_like(ccd_data.data)
-        xpx.at(ccd_data._mask)[10, 10].set(1)
+        ccd_data._mask = xp.zeros_like(ccd_data.data, dtype=xp.bool)
+        # xpx.at(...).set(...) returns the updated array rather than
+        # mutating in place, so the return value must be kept.
+        ccd_data._mask = xpx.at(ccd_data._mask)[10, 10].set(True)
     if uncertainty:
         err = RNG().normal(size=ccd_data.shape)
         ccd_data.uncertainty = StdDevUncertainty(xp.asarray(err))
@@ -853,6 +855,12 @@ def test_transform_image(mask_data, uncertainty):
     if mask_data:
         assert tran.shape == tran.mask.shape
         assert xp.all(xpx.isclose(ccd_data.mask, tran.mask))
+        # The mask was True only at [10, 10]; check that the transformed
+        # mask preserves that location instead of, say, being trivially
+        # all-True or all-False.
+        expected_mask = xp.zeros_like(tran.mask, dtype=xp.bool)
+        expected_mask = xpx.at(expected_mask)[10, 10].set(True)
+        assert xp.all(tran.mask == expected_mask)
     if uncertainty:
         assert tran.shape == tran.uncertainty.array.shape
         assert xp.all(
@@ -1294,7 +1302,7 @@ def test_ccd_process(uncertainty_type):
 
     ccd_data.meta["testkw"] = 100
 
-    mask = xp.zeros((100, 90))
+    mask = xp.zeros((100, 90), dtype=xp.bool)
 
     masterbias = CCDData(2.0 * xp.ones((100, 90)), unit=u.electron)
     masterbias.uncertainty = uncertainty_type(xp.zeros((100, 90)))
@@ -1363,7 +1371,9 @@ def test_ccd_process(uncertainty_type):
     assert xp.all(
         xpx.isclose(expected_error_factor * xp.ones((100, 90)), occd.uncertainty.array)
     )
-    assert xp.all(xpx.isclose(mask, occd.mask))
+    # ``mask`` is boolean, so compare exactly instead of with ``isclose``,
+    # which strict array namespaces only accept numeric dtypes for.
+    assert xp.all(mask == occd.mask)
     assert occd.unit == u.electron
     # Make sure the original keyword is still present. Regression test for #401
     assert occd.meta["testkw"] == 100
@@ -1377,7 +1387,7 @@ def test_ccd_process_gain_corrected():
     ccd_data.data = xp.concat([ccd_data.data[:, :-10], 2 * xp.ones((100, 10))], axis=1)
     ccd_data.meta["testkw"] = 100
 
-    mask = xp.zeros((100, 90))
+    mask = xp.zeros((100, 90), dtype=xp.bool)
 
     masterbias = CCDData(4.0 * xp.ones((100, 90)), unit=u.adu)
     masterbias.uncertainty = StdDevUncertainty(xp.zeros((100, 90)))
@@ -1411,7 +1421,9 @@ def test_ccd_process_gain_corrected():
 
     assert xp.all(xpx.isclose(2.0 * xp.ones((100, 90)), occd.data))
     assert xp.all(xpx.isclose(3.0 * xp.ones((100, 90)), occd.uncertainty.array))
-    assert xp.all(xpx.isclose(mask, occd.mask))
+    # ``mask`` is boolean, so compare exactly instead of with ``isclose``,
+    # which strict array namespaces only accept numeric dtypes for.
+    assert xp.all(mask == occd.mask)
     assert occd.unit == u.electron
     # Make sure the original keyword is still present. Regression test for #401
     assert occd.meta["testkw"] == 100

--- a/ccdproc/tests/test_ccdproc_logging.py
+++ b/ccdproc/tests/test_ccdproc_logging.py
@@ -7,6 +7,7 @@ from astropy.nddata import CCDData
 from ccdproc import Keyword, create_deviation, subtract_bias, trim_image
 from ccdproc.conftest import testing_array_library as xp
 from ccdproc.core import _short_names
+from ccdproc.log_meta import _replace_array_with_placeholder
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 
 
@@ -108,3 +109,26 @@ def test_logging_with_really_long_parameter_value():
     )
     trim_3 = trim_image(ccd, fits_section=section)
     assert section in trim_3.header[_short_names["trim_image"]]
+
+
+def test_replace_array_with_placeholder_no_len_no_data():
+    # Regression test for the "length = 42" fallback: an array API object
+    # with neither __len__ nor a .data attribute (like an array-api-strict
+    # array) should still be replaced with a placeholder string.
+    class NoLenNoData:
+        def __array_namespace__(self, *args, **kwargs):
+            return None
+
+    result = _replace_array_with_placeholder(NoLenNoData())
+    assert result == "<NoLenNoData>"
+
+    # If the object has a .data attribute of length 1 it is treated like
+    # NDData and returned unchanged.
+    class NoLenWithData:
+        def __array_namespace__(self, *args, **kwargs):
+            return None
+
+        data = [0]
+
+    obj = NoLenWithData()
+    assert _replace_array_with_placeholder(obj) is obj

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -479,6 +479,11 @@ class TestImageFileCollection:
         assert array_api_compat.array_namespace(ccd.uncertainty.array) is xp
         assert ccd.mask.dtype == xp.bool
 
+        # collection.data() goes through the same conversion, but as a
+        # bare array rather than a CCDData.
+        data = next(collection.data())
+        assert array_api_compat.array_namespace(data) is xp
+
     def test_consecutive_fiilters(self, triage_setup):
         collection = ImageFileCollection(
             location=triage_setup.test_dir, keywords=["imagetyp", "filter", "object"]

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -7,17 +7,21 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, TemporaryDirectory, mkdtemp
 
+import array_api_compat
 import astropy.io.fits as fits
 
-# Will continue to use np.testing here we are not testing array API
+# Will continue to use np.testing here we are not testing array API,
+# except in the one test that specifically checks that ccds()/data()
+# honor the array namespace requested via array_package.
 import numpy as np
 import pytest
 from astropy.io.fits.verify import VerifyWarning
-from astropy.nddata import CCDData
+from astropy.nddata import CCDData, StdDevUncertainty
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 
+from ccdproc.conftest import testing_array_library as xp
 from ccdproc.image_collection import ImageFileCollection
 
 _filters = []
@@ -456,6 +460,24 @@ class TestImageFileCollection:
         ccd_kwargs = {"unit": "adu"}
         for ccd in collection.ccds(ccd_kwargs=ccd_kwargs):
             assert isinstance(ccd, CCDData)
+
+    def test_generator_ccds_converts_to_array_namespace(self, tmp_path):
+        # A collection constructed with array_package=xp should hand
+        # data/uncertainty/mask read from FITS files to that namespace.
+        # This exercises the same FITS-to-namespace conversion as
+        # combine() (#971).
+        fitsfile = get_pkg_data_filename("data/a8280271.fits", package="ccdproc.tests")
+        ccd_data = CCDData.read(fitsfile, unit="adu")
+        ccd_data.mask = np.zeros(ccd_data.shape, dtype=bool)
+        ccd_data.uncertainty = StdDevUncertainty(np.ones(ccd_data.shape))
+        ccd_data.write(tmp_path / "with_mask_and_uncertainty.fits")
+
+        collection = ImageFileCollection(location=tmp_path, array_package=xp)
+        ccd = next(collection.ccds(ccd_kwargs={"unit": "adu"}))
+
+        assert array_api_compat.array_namespace(ccd.data) is xp
+        assert array_api_compat.array_namespace(ccd.uncertainty.array) is xp
+        assert ccd.mask.dtype == xp.bool
 
     def test_consecutive_fiilters(self, triage_setup):
         collection = ImageFileCollection(


### PR DESCRIPTION
Part of #971 (the "namespace dtypes" bucket).

Strict-backend count on top of `main` `711bb26`: **41 failed -> 35 failed** (456 -> 463 passed; 43 xfailed, 5 xpassed unchanged). No test regresses on strict, numpy, jax, or dask.

`ccd_process`, `transform_image`, `combine()`, and `ImageFileCollection.ccds()`/`data()` all leaked NumPy-specific dtype conventions across the array-namespace boundary: a builtin `bool` instead of `xp.bool` for `ccd_process`'s bad-pixel mask, running a transform function directly on a boolean mask in `transform_image`, and handing a NumPy dtype *object* (rather than a plain array) to `xp.asarray(..., dtype=...)` when converting FITS data to a requested namespace in `combine()` and `ImageFileCollection`. Each is fixed to speak the array API idiom already used elsewhere in the codebase (`xp.bool`, casting the mask to the data dtype before transforming, converting to native byte order and letting `xp.asarray` do a plain conversion). A new `_native_numpy` helper in `core.py`, next to `_is_array`, is shared by `combine()` and `ImageFileCollection`. `ImageFileCollection`'s mask conversion also had to switch from the public `.mask` setter to the private `_mask` attribute, since `CCDData`'s public setter unconditionally converts its value back to NumPy - the same workaround `ccd_process` already used, with a `TODO` to remove it once `CCDData` supports array namespaces.

Fixing `ccd_process`'s mask dtype uncovered a second, previously-masked bug: `log_meta.py`'s `_replace_array_with_placeholder` (used by the `@log_to_metadata` decorator to build the auto-logging string) crashed for a bare, non-`NDData` array-API array that does not implement `__len__` - which `array_api_strict` deliberately does not, per the array API standard. It fell through to `value.data`, which such an array does not have, raising `AttributeError` instead of the `TypeError` the code was written to catch. That crash was masking `ccd_process`'s tests even after the mask-dtype fix, so it is fixed here too (broadened the `except` to also catch `AttributeError`).

Test-body fixes bundled with the corresponding source fix: `test_transform_image` discarded the return value of `xpx.at(...).set(...)` (a silent no-op on JAX/strict, the same class of bug as #963) and did not build a real boolean mask; both are fixed, and the test now asserts the transformed mask is `True` only at the expected pixel. `test_ccd_process`/`test_ccd_process_gain_corrected` built their bad-pixel mask as a float array and compared it against the (now boolean) result with `xpx.isclose`, which strict namespaces reject for non-numeric dtypes; both now build a boolean mask and compare with `==`. A new `test_generator_ccds_converts_to_array_namespace` in `test_image_collection.py` exercises the same FITS-to-namespace conversion in `ImageFileCollection.ccds()` that `combine()` already had a regression test for (A4 in the working plan; not on the original strict-failure list since no existing test passed `array_package=` to `ImageFileCollection`, but the code path is byte-for-byte the same pattern as `combine()`, so it is included here).

One target test remains failing on strict for a reason outside this PR's scope: `test_combine_ccd_with_uncertainty_and_mask_from_fits[function]` reaches a second, unrelated bug once this PR's fix to `combine()` clears the first one - `test_combiner.py`'s `_make_mean_scaler` calls `ccd_data.data.mean()` as a method, which `array_api_strict` arrays do not support (only the top-level `xp.mean` function form is part of the standard). That is a bug in `test_combiner.py`, a file intentionally left untouched here to avoid conflicting with a parallel PR (fixing `Combiner.clip_extrema`) also touching that file; `[mean]` (the other parametrization) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME
