### PR TITLE
Narrow two stale backend_xfail markers in test_cosmicray.py

### DIFF
--- a/ccdproc/tests/test_cosmicray.py
+++ b/ccdproc/tests/test_cosmicray.py
@@ -254,17 +254,36 @@ def _run_cosmicray_gain_correct_uncertainty(
     )
 
 
-@pytest.mark.backend_xfail(
+# Only the gain_apply=True cases still fail on array-api-strict; the
+# gain_apply=False cases pass on every backend.
+_GAIN_APPLY_STRICT_XFAIL = pytest.mark.backend_xfail(
     "array-api-strict",
     reason="cosmicray_lacosmic's gain and mask paths do not support "
     "array-api-strict's strict scalar and dtype rules",
 )
+
+
 @pytest.mark.parametrize(
     ("uncertainty_type", "gain_power", "gain_apply"),
     [
-        (StdDevUncertainty, 1, True),
-        (VarianceUncertainty, 2, True),
-        (InverseVariance, -2, True),
+        pytest.param(
+            StdDevUncertainty,
+            1,
+            True,
+            marks=_GAIN_APPLY_STRICT_XFAIL,
+        ),
+        pytest.param(
+            VarianceUncertainty,
+            2,
+            True,
+            marks=_GAIN_APPLY_STRICT_XFAIL,
+        ),
+        pytest.param(
+            InverseVariance,
+            -2,
+            True,
+            marks=_GAIN_APPLY_STRICT_XFAIL,
+        ),
         (StdDevUncertainty, 1, False),
         (VarianceUncertainty, 2, False),
         (InverseVariance, -2, False),
@@ -484,15 +503,22 @@ def _masked_column_image(seed=1, sigma=1.0):
     return np_data, np_mask, crays
 
 
-@pytest.mark.backend_xfail(
-    "array-api-strict",
-    reason="cosmicray_median uses scipy.ndimage.median_filter, which "
-    "requires numpy and fails on a non-default device",
-)
 # (The CCDData branch takes its error image from the uncertainty.)
 @pytest.mark.parametrize(
     "kind,error_image",
-    [("masked_array", 1.0), ("masked_array", None), ("ccddata", None)],
+    [
+        ("masked_array", 1.0),
+        ("masked_array", None),
+        pytest.param(
+            "ccddata",
+            None,
+            marks=pytest.mark.backend_xfail(
+                "array-api-strict",
+                reason="cosmicray_median uses scipy.ndimage.median_filter, which "
+                "requires numpy and fails on a non-default device",
+            ),
+        ),
+    ],
 )
 def test_cosmicray_median_masked_column(kind, error_image):
     # Masked pixels are never flagged, not even by the gbox growth step,


### PR DESCRIPTION
Part of #971 (stale `backend_xfail` markers).

On `main` `6724c8e`, strict test_cosmicray.py shows 5 xpassed (failing narrowly at the scope of parametrised function-level markers). After this change: 0 xpassed.

The markers for `test_cosmicray_median_masked_column` and `test_cosmicray_gain_correct_uncertainty_namespace` were function-level and covered all parametrisations, but only a subset still fail on array-api-strict. In the former, masked_array cases pass because they never put data on device1. In the latter, gain_apply=False cases pass on all backends. Both markers are now narrowed to only the parametrisations that still fail.

The #958 astroscrappy-reason correction listed in #971 section 2 was already done on main in `d33d7cf` — no action needed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME