### PR TITLE
Write combine(output_file=) from a NumPy copy; map dtype to the array namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,14 @@ Bug Fixes
 - Keep the uncertainty propagation for correlated addition and subtraction
   through ``_CCDDataWrapperForArrayAPI`` in the array namespace instead of
   falling back to NumPy. [#997]
+- ``combine`` writes ``output_file`` from a NumPy copy of the result, so a
+  result in a non-NumPy array namespace can be written to FITS and is
+  returned unchanged in its namespace. [#999]
+- ``Combiner`` and ``combine`` map a ``dtype`` given as a builtin type,
+  string or NumPy dtype (e.g. ``dtype=int``) to the array namespace's own
+  dtype instead of passing it through unchanged. [#999]
+- Size the overscan model fit in ``subtract_overscan`` with ``shape``
+  instead of ``len``, which the array API standard does not provide. [#999]
 
 2.5.1 (2025-07-05)
 ------------------

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -20,7 +20,7 @@ from astropy.stats import sigma_clip
 from astropy.utils import deprecated_renamed_argument
 
 from ._nanfuncs import nanmean, nanmedian, nanstd, nansum
-from .core import _native_numpy, sigma_func
+from .core import _namespace_dtype, _native_numpy, _to_numpy, sigma_func
 
 __all__ = ["Combiner", "combine"]
 
@@ -98,9 +98,12 @@ class Combiner:
     ccd_iter : list or generator
         A list or generator of CCDData objects that will be combined together.
 
-    dtype : str or `numpy.dtype` or None, optional
-        Allows user to set dtype. See `numpy.array` ``dtype`` parameter
-        description. If ``None`` it uses ``np.float64``.
+    dtype : dtype-like or None, optional
+        The dtype for the stacked data and the results: a dtype object of
+        the array namespace, or anything NumPy accepts as a dtype (e.g.
+        ``int``, ``"float32"``, `numpy.float32`), which is mapped to the
+        namespace's dtype of the same name. If ``None`` the namespace's
+        ``float64`` is used.
         Default is ``None``.
 
     xp : array namespace, optional
@@ -178,6 +181,8 @@ class Combiner:
         self._xp = xp
         if dtype is None:
             dtype = xp.float64
+        else:
+            dtype = _namespace_dtype(dtype, xp)
 
         self.unit = default_unit
         self.weights = None
@@ -990,9 +995,10 @@ def combine(
         - ``sigma_clip_func`` : function, optional
         - ``sigma_clip_dev_func`` : function, optional
 
-    dtype : str or `numpy.dtype` or None, optional
-        The intermediate and resulting ``dtype`` for the combined CCDs. See
-        `ccdproc.Combiner`. If ``None`` this is set to ``float64``.
+    dtype : dtype-like or None, optional
+        The intermediate and resulting ``dtype`` for the combined CCDs; see
+        `ccdproc.Combiner` for the accepted forms. If ``None`` this is set to
+        the namespace's ``float64``.
         Default is ``None``.
 
     combine_uncertainty_function : callable, None, optional
@@ -1089,6 +1095,8 @@ def combine(
     xp = array_api_compat.array_namespace(ccd.data)
     if dtype is None:
         dtype = xp.float64
+    else:
+        dtype = _namespace_dtype(dtype, xp)
 
     if sigma_clip_func is None:
         sigma_clip_func = xp.mean
@@ -1268,6 +1276,17 @@ def combine(
 
     # Write fits file if filename was provided
     if output_file is not None:
-        ccd.write(output_file, overwrite=overwrite_output)
+        # astropy.io.fits needs NumPy arrays, so write from a NumPy copy and
+        # leave the returned result in its array namespace.
+        to_write = CCDData(
+            _to_numpy(ccd.data), unit=ccd.unit, meta=ccd.meta, wcs=ccd.wcs
+        )
+        if ccd.mask is not None:
+            to_write.mask = _to_numpy(ccd.mask)
+        if ccd.uncertainty is not None:
+            to_write.uncertainty = ccd.uncertainty.__class__(
+                _to_numpy(ccd.uncertainty.array)
+            )
+        to_write.write(output_file, overwrite=overwrite_output)
 
     return ccd

--- a/ccdproc/combiner.py
+++ b/ccdproc/combiner.py
@@ -99,12 +99,9 @@ class Combiner:
         A list or generator of CCDData objects that will be combined together.
 
     dtype : dtype-like or None, optional
-        The dtype for the stacked data and the results: a dtype object of
-        the array namespace, or anything NumPy accepts as a dtype (e.g.
-        ``int``, ``"float32"``, `numpy.float32`), which is mapped to the
-        namespace's dtype of the same name. If ``None`` the namespace's
-        ``float64`` is used.
-        Default is ``None``.
+        The dtype of the stacked data and the results; NumPy-style dtypes
+        (e.g. ``int``, ``"float32"``) are mapped to the namespace's dtype
+        of the same name. Default is ``None``, i.e. ``float64``.
 
     xp : array namespace, optional
         The array namespace to use for the data. If `None` or not provided, it will

--- a/ccdproc/core.py
+++ b/ccdproc/core.py
@@ -9,6 +9,7 @@ import warnings
 
 import array_api_compat
 import array_api_extra as xpx
+import numpy as np
 from astropy import nddata, stats
 from astropy import units as u
 from astropy.modeling import fitting
@@ -125,6 +126,76 @@ def _native_numpy(arr):
     problems.
     """
     return arr.astype(arr.dtype.type, copy=False)
+
+
+def _to_numpy(arr):
+    """
+    Return ``arr`` as a NumPy array, copying only when that is required.
+
+    Parameters
+    ----------
+    arr : array-like
+        An array from any array-API namespace, on any device.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        A NumPy array with the same shape, dtype and values as ``arr``.
+
+    Notes
+    -----
+    This is the deliberate host-side conversion for code that requires
+    NumPy, such as writing a FITS file through `astropy.io.fits`. Callers
+    must not hand the result back to the user in place of the input: the
+    input stays in its own array namespace.
+
+    ``np.asarray`` only works for arrays on the namespace's default device,
+    so the array is first moved there, asking for that device through the
+    standard ``__array_namespace_info__().default_device()``. The move is a
+    no-op when the array is already there, and is skipped when the
+    namespace reports `None` as its default device (as JAX does), since
+    there is then nothing to move to.
+    """
+    xp = array_api_compat.array_namespace(arr)
+    default_device = xp.__array_namespace_info__().default_device()
+    if default_device is not None:
+        arr = array_api_compat.to_device(arr, default_device)
+    return np.asarray(arr)
+
+
+def _namespace_dtype(dtype, xp):
+    """
+    Return the dtype object of an array namespace that corresponds to ``dtype``.
+
+    Parameters
+    ----------
+    dtype : dtype-like
+        Anything NumPy accepts as a dtype (a builtin such as ``int``, a
+        string such as ``"float32"``, a NumPy scalar type or `numpy.dtype`),
+        or a dtype object of ``xp`` itself.
+    xp : array namespace
+        The namespace whose dtype is wanted.
+
+    Returns
+    -------
+    dtype
+        The dtype of ``xp`` with the same name as NumPy's reading of
+        ``dtype``, or ``dtype`` itself if NumPy cannot interpret it (it is
+        then presumably already a dtype of ``xp``) or ``xp`` has no dtype of
+        that name.
+
+    Notes
+    -----
+    ``xp.asarray`` and ``xp.astype`` require the namespace's own dtype
+    objects. A builtin type such as ``int`` is a valid NumPy dtype, but
+    array-api-strict rejects it, so NumPy is used here only to resolve the
+    name and the dtype is then looked up on ``xp``.
+    """
+    try:
+        name = np.dtype(dtype).name
+    except TypeError:
+        return dtype
+    return getattr(xp, name, dtype)
 
 
 def _percentile_fallback(array, percentiles, xp=None):
@@ -695,7 +766,7 @@ def subtract_overscan(
 
     if model is not None:
         of = fitting.LinearLSQFitter()
-        yarr = xp.arange(len(oscan))
+        yarr = xp.arange(oscan.shape[0])
         oscan = of(model, yarr, oscan)
         # The model will return something array-like but it may not be the same array
         # library that we started with, so convert it back to the original

--- a/ccdproc/tests/array_escape_baseline.txt
+++ b/ccdproc/tests/array_escape_baseline.txt
@@ -4,23 +4,24 @@
 # The ratchet (CCDPROC_ENFORCE_ESCAPE_BASELINE=1) fails the session
 # if a library escape appears that is not listed here. Delete an
 # entry as you migrate that call site; this file only shrinks.
-# Regenerate with CCDPROC_WRITE_ESCAPE_BASELINE=1 (preserves tags).
+# Regenerate with CCDPROC_WRITE_ESCAPE_BASELINE=1 (preserves tags);
+# that requires CCDPROC_LOG_ARRAY_ESCAPES=1, a non-numpy
+# CCDPROC_ARRAY_LIBRARY (e.g. dask), and a *full* test-suite run --
+# a subset run drops the entries its tests never exercise.
 #
 # Tags are for humans, not the ratchet: TODO = still to migrate,
 # BOUNDARY = a numpy-only dependency (scipy/astroscrappy/reproject)
 # that will never leave. Verify/adjust the seeded tags by hand.
 #
-combiner.py  average_combine              numpy.asarray     BOUNDARY: result stored in astropy CCDData/StdDevUncertainty (numpy-backed)
 combiner.py  combine                      numpy.asarray     BOUNDARY: astropy CCDData mask/uncertainty attributes are numpy-backed
-combiner.py  median_combine               numpy.asarray     BOUNDARY: result stored in astropy CCDData/StdDevUncertainty (numpy-backed)
 combiner.py  sigma_clipping               numpy.asanyarray  BOUNDARY: astropy.stats.sigma_clip is numpy-only
-combiner.py  sum_combine                  numpy.asarray     BOUNDARY: result stored in astropy CCDData/StdDevUncertainty (numpy-backed)
+core.py      _cosmicray_median_array      numpy.asarray     BOUNDARY: scipy.ndimage median_filter/maximum_filter are numpy-only
+core.py      _to_numpy                    numpy.asarray     BOUNDARY: deliberate host copy for numpy-only consumers (combine() writes output_file through astropy.io.fits)
 core.py      background_deviation_filter  numpy.asarray     BOUNDARY: scipy.ndimage.generic_filter is numpy-only
 core.py      block_average                numpy.asanyarray  BOUNDARY: astropy.nddata.block_reduce is numpy-only
 core.py      block_reduce                 numpy.asanyarray  BOUNDARY: astropy.nddata.block_reduce is numpy-only
 core.py      block_replicate              numpy.asanyarray  BOUNDARY: astropy.nddata.block_replicate is numpy-only
 core.py      cosmicray_median             numpy.asarray     BOUNDARY: scipy.ndimage median_filter/maximum_filter are numpy-only
-core.py      _cosmicray_median_array      numpy.asarray     BOUNDARY: scipy.ndimage median_filter/maximum_filter are numpy-only
 core.py      create_deviation             numpy.asarray     BOUNDARY: astropy CCDData.copy()/StdDevUncertainty are numpy-backed
 core.py      sigma_func                   numpy.asanyarray  BOUNDARY: astropy.stats.median_absolute_deviation is numpy-only
 core.py      subtract_overscan            numpy.asanyarray  BOUNDARY: astropy.modeling fit/evaluation (model= path) is numpy-only

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -69,30 +69,6 @@ def ccd_data(
     return ccd
 
 
-def numpy_copy(array):
-    """
-    Return a NumPy copy of an array from any array namespace.
-
-    Parameters
-    ----------
-    array : array-like
-        An array from any array-API namespace, on any device.
-
-    Returns
-    -------
-    `numpy.ndarray`
-        A NumPy array with the same shape, dtype and values as ``array``.
-
-    Notes
-    -----
-    The strict tests run on ``Device("device1")``, on which array-api-strict
-    deliberately refuses to export to NumPy; `ccdproc.core._to_numpy` moves
-    the array to the namespace's default device first, which is a no-op on
-    every other backend the suite runs.
-    """
-    return _to_numpy(array)
-
-
 def numpy_ccddata(ccd):
     """
     Return a copy of a ``CCDData`` whose arrays are all NumPy arrays.
@@ -107,20 +83,22 @@ def numpy_ccddata(ccd):
     -------
     `~astropy.nddata.CCDData`
         A new ``CCDData`` with ``data``, ``mask`` and ``uncertainty.array``
-        converted with `numpy_copy`; ``unit`` and ``meta`` are carried over
-        unchanged and the uncertainty keeps its class.
+        converted with `ccdproc.core._to_numpy`; ``unit`` and ``meta`` are
+        carried over unchanged and the uncertainty keeps its class.
 
     Notes
     -----
     Use this to hand a namespace ``CCDData`` to code that requires NumPy,
-    such as ``CCDData.write``.
+    such as ``CCDData.write``. The strict tests run on ``Device("device1")``,
+    on which array-api-strict refuses to export to NumPy; ``_to_numpy``
+    moves the arrays to the default device first.
     """
-    new_ccd = CCDData(numpy_copy(ccd.data), unit=ccd.unit, meta=ccd.meta)
+    new_ccd = CCDData(_to_numpy(ccd.data), unit=ccd.unit, meta=ccd.meta)
     if ccd.mask is not None:
-        new_ccd.mask = numpy_copy(ccd.mask)
+        new_ccd.mask = _to_numpy(ccd.mask)
     if ccd.uncertainty is not None:
         new_ccd.uncertainty = ccd.uncertainty.__class__(
-            numpy_copy(ccd.uncertainty.array)
+            _to_numpy(ccd.uncertainty.array)
         )
     return new_ccd
 

--- a/ccdproc/tests/pytest_fixtures.py
+++ b/ccdproc/tests/pytest_fixtures.py
@@ -2,12 +2,12 @@
 
 from shutil import rmtree
 
-import array_api_compat
 import numpy as np
 import pytest
 from astropy import units as u
 from astropy.nddata import CCDData
 
+from ..core import _to_numpy
 from ..utils.sample_directory import directory_for_testing
 
 # If additional pytest markers are defined the key in the dictionary below
@@ -85,20 +85,12 @@ def numpy_copy(array):
 
     Notes
     -----
-    ``np.asarray`` only works for arrays on the namespace's default
-    device. The strict tests run on ``Device("device1")``, on which
-    array-api-strict deliberately refuses to export to NumPy, so the array
-    is moved to the default device first. That move is a no-op on every
-    other backend the suite runs. The default device is asked for through
-    the standard ``__array_namespace_info__().default_device()``, which
-    the 2025.12 standard allows to be `None` (JAX does this); in that case
-    there is nothing to move to and ``np.asarray`` is used directly.
+    The strict tests run on ``Device("device1")``, on which array-api-strict
+    deliberately refuses to export to NumPy; `ccdproc.core._to_numpy` moves
+    the array to the namespace's default device first, which is a no-op on
+    every other backend the suite runs.
     """
-    xp = array_api_compat.array_namespace(array)
-    default_device = xp.__array_namespace_info__().default_device()
-    if default_device is not None:
-        array = array_api_compat.to_device(array, default_device)
-    return np.asarray(array)
+    return _to_numpy(array)
 
 
 def numpy_ccddata(ccd):

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -202,6 +202,27 @@ def test_combiner_dtype():
     assert result_sum.dtype == c.dtype
 
 
+# A dtype that is not one of the namespace's own dtype objects (a builtin
+# type, a string, a NumPy scalar type) is mapped to the namespace's dtype of
+# the same name, so ``dtype=int`` works on every backend.
+@pytest.mark.parametrize(
+    "dtype,expected_name",
+    [
+        (int, "int64"),
+        (float, "float64"),
+        ("float32", "float32"),
+        (np.float32, "float32"),
+    ],
+)
+def test_combiner_dtype_mapped_to_namespace(dtype, expected_name):
+    ccd_data = ccd_data_func()
+    c = Combiner([ccd_data, ccd_data], dtype=dtype)
+    assert c.dtype == getattr(xp, expected_name)
+    assert c._data_arr.dtype == getattr(xp, expected_name)
+    avg = c.average_combine()
+    assert avg.dtype == getattr(xp, expected_name)
+
+
 # test mask is created from ccd.data
 def test_combiner_mask():
     data = xp.zeros((10, 10))
@@ -802,8 +823,9 @@ def test_combiner_result_dtype():
     res = combine([ccd, ccd_times_2, ccd_times_3], dtype=int)
     # The result dtype should be integer:
     assert xp.isdtype(res.data.dtype, "integral")
-    ref = xp.ones((3, 3)) * 2
-    assert xp.all(xpx.isclose(res.data, ref))
+    # Compare with a Python int: an integer array and a float reference
+    # cannot be promoted together under the array API standard.
+    assert xp.all(res.data == 2)
 
 
 def test_combiner_image_file_collection_input(tmp_path):
@@ -1106,11 +1128,17 @@ def test_combine_overwrite_output(tmp_path):
     # The default dtype of Combiner is float64
     res = combine([ccd, ccd_times_2], output_file=output_file, overwrite_output=True)
 
+    # The returned result must still be in the array namespace, with its
+    # uncertainty and mask; only the file is written from a NumPy copy.
+    xp_compat = array_api_compat.array_namespace(xp.asarray(0))
+    for arr in (res.data, res.uncertainty.array, res.mask):
+        assert array_api_compat.array_namespace(arr) is xp_compat
+
     # Need to convert this to the array namespace.
     res_from_disk = CCDData.read(output_file)
-    res_from_disk.data = xp.asarray(
-        res_from_disk.data, dtype=res_from_disk.data.dtype.type
-    )
+    assert res_from_disk.uncertainty is not None
+    assert res_from_disk.mask is not None
+    res_from_disk.data = xp.asarray(_native_numpy(res_from_disk.data))
 
     # Data should be the same
     assert xp.all(xpx.isclose(res.data, res_from_disk.data))

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -30,7 +30,7 @@ from ccdproc.combiner import (
 # Set up the array library to be used in tests
 from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
-from ccdproc.core import _native_numpy
+from ccdproc.core import _namespace_dtype, _native_numpy
 from ccdproc.image_collection import ImageFileCollection
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
 from ccdproc.tests.pytest_fixtures import numpy_ccddata, numpy_copy
@@ -221,6 +221,23 @@ def test_combiner_dtype_mapped_to_namespace(dtype, expected_name):
     assert c._data_arr.dtype == getattr(xp, expected_name)
     avg = c.average_combine()
     assert avg.dtype == getattr(xp, expected_name)
+
+
+def test_namespace_dtype_passes_through_what_numpy_cannot_read():
+    """
+    A dtype that NumPy cannot interpret is returned unchanged for the
+    namespace to deal with. On array-api-strict the namespace's own dtype
+    objects take this path; on the other backends they are NumPy types, so
+    an arbitrary object stands in for that case here.
+    """
+
+    class NotADtype:
+        pass
+
+    sentinel = NotADtype()
+    assert _namespace_dtype(sentinel, xp) is sentinel
+    # The namespace's own dtype objects always come back as themselves.
+    assert _namespace_dtype(xp.float32, xp) == xp.float32
 
 
 # test mask is created from ccd.data

--- a/ccdproc/tests/test_combiner.py
+++ b/ccdproc/tests/test_combiner.py
@@ -30,10 +30,10 @@ from ccdproc.combiner import (
 # Set up the array library to be used in tests
 from ccdproc.conftest import testing_array_device as xp_device
 from ccdproc.conftest import testing_array_library as xp
-from ccdproc.core import _namespace_dtype, _native_numpy
+from ccdproc.core import _namespace_dtype, _native_numpy, _to_numpy
 from ccdproc.image_collection import ImageFileCollection
 from ccdproc.tests.pytest_fixtures import ccd_data as ccd_data_func
-from ccdproc.tests.pytest_fixtures import numpy_ccddata, numpy_copy
+from ccdproc.tests.pytest_fixtures import numpy_ccddata
 
 # Several tests have many more NaNs in them than real data. numpy generates
 # lots of warnings in those cases and it makes more sense to suppress them
@@ -871,7 +871,7 @@ def test_combiner_image_file_collection_input(tmp_path):
     # above did not request ``xp_device``), while ``ccd.data`` is on
     # ``xp_device``; compare via NumPy copies rather than requiring both
     # sides to share a device.
-    assert_allclose(numpy_copy(ccd.data), numpy_copy(result.data))
+    assert_allclose(_to_numpy(ccd.data), _to_numpy(result.data))
 
 
 def test_combine_image_file_collection_input(tmp_path):
@@ -899,9 +899,9 @@ def test_combine_image_file_collection_input(tmp_path):
     # The combine() results land on the namespace's default device, while
     # ``ccd.data`` is on ``xp_device``; compare via NumPy copies rather than
     # requiring both sides to share a device.
-    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_files.data))
-    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_ccds.data))
-    assert_allclose(numpy_copy(ccd.data), numpy_copy(comb_string.data))
+    assert_allclose(_to_numpy(ccd.data), _to_numpy(comb_files.data))
+    assert_allclose(_to_numpy(ccd.data), _to_numpy(comb_ccds.data))
+    assert_allclose(_to_numpy(ccd.data), _to_numpy(comb_string.data))
 
     with pytest.raises(FileNotFoundError):
         # This should fail because the test is not running in the


### PR DESCRIPTION
Closes out the last three ccdproc-side items in section 1 of #971.

**`combine(output_file=...)`** handed the namespace result straight to `CCDData.write` (`combiner.py:1273`), which `astropy.io.fits` cannot take (`AttributeError: 'Array' object has no attribute 'astype'` on array-api-strict). The writer now gets a `CCDData` built from NumPy copies of `data`, `mask` and `uncertainty.array` (same uncertainty class, `unit`/`meta`/`wcs` carried over) and the returned result stays in its namespace; `test_combine_overwrite_output` now asserts both.

The copy is a new `ccdproc.core._to_numpy(arr)`: the deliberate host-side conversion for NumPy-only consumers. It moves the array to the namespace's default device first (asked for through the standard `__array_namespace_info__().default_device()`, skipped when that is `None` as on JAX), because array-api-strict refuses to export from its non-default devices. This is the same body as the `numpy_copy` test helper from #998, which now just delegates to it so the device logic lives in one place. Two consequences worth knowing:
- it is the first *library-side* host-copy helper, so it is the natural building block for whatever #935 decides for the CPU-only operations;
- in the escape log, test-suite calls through `numpy_copy` are now attributed to `core.py _to_numpy` (the innermost non-test ccdproc frame), so that site's count is inflated by the test helpers. It is one baseline entry either way.

**`Combiner(dtype=)` / `combine(dtype=)`** passed the user's dtype straight to `xp.asarray`/`xp.astype` (`combiner.py:191`, `:1104`); a builtin `int` or a string such as `"float32"` is a valid NumPy dtype but array-api-strict rejects it. `core._namespace_dtype(dtype, xp)` resolves the name with `numpy.dtype(...)` and looks it up on the namespace; anything NumPy cannot interpret (the namespace's own dtype objects, e.g. `array_api_strict.float32`) passes through untouched. Verified for builtins, strings, NumPy scalar types/dtypes and namespace dtypes on numpy, jax, dask and strict. New `test_combiner_dtype_mapped_to_namespace` covers `int`, `float`, `"float32"`, `np.float32`; the `dtype` docstrings are updated. `test_combiner_result_dtype` then failed in its own body — comparing the integer result with a float reference, which the standard does not promote — and now compares with a Python `int`.

**`subtract_overscan`** used `len(oscan)` for the model fit (`core.py:698`); now `oscan.shape[0]`. The test stays xfailed on #933 (`astropy.modeling`), as expected.

**Escape baseline** (`ccdproc/tests/array_escape_baseline.txt`): regenerated on dask with `CCDPROC_WRITE_ESCAPE_BASELINE=1`. `_to_numpy` is the one new site, tagged `BOUNDARY`. The rewrite also dropped the `average_combine`/`median_combine`/`sum_combine` entries, which have not fired since #992 replaced the `mask=` constructor calls with `_mask`, and updated the header comment (the writer's current text). The dask enforce run passes.

**Results**
- strict: **13 failed / 502 passed / 36 skipped / 45 xfailed / 0 xpassed** (was 15). `test_combine_overwrite_output` and `test_combiner_result_dtype` clear. All 13 that remain are upstream-blocked: 11 × #929, #936, #983 — section 1 of #971 is done.
- numpy: 561 passed / 35 skipped. jax and dask: `test_combiner.py` + `test_ccdproc.py` 177 passed each. dask + escape ratchet: 554 passed, no new escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S36ZzAAVXVm32vuTdtCQME
