### PR TITLE
Fix strict array-API test bodies in test_combiner/test_ccdproc/test_image_collection

### DIFF
--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -88,11 +88,16 @@ def numpy_copy(array):
     ``np.asarray`` only works for arrays on the namespace's default
     device. The strict tests run on ``Device("device1")``, on which
     array-api-strict deliberately refuses to export to NumPy, so the array
-    is moved to the default device first.
+    is moved to the default device first. That move is a no-op on every
+    other backend the suite runs. The default device is asked for through
+    the standard ``__array_namespace_info__().default_device()``, which
+    the 2025.12 standard allows to be `None` (JAX does this); in that case
+    there is nothing to move to and ``np.asarray`` is used directly.
     """
     xp = array_api_compat.array_namespace(array)
-    if xp.__name__ == "array_api_strict":
-        array = xp.asarray(array, device=xp.Device("CPU_DEVICE"))
+    default_device = xp.__array_namespace_info__().default_device()
+    if default_device is not None:
+        array = array_api_compat.to_device(array, default_device)
     return np.asarray(array)
 
 

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -2,6 +2,7 @@
 
 from shutil import rmtree
 
+import array_api_compat
 import numpy as np
 import pytest
 from astropy import units as u
@@ -66,6 +67,39 @@ def ccd_data(
     ccd = CCDData(xp.asarray(data, device=xp_device), unit=u.adu)
     ccd.header = fake_meta
     return ccd
+
+
+def numpy_copy(array):
+    """
+    Return a NumPy copy of ``array``, moving it off a non-default device first.
+
+    ``np.asarray`` raises on an array-api-strict array that lives on one of
+    the library's fake non-default devices (the suite runs strict tests on
+    ``Device("device1")`` for exactly that reason), so move the array to the
+    default device before converting.
+    """
+    xp = array_api_compat.array_namespace(array)
+    if xp.__name__ == "array_api_strict":
+        array = xp.asarray(array, device=xp.Device("CPU_DEVICE"))
+    return np.asarray(array)
+
+
+def numpy_ccddata(ccd):
+    """
+    Return a copy of ``ccd`` with ``data``, ``mask`` and ``uncertainty.array``
+    (when present) converted to NumPy via `numpy_copy`.
+
+    Unit and meta are copied over unchanged. Useful for handing a namespace
+    ``CCDData`` to code that requires NumPy, such as ``CCDData.write``.
+    """
+    new_ccd = CCDData(numpy_copy(ccd.data), unit=ccd.unit, meta=ccd.meta)
+    if ccd.mask is not None:
+        new_ccd.mask = numpy_copy(ccd.mask)
+    if ccd.uncertainty is not None:
+        new_ccd.uncertainty = ccd.uncertainty.__class__(
+            numpy_copy(ccd.uncertainty.array)
+        )
+    return new_ccd
 
 
 @pytest.fixture

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -71,12 +71,24 @@ def ccd_data(
 
 def numpy_copy(array):
     """
-    Return a NumPy copy of ``array``, moving it off a non-default device first.
+    Return a NumPy copy of an array from any array namespace.
 
-    ``np.asarray`` raises on an array-api-strict array that lives on one of
-    the library's fake non-default devices (the suite runs strict tests on
-    ``Device("device1")`` for exactly that reason), so move the array to the
-    default device before converting.
+    Parameters
+    ----------
+    array : array-like
+        An array from any array-API namespace, on any device.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        A NumPy array with the same shape, dtype and values as ``array``.
+
+    Notes
+    -----
+    ``np.asarray`` only works for arrays on the namespace's default
+    device. The strict tests run on ``Device("device1")``, on which
+    array-api-strict deliberately refuses to export to NumPy, so the array
+    is moved to the default device first.
     """
     xp = array_api_compat.array_namespace(array)
     if xp.__name__ == "array_api_strict":
@@ -86,11 +98,25 @@ def numpy_copy(array):
 
 def numpy_ccddata(ccd):
     """
-    Return a copy of ``ccd`` with ``data``, ``mask`` and ``uncertainty.array``
-    (when present) converted to NumPy via `numpy_copy`.
+    Return a copy of a ``CCDData`` whose arrays are all NumPy arrays.
 
-    Unit and meta are copied over unchanged. Useful for handing a namespace
-    ``CCDData`` to code that requires NumPy, such as ``CCDData.write``.
+    Parameters
+    ----------
+    ccd : `~astropy.nddata.CCDData`
+        Image whose ``data``, and ``mask`` and ``uncertainty`` if present,
+        may be in any array namespace.
+
+    Returns
+    -------
+    `~astropy.nddata.CCDData`
+        A new ``CCDData`` with ``data``, ``mask`` and ``uncertainty.array``
+        converted with `numpy_copy`; ``unit`` and ``meta`` are carried over
+        unchanged and the uncertainty keeps its class.
+
+    Notes
+    -----
+    Use this to hand a namespace ``CCDData`` to code that requires NumPy,
+    such as ``CCDData.write``.
     """
     new_ccd = CCDData(numpy_copy(ccd.data), unit=ccd.unit, meta=ccd.meta)
     if ccd.mask is not None:

--- a/ccdproc/tests/test_ccdproc.py
+++ b/ccdproc/tests/test_ccdproc.py
@@ -292,6 +292,11 @@ def test_subtract_overscan(median, transpose, data_rectangle):
 
 
 # A more substantial test of overscan modeling
+@pytest.mark.backend_xfail(
+    "array-api-strict",
+    reason="subtract_overscan model fitting goes through astropy.modeling, "
+    "which is NumPy-only (#933)",
+)
 @pytest.mark.parametrize("transpose", [True, False])
 def test_subtract_overscan_model(transpose):
     ccd_data = ccd_data_func()
@@ -301,7 +306,11 @@ def test_subtract_overscan_model(transpose):
     oscan_region = (slice(None), slice(0, 10))
     science_region = (slice(None), slice(10, None))
 
-    yscan, xscan = xp.asarray(np_mgrid[0:size, 0:size]) / 10.0 + 300.0
+    mgrid_scan = (
+        xp.asarray(np_mgrid[0:size, 0:size], dtype=xp.float64, device=xp_device) / 10.0
+        + 300.0
+    )
+    yscan, xscan = mgrid_scan[0, ...], mgrid_scan[1, ...]
 
     if transpose:
         oscan_region = oscan_region[::-1]
@@ -314,10 +323,10 @@ def test_subtract_overscan_model(transpose):
 
     original_mean = xp.mean(ccd_data.data[science_region])
 
-    science_data = ccd_data.data[science_region].copy()
+    science_data = xp.asarray(ccd_data.data[science_region], copy=True)
     # Set any existing overscan to zero. Overscan is stored for the entire
     # image, so we need to do this before we add the new overscan.
-    overscan_data = 0 * ccd_data.data[oscan_region].copy()
+    overscan_data = 0 * xp.asarray(ccd_data.data[oscan_region], copy=True)
     # Reconstruct the full image
     ccd_data.data = xp.concat([overscan_data, science_data], axis=overscan_axis) + scan
 

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -30,6 +30,7 @@ from ccdproc.combiner import (
 # Set up the array library to be used in tests
 from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
+from ccdproc.core import _native_numpy
 from ccdproc.image_collection import ImageFileCollection
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 from ccdproc.tests.pytest_fixtures import numpy_ccddata, numpy_copy
@@ -874,9 +875,8 @@ def test_combine_average_ccddata():
     fitsfile = get_pkg_data_filename("data/a8280271.fits")
     ccd = CCDData.read(fitsfile, unit=u.adu)
     # ``combine`` ignores ``array_package`` for CCDData input, so convert
-    # the data to the namespace ourselves (``.astype(float)`` makes the
-    # big-endian FITS data native; strict/jax reject ``>f8``).
-    ccd.data = xp.asarray(ccd.data.astype(float))
+    # the data to the namespace ourselves.
+    ccd.data = xp.asarray(_native_numpy(ccd.data))
     ccd_list = [ccd] * 3
     c = Combiner(ccd_list)
     ccd_by_combiner = c.average_combine()

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -7,7 +7,6 @@ import array_api_compat
 import array_api_extra as xpx
 import astropy.units as u
 import numpy as np
-import numpy.ma as np_ma
 import pytest
 from astropy.nddata import CCDData
 from astropy.stats import median_absolute_deviation as mad
@@ -33,6 +32,7 @@ from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
 from ccdproc.image_collection import ImageFileCollection
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
+from ccdproc.tests.pytest_fixtures import numpy_ccddata, numpy_copy
 
 # Several tests have many more NaNs in them than real data. numpy generates
 # lots of warnings in those cases and it makes more sense to suppress them
@@ -48,9 +48,16 @@ def _overall_median(arr):
 
 
 def _make_mean_scaler(ccd_data):
+    # Use the namespace of each argument: the reference image may be a
+    # NumPy array read from FITS while ``x`` is a namespace array (or vice
+    # versa), so neither side can assume the other's array library.
+    ref_xp = array_api_compat.array_namespace(ccd_data.data)
+    ref_mean = float(ref_xp.mean(ccd_data.data))
+
     def scale_by_mean(x):
         # scale each array to the mean of the first image
-        return ccd_data.data.mean() / np_ma.average(x)
+        xp_x = array_api_compat.array_namespace(x)
+        return ref_mean / float(xp_x.mean(x))
 
     return scale_by_mean
 
@@ -645,25 +652,19 @@ def test_combiner_mask_average():
     assert not ccd.mask[5, 5]
 
 
-@pytest.mark.backend_xfail(
-    "jax",
-    reason="astropy nddata arithmetic passes a jax array as dtype=, "
-    "triggering jax's implicit-array-to-dtype DeprecationWarning, which "
-    "is an error under this test suite's warning filters",
-)
 def test_combiner_with_scaling():
     ccd_data = ccd_data_func()
     # The factors below are not particularly important; just avoid anything
     # whose average is 1.
-    ccd_data_lower = ccd_data.multiply(3)
-    ccd_data_higher = ccd_data.multiply(0.9)
+    ccd_data_lower = CCDData(ccd_data.data * 3, unit=ccd_data.unit)
+    ccd_data_higher = CCDData(ccd_data.data * 0.9, unit=ccd_data.unit)
     combiner = Combiner([ccd_data, ccd_data_higher, ccd_data_lower])
     scale_by_mean = _make_mean_scaler(ccd_data)
     combiner.scaling = scale_by_mean
     avg_ccd = combiner.average_combine()
     # Does the mean of the scaled arrays match the value to which it was
     # scaled?
-    assert xp.all(xpx.isclose(avg_ccd.data.mean(), ccd_data.data.mean()))
+    assert xp.all(xpx.isclose(xp.mean(avg_ccd.data), xp.mean(ccd_data.data)))
     assert avg_ccd.shape == ccd_data.shape
     median_ccd = combiner.median_combine()
     # Does median also scale to the correct value?
@@ -672,9 +673,9 @@ def test_combiner_with_scaling():
     )
 
     # Set the scaling manually...
-    combiner.scaling = [scale_by_mean(combiner._data_arr[i]) for i in range(3)]
+    combiner.scaling = [scale_by_mean(combiner._data_arr[i, ...]) for i in range(3)]
     avg_ccd = combiner.average_combine()
-    assert xp.all(xpx.isclose(avg_ccd.data.mean(), ccd_data.data.mean()))
+    assert xp.all(xpx.isclose(xp.mean(avg_ccd.data), xp.mean(ccd_data.data)))
     assert avg_ccd.shape == ccd_data.shape
 
     # Scale by a float
@@ -745,11 +746,17 @@ def test_combine_average_fitsimages():
     fitsfile = get_pkg_data_filename("data/a8280271.fits", package="ccdproc.tests")
     ccd = CCDData.read(fitsfile, unit=u.adu)
     ccd_list = [ccd] * 3
-    c = Combiner(ccd_list)
+    c = Combiner(ccd_list, xp=xp)
     ccd_by_combiner = c.average_combine()
 
     fitsfilename_list = [fitsfile] * 3
-    avgccd = combine(fitsfilename_list, output_file=None, method="average", unit=u.adu)
+    avgccd = combine(
+        fitsfilename_list,
+        output_file=None,
+        method="average",
+        unit=u.adu,
+        array_package=xp,
+    )
     # averaging same fits images should give back same fits image
     assert xp.all(xpx.isclose(avgccd.data, ccd_by_combiner.data))
 
@@ -763,33 +770,35 @@ def test_combine_numpyndarray():
     fitsfile = get_pkg_data_filename("data/a8280271.fits")
     ccd = CCDData.read(fitsfile, unit=u.adu)
     ccd_list = [ccd] * 3
-    c = Combiner(ccd_list)
+    c = Combiner(ccd_list, xp=xp)
     ccd_by_combiner = c.average_combine()
 
     fitsfilename_list = [fitsfile] * 3
-    avgccd = combine(fitsfilename_list, output_file=None, method="average", unit=u.adu)
+    avgccd = combine(
+        fitsfilename_list,
+        output_file=None,
+        method="average",
+        unit=u.adu,
+        array_package=xp,
+    )
     # averaging same fits images should give back same fits image
     assert xp.all(xpx.isclose(avgccd.data, ccd_by_combiner.data))
 
 
-@pytest.mark.backend_xfail(
-    "jax",
-    reason="astropy nddata arithmetic passes a jax array as dtype=, "
-    "triggering jax's implicit-array-to-dtype DeprecationWarning, which "
-    "is an error under this test suite's warning filters",
-)
 def test_combiner_result_dtype():
     """Regression test: #391
 
     The result should have the appropriate dtype not the dtype of the first
     input."""
     ccd = CCDData(xp.ones((3, 3), dtype=xp.uint16), unit="adu")
-    res = combine([ccd, ccd.multiply(2)])
+    ccd_times_2 = CCDData(ccd.data * 2, unit=ccd.unit)
+    ccd_times_3 = CCDData(ccd.data * 3, unit=ccd.unit)
+    res = combine([ccd, ccd_times_2])
     # The default dtype of Combiner is float64
     assert res.data.dtype == xp.float64
     ref = xp.ones((3, 3)) * 1.5
     assert xp.all(xpx.isclose(res.data, ref))
-    res = combine([ccd, ccd.multiply(2), ccd.multiply(3)], dtype=int)
+    res = combine([ccd, ccd_times_2, ccd_times_3], dtype=int)
     # The result dtype should be integer:
     assert xp.isdtype(res.data.dtype, "integral")
     ref = xp.ones((3, 3)) * 2
@@ -800,7 +809,7 @@ def test_combiner_image_file_collection_input(tmp_path):
     # Regression check for #754
     ccd = ccd_data_func()
     for i in range(3):
-        ccd.write(tmp_path / f"ccd-{i}.fits")
+        numpy_ccddata(ccd).write(tmp_path / f"ccd-{i}.fits")
 
     ifc = ImageFileCollection(tmp_path)
     ccds = list(ifc.ccds())
@@ -818,7 +827,11 @@ def test_combiner_image_file_collection_input(tmp_path):
 
     # Do this on a separate line from the assert to make debugging easier
     result = comb.average_combine()
-    assert xp.all(xpx.isclose(ccd.data, result.data))
+    # ``result`` lands on the namespace's default device (the conversion
+    # above did not request ``xp_device``), while ``ccd.data`` is on
+    # ``xp_device``; compare via NumPy copies rather than requiring both
+    # sides to share a device.
+    assert_allclose(numpy_copy(ccd.data), numpy_copy(result.data))
 
 
 def test_combine_image_file_collection_input(tmp_path):
@@ -827,7 +840,7 @@ def test_combine_image_file_collection_input(tmp_path):
     ccd = ccd_data_func()
     xp = array_api_compat.array_namespace(ccd.data)
     for i in range(3):
-        ccd.write(tmp_path / f"ccd-{i}.fits")
+        numpy_ccddata(ccd).write(tmp_path / f"ccd-{i}.fits")
 
     ifc = ImageFileCollection(tmp_path, array_package=xp)
 
@@ -843,9 +856,12 @@ def test_combine_image_file_collection_input(tmp_path):
         array_package=xp,
     )
 
-    assert xp.all(xpx.isclose(ccd.data, comb_files.data))
-    assert xp.all(xpx.isclose(ccd.data, comb_ccds.data))
-    assert xp.all(xpx.isclose(ccd.data, comb_string.data))
+    # The combine() results land on the namespace's default device, while
+    # ``ccd.data`` is on ``xp_device``; compare via NumPy copies rather than
+    # requiring both sides to share a device.
+    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_files.data))
+    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_ccds.data))
+    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_string.data))
 
     with pytest.raises(FileNotFoundError):
         # This should fail because the test is not running in the
@@ -857,6 +873,10 @@ def test_combine_image_file_collection_input(tmp_path):
 def test_combine_average_ccddata():
     fitsfile = get_pkg_data_filename("data/a8280271.fits")
     ccd = CCDData.read(fitsfile, unit=u.adu)
+    # ``combine`` ignores ``array_package`` for CCDData input, so convert
+    # the data to the namespace ourselves (``.astype(float)`` makes the
+    # big-endian FITS data native; strict/jax reject ``>f8``).
+    ccd.data = xp.asarray(ccd.data.astype(float))
     ccd_list = [ccd] * 3
     c = Combiner(ccd_list)
     ccd_by_combiner = c.average_combine()
@@ -892,12 +912,17 @@ def test_combine_limitedmem_fitsimages():
     fitsfile = get_pkg_data_filename("data/a8280271.fits")
     ccd = CCDData.read(fitsfile, unit=u.adu)
     ccd_list = [ccd] * 5
-    c = Combiner(ccd_list)
+    c = Combiner(ccd_list, xp=xp)
     ccd_by_combiner = c.average_combine()
 
     fitsfilename_list = [fitsfile] * 5
     avgccd = combine(
-        fitsfilename_list, output_file=None, method="average", mem_limit=1e6, unit=u.adu
+        fitsfilename_list,
+        output_file=None,
+        method="average",
+        mem_limit=1e6,
+        unit=u.adu,
+        array_package=xp,
     )
     # averaging same ccdData should give back same images
     assert xp.all(xpx.isclose(avgccd.data, ccd_by_combiner.data))
@@ -909,7 +934,7 @@ def test_combine_limitedmem_scale_fitsimages():
     fitsfile = get_pkg_data_filename("data/a8280271.fits")
     ccd = CCDData.read(fitsfile, unit=u.adu)
     ccd_list = [ccd] * 5
-    c = Combiner(ccd_list)
+    c = Combiner(ccd_list, xp=xp)
     # scale each array to the mean of the first image
     scale_by_mean = _make_mean_scaler(ccd)
     c.scaling = scale_by_mean
@@ -923,6 +948,7 @@ def test_combine_limitedmem_scale_fitsimages():
         mem_limit=1e6,
         scale=scale_by_mean,
         unit=u.adu,
+        array_package=xp,
     )
 
     assert xp.all(xpx.isclose(avgccd.data, ccd_by_combiner.data))
@@ -1060,12 +1086,6 @@ def test_combine_result_uncertainty_and_mask(comb_func, mask_point):
     assert int(xp.count_nonzero(ccd_comb.mask)) == int(mask_point)
 
 
-@pytest.mark.backend_xfail(
-    "jax",
-    reason="astropy nddata arithmetic passes a jax array as dtype=, "
-    "triggering jax's implicit-array-to-dtype DeprecationWarning, which "
-    "is an error under this test suite's warning filters",
-)
 def test_combine_overwrite_output(tmp_path):
     """
     The combine function should *not* overwrite the result file
@@ -1074,18 +1094,17 @@ def test_combine_overwrite_output(tmp_path):
     output_file = tmp_path / "fake.fits"
 
     ccd = CCDData(xp.ones((3, 3)), unit="adu")
+    ccd_times_2 = CCDData(ccd.data * 2, unit=ccd.unit)
 
     # Make sure we have a file to overwrite
     ccd.write(output_file)
     # Test that overwrite does NOT happen by default
     with pytest.raises(OSError, match="fake.fits already exists"):
-        res = combine([ccd, ccd.multiply(2)], output_file=str(output_file))
+        res = combine([ccd, ccd_times_2], output_file=str(output_file))
 
     # Should be no error here...
     # The default dtype of Combiner is float64
-    res = combine(
-        [ccd, ccd.multiply(2)], output_file=output_file, overwrite_output=True
-    )
+    res = combine([ccd, ccd_times_2], output_file=output_file, overwrite_output=True)
 
     # Need to convert this to the array namespace.
     res_from_disk = CCDData.read(output_file)
@@ -1211,7 +1230,7 @@ def test_3d_combiner_with_scaling():
     avg_ccd = combiner.average_combine()
     # Does the mean of the scaled arrays match the value to which it was
     # scaled?
-    assert xp.all(xpx.isclose(avg_ccd.data.mean(), ccd_data.data.mean()))
+    assert xp.all(xpx.isclose(xp.mean(avg_ccd.data), xp.mean(ccd_data.data)))
     assert avg_ccd.shape == ccd_data.shape
     median_ccd = combiner.median_combine()
     # Does median also scale to the correct value?
@@ -1220,9 +1239,9 @@ def test_3d_combiner_with_scaling():
     )
 
     # Set the scaling manually...
-    combiner.scaling = [scale_by_mean(combiner._data_arr[i]) for i in range(3)]
+    combiner.scaling = [scale_by_mean(combiner._data_arr[i, ...]) for i in range(3)]
     avg_ccd = combiner.average_combine()
-    assert xp.all(xpx.isclose(avg_ccd.data.mean(), ccd_data.data.mean()))
+    assert xp.all(xpx.isclose(xp.mean(avg_ccd.data), xp.mean(ccd_data.data)))
     assert avg_ccd.shape == ccd_data.shape
 
 
@@ -1301,7 +1320,7 @@ def test_writeable_after_combine(tmpdir, comb_func):
     combined = Combiner([ccd_data for _ in range(3)])
     ccd2 = getattr(combined, comb_func)()
     # This should not fail because the resulting uncertainty has a mask
-    ccd2.write(tmp_file.strpath)
+    numpy_ccddata(ccd2).write(tmp_file.strpath)
 
 
 def test_clip_extrema_alone():
@@ -1421,12 +1440,6 @@ def test_combiner_gen():
     assert c._data_arr_mask.shape == (3, 100, 100)
 
 
-@pytest.mark.backend_xfail(
-    "jax",
-    reason="astropy nddata arithmetic passes a jax array as dtype=, "
-    "triggering jax's implicit-array-to-dtype DeprecationWarning, which "
-    "is an error under this test suite's warning filters",
-)
 @pytest.mark.parametrize(
     "comb_func", ["average_combine", "median_combine", "sum_combine"]
 )
@@ -1438,15 +1451,15 @@ def test_combiner_with_scaling_uncertainty(comb_func):
     ccd_data = ccd_data_func()
     # The factors below are not particularly important; just avoid anything
     # whose average is 1.
-    ccd_data_lower = ccd_data.multiply(3)
-    ccd_data_higher = ccd_data.multiply(0.9)
+    ccd_data_lower = CCDData(ccd_data.data * 3, unit=ccd_data.unit)
+    ccd_data_higher = CCDData(ccd_data.data * 0.9, unit=ccd_data.unit)
 
     combiner = Combiner([ccd_data, ccd_data_higher, ccd_data_lower])
     # scale each array to the mean of the first image
     scale_by_mean = _make_mean_scaler(ccd_data)
     combiner.scaling = scale_by_mean
 
-    scaled_ccds = xp.asarray(
+    scaled_ccds = xp.stack(
         [
             ccd_data.data * scale_by_mean(ccd_data.data),
             ccd_data_lower.data * scale_by_mean(ccd_data_lower.data),

--- a/ccdproc/tests/test_image_collection.py
+++ b/ccdproc/tests/test_image_collection.py
@@ -438,14 +438,17 @@ class TestImageFileCollection:
         for img in collection.data():
             assert isinstance(img, np.ndarray)
 
-    @pytest.mark.backend_xfail(
-        "jax",
-        reason="on Linux CI with the jax backend, ccds() does not raise "
-        "ValueError for unit-less files; the same test passes on macOS with "
-        "identical astropy/jax versions. Platform-dependent, root cause not "
-        "yet understood.",
-    )
     def test_generator_ccds_without_unit(self, triage_setup):
+        # astropy's ``_arithmetic`` decorator (ccddata.py) sets the module
+        # global ``_config_ccd_requires_unit = False`` around an arithmetic
+        # call and restores it with no try/finally, so an earlier test whose
+        # arithmetic raised (e.g. test_unit_mismatch_behaves_as_expected)
+        # can leave it permanently disabled (astropy/astropy#20268). Reset
+        # it explicitly so this test does not depend on what ran before it.
+        import astropy.nddata.ccddata as _ccddata_module
+
+        _ccddata_module._config_ccd_requires_unit = True
+
         collection = ImageFileCollection(
             location=triage_setup.test_dir, keywords=["imagetyp"]
         )


### PR DESCRIPTION
Part of #971 (section 2: strict test-body fixes).

Strict count on top of `main` `6724c8e`: **31 failed → 15 failed** (469 passed/36 skipped/43 xfailed/5 xpassed → 483 passed/36 skipped/45 xfailed/5 xpassed). numpy, jax, and dask show no regressions; jax additionally improves (541 passed/7 xfailed → 548 passed/0 xfailed/0 xpassed — see the third commit).

**Add numpy_copy/numpy_ccddata test helpers for strict device1 arrays.** The strict suite runs on array-api-strict's non-default `Device("device1")`, where `np.asarray()` deliberately raises, but several tests need to hand data to `astropy.io.fits`, which requires NumPy. Adds `numpy_copy()` (move to the default device, then convert) and `numpy_ccddata()` (a CCDData with data/mask/uncertainty all converted) to `pytest_fixtures.py` for the write-path fixes below.

**Fix strict-incompatible test bodies in test_combiner.py.** `_make_mean_scaler` called `ndarray.mean()`/`np.ma.average()` directly; rewritten to use each argument's own array namespace, since the reference image can be plain NumPy (read from FITS) while the scaled array is a namespace array. Several tests called `CCDData.multiply()`, iterated over an array, or called `xp.asarray()` on a list of arrays — all of which either route through astropy's arithmetic wrapper (which calls `np.result_type` and breaks on strict) or are flatly disallowed by array-api-strict; replaced with in-namespace construction, `xp.stack()`, and explicit `arr[i, ...]` indexing. `combine()` only honors `array_package` for filename/string input and the `Combiner` reference built from `CCDData.read()` defaults to NumPy, so several tests now pass `array_package=xp`/`Combiner(..., xp=xp)` (or convert the `CCDData` list's `.data` by hand) so both sides of each comparison are namespace arrays. Writing a device1 `CCDData` via `CCDData.write()` — which `ImageFileCollection` round-trips and `combine(output_file=...)` both do — needs `numpy_ccddata()`; comparisons against results that land on the namespace's default device use `numpy_copy()` + `assert_allclose()` instead of `xp.all(...)`.

Two of this bucket's targets still fail after these fixes, on causes outside test-code's reach: `test_combiner_result_dtype`'s `dtype=int` case, because `combine()` passes the bare Python `int` straight to `xp.astype`/`xp.asarray`, which array-api-strict rejects (`AttributeError: type object 'int' has no attribute '_np_dtype'`) — a new gap, not previously reachable because an earlier `.multiply()` failure masked it; and `test_combine_overwrite_output`, because `combine(output_file=...)` writes the still-in-namespace result via `ccd.write()` at `combiner.py:1273` (`AttributeError: 'Array' object has no attribute 'astype'`), the same class of bug as #935. Both are left failing, unmarked, for the coordinator to track in #971. Three more tests that call default `median_combine()` (`test_combiner_with_scaling`, `test_combiner_with_scaling_uncertainty[median_combine]`, `test_writeable_after_combine[median_combine]`) remain failing on #929's `sigma_func`/`astropy.stats` densification, unrelated to and untouched by this PR — `test_writeable_after_combine[median_combine]` was already known to the plan; the other two are additional #929 instances this PR's fixes exposed by clearing their first-listed cause.

Because these fixes remove every `CCDData.multiply()` call from the affected tests, the jax-only `backend_xfail` markers on `test_combiner_with_scaling`, `test_combiner_result_dtype`, `test_combine_overwrite_output`, and `test_combiner_with_scaling_uncertainty` (added for a jax `DeprecationWarning` triggered by astropy arithmetic receiving a jax array as `dtype=`) no longer apply and are removed; jax now XPASSes all of them cleanly.

**Fix test_subtract_overscan_model for strict; xfail the astropy.modeling path.** The test built its overscan gradient with integer/float division array-api-strict rejects, then unpacked the resulting 3D array by iteration, which array-api-strict also disallows for arrays with more than one dimension; fixed with an explicit float64 dtype/device and `[0, ...]`/`[1, ...]` indexing. Also replaced two `ndarray.copy()` calls with `xp.asarray(..., copy=True)`. With those fixed, both parametrizations reach `subtract_overscan(model=...)`, which goes through astropy.modeling's `LinearLSQFitter` — NumPy-only and unrelated to this test's array handling (#933); marked `backend_xfail("array-api-strict", ...)` citing #933. Exact stop: `TypeError: object of type 'Array' has no len()` from `xp.arange(len(oscan))` in `ccdproc/core.py`'s `subtract_overscan`.

**Reset leaked `_config_ccd_requires_unit` before `test_generator_ccds_without_unit`.** astropy's `_arithmetic` decorator sets the module global `_config_ccd_requires_unit = False` around an arithmetic call and restores it only on success, with no try/finally; when an earlier test's arithmetic raises (`test_unit_mismatch_behaves_as_expected` does this deliberately, on every backend), nothing resets the flag before later tests run (astropy/astropy#20268). This previously only reproduced on jax (and, after this PR's strict fixes, on array-api-strict too) and was marked `backend_xfail` for both — but removing several successful `.multiply()` calls in the `test_combiner.py` commit above also removed incidental resets of that global, which surfaced the same leak as a genuine regression on plain NumPy. Rather than add NumPy to the xfail list, the test now resets `astropy.nddata.ccddata._config_ccd_requires_unit = True` itself and drops the marker entirely — it passes deterministically on all four backends regardless of what ran before it.

Leftover failures after this PR (for #971 bookkeeping):
- `test_combiner_result_dtype` — `combine(dtype=int)` vs. array-api-strict's dtype objects (new gap, undocumented pre-PR).
- `test_combine_overwrite_output` — `combine(output_file=...)` writes a namespace array via `CCDData.write()` (same class as #935).
- `test_combiner_with_scaling`, `test_combiner_with_scaling_uncertainty[median_combine]`, `test_writeable_after_combine[median_combine]` — #929 (`median_combine`'s default `sigma_func` densifies via `astropy.stats`).
- The remaining ~10 failures are the pre-existing, untouched upstream bucket (`test_unit_mismatch_behaves_as_expected`, `test_sigma_func_for_ccddata`, `test_combiner_dtype`, `test_combiner_sigmaclip_*`, `test_combiner_median`, `test_combine_result_uncertainty_and_mask[median_combine-*]`, `test_rebin_ccddata[True-True]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME
